### PR TITLE
disk_image: include all of /usr/local

### DIFF
--- a/pycheribuild/projects/disk_image.py
+++ b/pycheribuild/projects/disk_image.py
@@ -225,6 +225,12 @@ class _BuildDiskImageBase(SimpleProject):
                 for filename in filenames:
                     self.extraFiles.append(Path(root, filename))
 
+        for root, dirnames, filenames in os.walk(Path(self.rootfsDir,"usr/local")):
+            for filename in filenames:
+                fp = Path(root,filename)
+                tp = fp.relative_to(self.rootfsDir)
+                self.mtree.add_file(fp, tp)
+
         # TODO: https://www.freebsd.org/cgi/man.cgi?mount_unionfs(8) should make this easier
         # Overlay extra-files over additional stuff over cheribsd rootfs dir
 


### PR DESCRIPTION
gdb-mips installs itself into the target root, but the recent mtree work
(d69762d83d480b65670421076fe650f3edd9ea50) means that it no longer gets
installed into the actual image.

I'm not quite sure this is the right way to do this, but something along these lines
would be nice to have!