### PR TITLE
Don't pull all Git history when cloning

### DIFF
--- a/pycheribuild/projects/project.py
+++ b/pycheribuild/projects/project.py
@@ -871,7 +871,7 @@ class Project(SimpleProject):
             print(srcDir, "is not a git repository. Clone it from' " + remoteUrl + "'?", end="")
             if not self.queryYesNo(defaultResult=False):
                 fatalError("Sources for", str(srcDir), " missing!")
-            cloneCmd = ["git", "clone"]
+            cloneCmd = ["git", "clone", "--depth", "1"]
             if not skipSubmodules:
                 cloneCmd.append("--recurse-submodules")
             if initialBranch:


### PR DESCRIPTION
This speeds up clones.

One can run `git fetch --unshallow` to get the full history.