### PR TITLE
gdb: disable guile

### DIFF
--- a/pycheribuild/projects/cross/gdb.py
+++ b/pycheribuild/projects/cross/gdb.py
@@ -91,6 +91,7 @@ class BuildGDB(CrossCompileAutotoolsProject):
             "MAKEINFO=/bin/false",
             "--with-gdb-datadir=" + str(installRoot / "share/gdb"),
             "--disable-libstdcxx",
+            "--with-guile=no",
             # TODO:
             "--enable-build-with-cxx",
             ])


### PR DESCRIPTION
I have guile 2.2.4 installed and it seems it's too recent for this
gdb. Since I don't really care about Scheme I just disabled it and
it builds fine.

More details: https://github.com/riscv/riscv-binutils-gdb/issues/82

Logs excerpt:

```
/usr/bin/clang++ -ggdb -Wno-mismatched-tags -Wno-unknown-warning-option -Wno-mismatched-tags  -O2 -Wno-mismatched-tags -Wno-unknown-warning-option   -I. -I/home/simon/src/cheri/gdb/gdb -I/home/simon/src/cheri/gdb/gdb/common -I/home/simon/src/cheri/gdb/gdb/config -DLOCALEDIR="\"/home/simon/src/cheri/build/sdk/share/locale\"" -DHAVE_CONFIG_H -I/home/simon/src/cheri/gdb/gdb/../include/opcode -I/home/simon/src/cheri/gdb/gdb/../opcodes/.. -I/home/simon/src/cheri/gdb/gdb/../readline/.. -I/home/simon/src/cheri/gdb/gdb/../zlib -I../bfd -I/home/simon/src/cheri/gdb/gdb/../bfd -I/home/simon/src/cheri/gdb/gdb/../include -I../libdecnumber -I/home/simon/src/cheri/gdb/gdb/../libdecnumber  -I/home/simon/src/cheri/gdb/gdb/gnulib/import -Ibuild-gnulib/import   -DTUI=1   -I/usr/include/guile/2.2 -pthread  -I/usr/include/python3.6m -I/usr/include/python3.6m -Wall -Wpointer-arith -Wno-unused -Wunused-value -Wunused-function -Wno-switch -Wno-char-subscripts -Wempty-body -Wunused-but-set-parameter -Wunused-but-set-variable -Wno-sign-compare -Wno-narrowing -Wformat-nonl/usr/bin/clang++ -ggdb -Wno-mismatched-tags -Wno-unknown-warning-option -Wno-mismatched-tags  -O2 -Wno-mismatched-tags -Wno-unknown-warning-option   -I. -I/home/simon/src/cheri/gdb/gdb -I/home/simon/src/cheri/gdb/gdb/common -I/home/simon/src/cheri/gdb/gdb/config -DLOCALEDIR="\"/home/simon/src/cheri/build/sdk/share/locale\"" -DHAVE_CONFIG_H -I/home/simon/src/cheri/gdb/gdb/../include/opcode -I/home/simon/src/cheri/gdb/gdb/../opcodes/.. -I/home/simon/src/cheri/gdb/gdb/../readline/.. -I/home/simon/src/cheri/gdb/gdb/../zlib -I../bfd -I/home/simon/src/cheri/gdb/gdb/../bfd -I/home/simon/src/cheri/gdb/gdb/../include -I../libdecnumber -I/home/simon/src/cheri/gdb/gdb/../libdecnumber  -I/home/simon/src/cheri/gdb/gdb/gnulib/import -Ibuild-gnulib/import   -DTUI=1   -I/usr/include/guile/2.2 -pthread  -I/usr/include/python3.6m -I/usr/include/python3.6m -Wall -Wpointer-arith -Wno-unused -Wunused-value -Wunused-function -Wno-switch -Wno-char-subscripts -Wempty-body -Wunused-but-set-parameter -Wunused-but-set-variable -Wno-sign-compare -Wno-narrowing -Wformat-nonliteral  -c -o scm-symtab.o -MT scm-symtab.o -MMD -MP -MF .deps/scm-symtab.Tpo /home/simon/src/cheri/gdb/gdb/guile/scm-symtab.c 
clang-6.0: warning: treating 'c' input as 'c++' when in C++ mode, this behavior is deprecated [-Wdeprecated]
clang-6.0: warning: treating 'c' input as 'c++' when in C++ mode, this behavior is deprecated [-Wdeprecated]
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:146:10: error: use of undeclared identifier 'scm_new_port_table_entry'
  port = scm_new_port_table_entry (port_type);
         ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:231:20: error: use of undeclared identifier 'SCM_PTAB_ENTRY'
  scm_t_port *pt = SCM_PTAB_ENTRY (port);
                   ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:240:47: error: member access into incomplete type 'scm_t_port'
  count = ui_file_read (gdb_stdin, (char *) pt->read_buf, pt->read_buf_size);
                                              ^
/usr/include/guile/2.2/libguile/ports.h:82:16: note: forward declaration of 'scm_t_port'
typedef struct scm_t_port scm_t_port;
               ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:240:61: error: member access into incomplete type 'scm_t_port'
  count = ui_file_read (gdb_stdin, (char *) pt->read_buf, pt->read_buf_size);
                                                            ^
/usr/include/guile/2.2/libguile/ports.h:82:16: note: forward declaration of 'scm_t_port'
typedef struct scm_t_port scm_t_port;
               ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:246:5: error: member access into incomplete type 'scm_t_port'
  pt->read_pos = pt->read_buf;
    ^
/usr/include/guile/2.2/libguile/ports.h:82:16: note: forward declaration of 'scm_t_port'
typedef struct scm_t_port scm_t_port;
               ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:247:5: error: member access into incomplete type 'scm_t_port'
  pt->read_end = pt->read_buf + count;
    ^
/usr/include/guile/2.2/libguile/ports.h:82:16: note: forward declaration of 'scm_t_port'
typedef struct scm_t_port scm_t_port;
               ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:248:13: error: member access into incomplete type 'scm_t_port'
  return *pt->read_buf;
            ^
/usr/include/guile/2.2/libguile/ports.h:82:16: note: forward declaration of 'scm_t_port'
typedef struct scm_t_port scm_t_port;
               ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:315:21: error: no matching function for call to 'scm_make_port_type'
  stdio_port_desc = scm_make_port_type (stdio_port_desc_name,
                    ^~~~~~~~~~~~~~~~~~
/usr/include/guile/2.2/libguile/ports.h:93:26: note: candidate function not viable: no known conversion from 'int (SCM)' (aka 'int (scm_unused_struct *)') to 'size_t (*)(SCM, SCM, size_t, size_t)' (aka 'unsigned long (*)(scm_unused_struct *, scm_unused_struct *, unsigned long, unsigned long)') for 2nd argument
SCM_API scm_t_port_type *scm_make_port_type
                         ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:318:3: error: no matching function for call to 'scm_set_port_input_waiting'
  scm_set_port_input_waiting (stdio_port_desc, ioscm_input_waiting);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/guile/2.2/libguile/ports.h:117:14: note: candidate function not viable: no known conversion from 'scm_t_bits' (aka 'unsigned long') to 'scm_t_port_type *' for 1st argument
SCM_API void scm_set_port_input_waiting (scm_t_port_type *ptob,
             ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:319:3: error: use of undeclared identifier 'scm_set_port_flush'; did you mean 'scm_set_port_close'?
  scm_set_port_flush (stdio_port_desc, ioscm_flush);
  ^~~~~~~~~~~~~~~~~~
  scm_set_port_close
/usr/include/guile/2.2/libguile/ports.h:107:14: note: 'scm_set_port_close' declared here
SCM_API void scm_set_port_close (scm_t_port_type *ptob, void (*close) (SCM));
             ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:319:23: error: cannot initialize a parameter of type 'scm_t_port_type *' with an lvalue of type 'scm_t_bits' (aka 'unsigned long')
  scm_set_port_flush (stdio_port_desc, ioscm_flush);
                      ^~~~~~~~~~~~~~~
/usr/include/guile/2.2/libguile/ports.h:107:51: note: passing argument to parameter 'ptob' here
SCM_API void scm_set_port_close (scm_t_port_type *ptob, void (*close) (SCM));
                                                  ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:329:20: error: use of undeclared identifier 'SCM_PTAB_ENTRY'
  scm_t_port *pt = SCM_PTAB_ENTRY (port);
                   ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:338:9: error: member access into incomplete type 'scm_t_port'
      pt->read_buf
        ^
/usr/include/guile/2.2/libguile/ports.h:82:16: note: forward declaration of 'scm_t_port'
typedef struct scm_t_port scm_t_port;
               ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:340:9: error: member access into incomplete type 'scm_t_port'
      pt->read_pos = pt->read_end = pt->read_buf;
        ^
/usr/include/guile/2.2/libguile/ports.h:82:16: note: forward declaration of 'scm_t_port'
typedef struct scm_t_port scm_t_port;
               ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:341:9: error: member access into incomplete type 'scm_t_port'
      pt->read_buf_size = size;
        ^
/usr/include/guile/2.2/libguile/ports.h:82:16: note: forward declaration of 'scm_t_port'
typedef struct scm_t_port scm_t_port;
               ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:345:9: error: member access into incomplete type 'scm_t_port'
      pt->read_pos = pt->read_buf = pt->read_end = &pt->shortbuf;
        ^
/usr/include/guile/2.2/libguile/ports.h:82:16: note: forward declaration of 'scm_t_port'
typedef struct scm_t_port scm_t_port;
               ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:346:9: error: member access into incomplete type 'scm_t_port'
      pt->read_buf_size = 1;
        ^
/usr/include/guile/2.2/libguile/ports.h:82:16: note: forward declaration of 'scm_t_port'
typedef struct scm_t_port scm_t_port;
               ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:351:9: error: member access into incomplete type 'scm_t_port'
      pt->write_buf
        ^
/usr/include/guile/2.2/libguile/ports.h:82:16: note: forward declaration of 'scm_t_port'
typedef struct scm_t_port scm_t_port;
               ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:353:9: error: member access into incomplete type 'scm_t_port'
      pt->write_pos = pt->write_buf;
        ^
/usr/include/guile/2.2/libguile/ports.h:82:16: note: forward declaration of 'scm_t_port'
typedef struct scm_t_port scm_t_port;
               ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
13 warnings and 20 errors generated.
```

Full logs:

<details>

```
> ./cheribuild.py gdb
Overriding default value for output-root with value from JSON key output-root -> ~/src/cheri/build
Overriding default value for cheri-bits with value from JSON key cheri-bits -> 256
Overriding default value for source-root with value from JSON key source-root -> ~/src/cheri
Sources will be stored in /home/simon/src/cheri
Build artifacts will be stored in /home/simon/src/cheri/build
Failed to check for updates: Command '['git', 'fetch']' timed out after 5 seconds
/usr/bin/clang supports -fuse-ld=lld, linking should be much faster!
Could not find `gmake` command, assuming `make` is GNU make
Could not find `gmake` command, assuming `make` is GNU make
 /usr/bin/git --version
Current branch mips_cheri-8.0.1 is up to date.
Status =  b'## mips_cheri-8.0.1...origin/mips_cheri-8.0.1\n'
Configuring GDB (native) ... 
Cross configure environment: {'CC': '/usr/bin/clang -ggdb -Wno-mismatched-tags -Wno-unknown-warning-option',
 'CC_FOR_BUILD': '/usr/bin/clang',
 'CFLAGS': '-O2 -Wno-mismatched-tags -Wno-unknown-warning-option',
 'CFLAGS_FOR_BUILD': '-g',
 'CXX': '/usr/bin/clang++ -ggdb -Wno-mismatched-tags -Wno-unknown-warning-option -Wno-mismatched-tags',
 'CXXFLAGS': '-O2 -Wno-mismatched-tags -Wno-unknown-warning-option',
 'CXXFLAGS_FOR_BUILD': '-g',
 'CXX_FOR_BUILD': '/usr/bin/clang++',
 'LDFLAGS': '-L/usr/local/lib'}
Building GDB (native) ... 
Temporarily moving ['as', 'ld', 'objcopy', 'objdump'] from /home/simon/src/cheri/build/sdk/bin
Could not find `gmake` command, assuming `make` is GNU make
Overriding default value for make-jobs with value from JSON key make-jobs -> 3
cd /home/simon/src/cheri/build/gdb-native-build && nice make all-binutils -j3
Saving build log to /home/simon/src/cheri/build/gdb-native-build/make.all-binutils.log
true "AR_FLAGS=rc" "CC_FOR_BUILD=/usr/bin/clang -ggdb -Wno-mismatched-tags -Wno-unknown-warning-option" "CFLAGS=-O2 -Wno-mismatched-tags -Wno-unknown-warning-option" "CXXFLAGS=-O2 -Wno-mismatched-tags -Wno-unknown-warning-option" "CFLAGS_FOR_BUILD=-g" "CFLAGS_FOR_TARGET=-g -O2 -Wno-mismatched-tags -Wno-unknown-warning-option" "INSTALL=/usr/bin/install -c" "INSTALL_DATA=/usr/bin/install -c -m 644" "INSTALL_PROGRAM=/usr/bin/install -c" "INSTALL_SCRIPT=/usr/bin/install -c" "LDFLAGS=-L/usr/local/lib" "LIBCFLAGS=-O2 -Wno-mismatched-tags -Wno-unknown-warning-option" "LIBCFLAGS_FOR_TARGET=-g -O2 -Wno-mismatched-tags -Wno-unknown-warning-option" "MAKE=make" "MAKEINFO=/home/simon/src/cheri/gdb/missing makeinfo --split-size=5000000 " "PICFLAG=" "PICFLAG_FOR_TARGET=" "SHELL=/bin/sh" "EXPECT=expect" "RUNTEST=runtest" "RUNTESTFLAGS=" "exec_prefix=/home/simon/src/cheri/build/sdk" "infodir=/home/simon/src/cheri/build/sdk/info" "libdir=/home/simon/src/cheri/build/sdk/lib" "prefix=/home/simon/src/cheri/build/sdk" "tooldir=/home/simon/src/cheri/build/sdk/x86_64-pc-linux-gnu" "AR=ar" "AS=as" "CC=/usr/bin/clang -ggdb -Wno-mismatched-tags -Wno-unknown-warning-option" "CXX=/usr/bin/clang++ -ggdb -Wno-mismatched-tags -Wno-unknown-warning-optimake[1]: Leaving directory '/home/simon/src/cheri/build/gdb-native-build/binutils' 
Running make all-binutils took 8.022980451583862 seconds
Could not find `gmake` command, assuming `make` is GNU make
cd /home/simon/src/cheri/build/gdb-native-build && nice make all-gdb -j3
Saving build log to /home/simon/src/cheri/build/gdb-native-build/make.all-gdb.log
true "AR_FLAGS=rc" "CC_FOR_BUILD=/usr/bin/clang -ggdb -Wno-mismatched-tags -Wno-unknown-warning-option" "CFLAGS=-O2 -Wno-mismatched-tags -Wno-unknown-warning-option" "CXXFLAGS=-O2 -Wno-mismatched-tags -Wno-unknown-warning-option" "CFLAGS_FOR_BUILD=-g" "CFLAGS_FOR_TARGET=-g -O2 -Wno-mismatched-tags -Wno-unknown-warning-option" "INSTALL=/usr/bin/install -c" "INSTALL_DATA=/usr/bin/install -c -m 644" "INSTALL_PROGRAM=/usr/bin/install -c" "INSTALL_SCRIPT=/usr/bin/install -c" "LDFLAGS=-L/usr/local/lib" "LIBCFLAGS=-O2 -Wno-mismatched-tags -Wno-unknown-warning-option" "LIBCFLAGS_FOR_TARGET=-g -O2 -Wno-mismatched-tags -Wno-unknown-warning-option" "MAKE=make" "MAKEINFO=/home/simon/src/cheri/gdb/missing makeinfo --split-size=5000000 " "PICFLAG=" "PICFLAG_FOR_TARGET=" "SHELL=/bin/sh" "EXPECT=expect" "RUNTEST=runtest" "RUNTESTFLAGS=" "exec_prefix=/home/simon/src/cheri/build/sdk" "infodir=/home/simon/src/cheri/build/sdk/info" "libdir=/home/simon/src/cheri/build/sdk/lib" "prefix=/home/simon/src/cheri/build/sdk" "tooldir=/home/simon/src/cheri/build/sdk/x86_64-pc-linux-gnu" "AR=ar" "AS=as" "CC=/usr/bin/clang -ggdb -Wno-mismatched-tags -Wno-unknown-warning-option" "CXX=/usr/bin/clang++ -ggdb -Wno-mismatched-tags -Wno-unknown-warning-opti/usr/bin/clang++ -ggdb -Wno-mismatched-tags -Wno-unknown-warning-option -Wno-mismatched-tags  -O2 -Wno-mismatched-tags -Wno-unknown-warning-option   -I. -I/home/simon/src/cheri/gdb/gdb -I/home/simon/src/cheri/gdb/gdb/common -I/home/simon/src/cheri/gdb/gdb/config -DLOCALEDIR="\"/home/simon/src/cheri/build/sdk/share/locale\"" -DHAVE_CONFIG_H -I/home/simon/src/cheri/gdb/gdb/../include/opcode -I/home/simon/src/cheri/gdb/gdb/../opcodes/.. -I/home/simon/src/cheri/gdb/gdb/../readline/.. -I/home/simon/src/cheri/gdb/gdb/../zlib -I../bfd -I/home/simon/src/cheri/gdb/gdb/../bfd -I/home/simon/src/cheri/gdb/gdb/../include -I../libdecnumber -I/home/simon/src/cheri/gdb/gdb/../libdecnumber  -I/home/simon/src/cheri/gdb/gdb/gnulib/import -Ibuild-gnulib/import   -DTUI=1   -I/usr/include/guile/2.2 -pthread  -I/usr/include/python3.6m -I/usr/include/python3.6m -Wall -Wpointer-arith -Wno-unused -Wunused-value -Wunused-function -Wno-switch -Wno-char-subscripts -Wempty-body -Wunused-but-set-parameter -Wunused-but-set-variable -Wno-sign-compare -Wno-narrowing -Wformat-nonl/usr/bin/clang++ -ggdb -Wno-mismatched-tags -Wno-unknown-warning-option -Wno-mismatched-tags  -O2 -Wno-mismatched-tags -Wno-unknown-warning-option   -I. -I/home/simon/src/cheri/gdb/gdb -I/home/simon/src/cheri/gdb/gdb/common -I/home/simon/src/cheri/gdb/gdb/config -DLOCALEDIR="\"/home/simon/src/cheri/build/sdk/share/locale\"" -DHAVE_CONFIG_H -I/home/simon/src/cheri/gdb/gdb/../include/opcode -I/home/simon/src/cheri/gdb/gdb/../opcodes/.. -I/home/simon/src/cheri/gdb/gdb/../readline/.. -I/home/simon/src/cheri/gdb/gdb/../zlib -I../bfd -I/home/simon/src/cheri/gdb/gdb/../bfd -I/home/simon/src/cheri/gdb/gdb/../include -I../libdecnumber -I/home/simon/src/cheri/gdb/gdb/../libdecnumber  -I/home/simon/src/cheri/gdb/gdb/gnulib/import -Ibuild-gnulib/import   -DTUI=1   -I/usr/include/guile/2.2 -pthread  -I/usr/include/python3.6m -I/usr/include/python3.6m -Wall -Wpointer-arith -Wno-unused -Wunused-value -Wunused-function -Wno-switch -Wno-char-subscripts -Wempty-body -Wunused-but-set-parameter -Wunused-but-set-variable -Wno-sign-compare -Wno-narrowing -Wformat-nonl/usr/bin/clang++ -ggdb -Wno-mismatched-tags -Wno-unknown-warning-option -Wno-mismatched-tags  -O2 -Wno-mismatched-tags -Wno-unknown-warning-option   -I. -I/home/simon/src/cheri/gdb/gdb -I/home/simon/src/cheri/gdb/gdb/common -I/home/simon/src/cheri/gdb/gdb/config -DLOCALEDIR="\"/home/simon/src/cheri/build/sdk/share/locale\"" -DHAVE_CONFIG_H -I/home/simon/src/cheri/gdb/gdb/../include/opcode -I/home/simon/src/cheri/gdb/gdb/../opcodes/.. -I/home/simon/src/cheri/gdb/gdb/../readline/.. -I/home/simon/src/cheri/gdb/gdb/../zlib -I../bfd -I/home/simon/src/cheri/gdb/gdb/../bfd -I/home/simon/src/cheri/gdb/gdb/../include -I../libdecnumber -I/home/simon/src/cheri/gdb/gdb/../libdecnumber  -I/home/simon/src/cheri/gdb/gdb/gnulib/import -Ibuild-gnulib/import   -DTUI=1   -I/usr/include/guile/2.2 -pthread  -I/usr/include/python3.6m -I/usr/include/python3.6m -Wall -Wpointer-arith -Wno-unused -Wunused-value -Wunused-function -Wno-switch -Wno-char-subscripts -Wempty-body -Wunused-but-set-parameter -Wunused-but-set-variable -Wno-sign-compare -Wno-narrowing -Wformat-nonliteral  -c -o scm-string.o -MT scm-string.o -MMD -MP -MF .deps/scm-string.Tpo /home/simon/src/cheri/gdb/gdb/guile/scm-string.c 
clang-6.0: clang-6.0warning: : treating 'c' input as 'c++' when in C++ mode, this behavior is deprecated [-Wdeprecated]
warning: treating 'c' input as 'c++' when in C++ mode, this behavior is deprecated [-Wdeprecated]
clang-6.0: warning: treating 'c' input as 'c++' when in C++ mode, this behavior is deprecated [-Wdeprecated]
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-string.c:23:
In file included from /home/simon/src/cheri/gdb/gdb/defs.h:53:
/home/simon/src/cheri/gdb/gdb/ui-file.h:93:28: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
extern int ui_file_isatty (struct ui_file *);
                           ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:93:28: noteIn file included from /home/simon/src/cheri/gdb/gdb/guile/scm-safe-call.c:23:
In file included from /home/simon/src/cheri/gdb/gdb/defs.h:53:
/home/simon/src/cheri/gdb/gdb/ui-file.h:93In file included from :28/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:: 24warning:
: In file included from struct 'ui_file' was previously declared as a class [-Wmismatched-tags]/home/simon/src/cheri/gdb/gdb/defs.h
:53:
/home/simon/src/cheri/gdb/gdb/ui-file.h:93:28: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
extern int ui_file_isatty (struct ui_file *);extern int ui_file_isatty (struct ui_file *);

                           ^                           ^

/home/simon/src/cheri/gdb/gdb/ui-file.h/home/simon/src/cheri/gdb/gdb/ui-file.h::2626::77::  notenote: : previous use is hereprevious use is here
class ui_file
      ^

/home/simon/src/cheri/gdb/gdb/ui-file.h: did you mean class here?:
93:28: note: class ui_filedid you mean class here?

      ^
extern int ui_file_isatty (struct ui_file *);
                           ^~~~~~
extern int ui_file_isatty (struct ui_file *);                           class

                           ^~~~~~
                           class
/home/simon/src/cheri/gdb/gdb/ui-file.h:95/home/simon/src/cheri/gdb/gdb/ui-file.h:28:: 95:warning28: :struct 'ui_file' was previously declared as a class [-Wmismatched-tags] 
warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
extern void ui_file_write (struct ui_file *file, const char *buf,
                           ^
extern void ui_file_write (struct ui_file *file, const char *buf,
                           ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:/home/simon/src/cheri/gdb/gdb/ui-file.h7::26 :note7: :previous use is here 
note: previous use is here
class ui_file
      ^
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:95:28: note: did you mean class here?/home/simon/src/cheri/gdb/gdb/ui-file.h
:95:28: note: did you mean class here?
extern void ui_file_write (struct ui_file *file, const char *buf,
                           ^~~~~~
                           class
extern void ui_file_write (struct ui_file *file, const char *buf,
                           ^~~~~~
                           class
/home/simon/src/cheri/gdb/gdb/ui-file.h:98:39: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
/home/simon/src/cheri/gdb/gdb/ui-file.h:98:39: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
extern void ui_file_write_async_safe (struct ui_file *file, const char *buf,
                                      ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is hereextern void ui_file_write_async_safe (struct ui_file *file, const char *buf,

                                      ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26class ui_file:
7      ^:
 note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:98:39: note: did you mean class here?
/home/simon/src/cheri/gdb/gdb/ui-file.h:98:39: note: did you mean class here?
extern void ui_file_write_async_safe (struct ui_file *file, const char *buf,
                                      ^~~~~~
                                      class
extern void ui_file_write_async_safe (struct ui_file *file, const char *buf,
                                      ^~~~~~
                                      class
/home/simon/src/cheri/gdb/gdb/ui-file.h:101:27: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
/home/simon/src/cheri/gdb/gdb/ui-file.h:101:27: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
extern long ui_file_read (struct ui_file *file, char *buf, long length_buf);
                          ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
extern long ui_file_read (struct ui_file *file, char *buf, long length_buf);
                          ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:101:27: note: did you mean class here?
/home/simon/src/cheri/gdb/gdb/ui-file.h:101:27: extern long ui_file_read (struct ui_file *file, char *buf, long length_buf);note
:                           ^~~~~~did you mean class here?

                          class
extern long ui_file_read (struct ui_file *file, char *buf, long length_buf);
                          ^~~~~~
                          class
/home/simon/src/cheri/gdb/gdb/ui-file.h:93:28: note: did you mean class here?
extern int ui_file_isatty (struct ui_file *);
                           ^~~~~~
                           class
/home/simon/src/cheri/gdb/gdb/ui-file.h:95:28: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
extern void ui_file_write (struct ui_file *file, const char *buf,
                           ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:95:28: note: did you mean class here?
extern void ui_file_write (struct ui_file *file, const char *buf,
                           ^~~~~~
                           class
/home/simon/src/cheri/gdb/gdb/ui-file.h:98:39: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
extern void ui_file_write_async_safe (struct ui_file *file, const char *buf,
                                      ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:98:39: note: did you mean class here?
extern void ui_file_write_async_safe (struct ui_file *file, const char *buf,
                                      ^~~~~~
                                      class
/home/simon/src/cheri/gdb/gdb/ui-file.h:101:27: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
extern long ui_file_read (struct ui_file *file, char *buf, long length_buf);
                          ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:101:27: note: did you mean class here?
extern long ui_file_read (struct ui_file *file, char *buf, long length_buf);
                          ^~~~~~
                          class
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-string.c:23:
/home/simon/src/cheri/gdb/gdb/defs.h:327:8: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
                                   struct ui_file *, int,
                                   ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-safe-call.c:23:
/home/simon/src/cheri/gdb/gdb/defs.h:327:8: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
                                   struct ui_file *, int,
                                   ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/defs.h:327:8: note: did you mean class here?
                                   struct ui_file *, int,
                                   ^~~~~~
                                   class
/home/simon/src/cheri/gdb/gdb/defs.h:339:57: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
extern void print_address (struct gdbarch *, CORE_ADDR, struct ui_file *);
                                                        ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/defs.h:339:57: note: did you mean class here?
extern void print_address (struct gdbarch *, CORE_ADDR, struct ui_file *);
                                                        ^~~~~~
                                                        class
/home/simon/src/cheri/gdb/gdb/defs.h:327:8: note: did you mean class here?
                                   struct ui_file *, int,
                                   ^~~~~~
                                   class
/home/simon/src/cheri/gdb/gdb/defs.h:339:57: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
extern void print_address (struct gdbarch *, CORE_ADDR, struct ui_file *);
                                                        ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/defs.h:339:57: note: did you mean class here?
extern void print_address (struct gdbarch *, CORE_ADDR, struct ui_file *);
                                                        ^~~~~~
                                                        class
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:24:
/home/simon/src/cheri/gdb/gdb/defs.h:327:8: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
                                   struct ui_file *, int,
                                   ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/defs.h:327:8: note: did you mean class here?
                                   struct ui_file *, int,
                                   ^~~~~~
                                   class
/home/simon/src/cheri/gdb/gdb/defs.h:339:57: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
extern void print_address (struct gdbarch *, CORE_ADDR, struct ui_file *);
                                                        ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/defs.h:339:57: note: did you mean class here?
extern void print_address (struct gdbarch *, CORE_ADDR, struct ui_file *);
                                                        ^~~~~~
                                                        class
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-safe-call.c:23:
In file included from /home/simon/src/cheri/gdb/gdb/defs.h:631:
In file included from /home/simon/src/cheri/gdb/gdb/gdbarch.h:38:
In file included from /home/simon/src/cheri/gdb/gdb/frame.h:72:
In file included from /home/simon/src/cheri/gdb/gdb/language.h:26:
In file included from /home/simon/src/cheri/gdb/gdb/symtab.h:25:
/home/simon/src/cheri/gdb/gdb/gdbtypes.h:1938:14: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
                                    int, struct ui_file *);
                                         ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/gdbtypes.h:1938:14: note: did you mean class here?
                                    int, struct ui_file *);
                                         ^~~~~~
                                         class
In file included from In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-string.c/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c::2324:
:
In file included from In file included from /home/simon/src/cheri/gdb/gdb/defs.h/home/simon/src/cheri/gdb/gdb/defs.h::631631:
:
In file included from In file included from /home/simon/src/cheri/gdb/gdb/gdbarch.h/home/simon/src/cheri/gdb/gdb/gdbarch.h::3838:
:
In file included from In file included from /home/simon/src/cheri/gdb/gdb/frame.h/home/simon/src/cheri/gdb/gdb/frame.h::7272:
:
In file included from In file included from /home/simon/src/cheri/gdb/gdb/language.h/home/simon/src/cheri/gdb/gdb/language.h::2626:
:
In file included from In file included from /home/simon/src/cheri/gdb/gdb/symtab.h/home/simon/src/cheri/gdb/gdb/symtab.h::2525:
:
/home/simon/src/cheri/gdb/gdb/gdbtypes.h/home/simon/src/cheri/gdb/gdb/gdbtypes.h::19381938::1414::  warningwarning: : struct 'ui_file' was previously declared as a class [-Wmismatched-tags]struct 'ui_file' was previously declared as a class [-Wmismatched-tags]

                                    int, struct ui_file *);                                    int, struct ui_file *);

                                         ^                                         ^

/home/simon/src/cheri/gdb/gdb/ui-file.h/home/simon/src/cheri/gdb/gdb/ui-file.h::2626::77::  notenote: : previous use is hereprevious use is here

class ui_fileclass ui_file

      ^      ^

/home/simon/src/cheri/gdb/gdb/gdbtypes.h/home/simon/src/cheri/gdb/gdb/gdbtypes.h:1938:14: note: did you mean class here?
:1938:14: note: did you mean class here?
                                    int, struct ui_file *);
                                         ^~~~~~
                                         class
                                    int, struct ui_file *);
                                         ^~~~~~
                                         class
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:24:
In file included from /home/simon/src/cheri/gdb/gdb/defs.h:631:
In file included from /home/simon/src/cheri/gdb/gdb/gdbarch.h:38:
In file included from /home/simon/src/cheri/gdb/gdb/frame.h:72:
In file included from /home/simon/src/cheri/gdb/gdb/language.h:26:
In file included from /home/simon/src/cheri/gdb/gdb/symtab.h:27:
/home/simon/src/cheri/gdb/gdb/common/function-view.h:208:1: warning: 'function_view' defined as a class template here but previously declared as a struct template [-Wmismatched-tags]
class function_view<Res (Args...)>
^
In file included from In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-safe-call.c/home/simon/src/cheri/gdb/gdb/guile/scm-string.c::2323:
:
In file included from In file included from /home/simon/src/cheri/gdb/gdb/defs.h/home/simon/src/cheri/gdb/gdb/defs.h::631631:
:
In file included from In file included from /home/simon/src/cheri/gdb/gdb/gdbarch.h/home/simon/src/cheri/gdb/gdb/gdbarch.h::3838:
:
In file included from In file included from /home/simon/src/cheri/gdb/gdb/frame.h/home/simon/src/cheri/gdb/gdb/frame.h::7272:
:
In file included from In file included from /home/simon/src/cheri/gdb/gdb/language.h/home/simon/src/cheri/gdb/gdb/language.h::2626:
:
In file included from In file included from /home/simon/src/cheri/gdb/gdb/symtab.h/home/simon/src/cheri/gdb/gdb/symtab.h::2727:
:
/home/simon/src/cheri/gdb/gdb/common/function-view.h/home/simon/src/cheri/gdb/gdb/common/function-view.h::208208::11::  warningwarning: : 'function_view' defined as a class template here but previously declared as a struct template [-Wmismatched-tags]'function_view' defined as a class template here but previously declared as a struct template [-Wmismatched-tags]

class function_view<Res (Args...)>class function_view<Res (Args...)>

^^

/home/simon/src/cheri/gdb/gdb/common/function-view.h:205:1: note: did you mean class here?
struct function_view;
^~~~~~
class
/home/simon/src/cheri/gdb/gdb/common/function-view.h:205:1: note: /home/simon/src/cheri/gdb/gdb/common/function-view.hdid you mean class here?:
205:1: note: did you mean class here?
struct function_view;
^~~~~~
class
struct function_view;
^~~~~~
class
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:24:
In file included from /home/simon/src/cheri/gdb/gdb/defs.h:631:
In file included from /home/simon/src/cheri/gdb/gdb/gdbarch.h:38:
In file included from /home/simon/src/cheri/gdb/gdb/frame.h:72:
In file included from /home/simon/src/cheri/gdb/gdb/language.h:26:
/home/simon/src/cheri/gdb/gdb/symtab.h:30:1: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
struct ui_file;
^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/symtab.h:30:1: note: did you mean class here?
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-string.c:23:
In file included from /home/simon/src/cheri/gdb/gdb/defs.h:struct ui_file;631
:
^~~~~~In file included from 
/home/simon/src/cheri/gdb/gdb/gdbarch.hclass:38
:
In file included from /home/simon/src/cheri/gdb/gdb/frame.h:72:
In file included from /home/simon/src/cheri/gdb/gdb/language.h:26:
/home/simon/src/cheri/gdb/gdb/symtab.h:30:1: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
struct ui_file;
^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/symtab.h:30:1: note: did you mean class here?
struct ui_file;
^~~~~~
class
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-safe-call.c:23:
In file included from /home/simon/src/cheri/gdb/gdb/defs.h:631:
In file included from /home/simon/src/cheri/gdb/gdb/gdbarch.h:38:
In file included from /home/simon/src/cheri/gdb/gdb/frame.h:72:
In file included from /home/simon/src/cheri/gdb/gdb/language.h:26:
/home/simon/src/cheri/gdb/gdb/symtab.h:30:1: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
struct ui_file;
^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/symtab.h:30:1: note: did you mean class here?
struct ui_file;
^~~~~~
class
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-string.c:23:
In file included from /home/simon/src/cheri/gdb/gdb/defs.h:751:
In file included from /home/simon/src/cheri/gdb/gdb/utils.h:24:
In file included from /home/simon/src/cheri/gdb/gdb/exceptions.h:23:
/home/simon/src/cheri/gdb/gdb/ui-out.h:81:1: warning: 'ui_out' defined as a class here but previously declared as a struct [-Wmismatched-tags]
class ui_out
^
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:24:
In file included from /home/simon/src/cheri/gdb/gdb/defs.h:751In file included from :
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-safe-call.c/home/simon/src/cheri/gdb/gdb/utils.h::2324:
:
In file included from In file included from /home/simon/src/cheri/gdb/gdb/defs.h/home/simon/src/cheri/gdb/gdb/exceptions.h::75123:
:
In file included from /home/simon/src/cheri/gdb/gdb/ui-out.h/home/simon/src/cheri/gdb/gdb/utils.h::8124::
1In file included from :/home/simon/src/cheri/gdb/gdb/exceptions.h :warning23: :
'ui_out' defined as a class here but previously declared as a struct [-Wmismatched-tags]/home/simon/src/cheri/gdb/gdb/ui-out.h
:81:1: warning: 'ui_out' defined as a class here but previously declared as a struct [-Wmismatched-tags]
class ui_out
^
class ui_out
^
/home/simon/src/cheri/gdb/gdb/gdbarch.h:68:1: note: did you mean class here?
struct ui_out;
^~~~~~
class
/home/simon/src/cheri/gdb/gdb/gdbarch.h:68:1: note: did you mean class here?
struct ui_out;/home/simon/src/cheri/gdb/gdb/gdbarch.h
^~~~~~:
68class:
1: note: did you mean class here?
struct ui_out;
^~~~~~
class/home/simon/src/cheri/gdb/gdb/frame.h
:80:1: note: did you mean class here?
struct ui_out;
^~~~~~
class
/home/simon/src/cheri/gdb/gdb/frame.h:80:1: note: did you mean class here?
struct ui_out;
^~~~~~
class
/home/simon/src/cheri/gdb/gdb/frame.h:80:1: note: did you mean class here?
struct ui_out;
^~~~~~
class
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-safe-call.c:23:
In file included from /home/simon/src/cheri/gdb/gdb/defs.h:751:
In file included from /home/simon/src/cheri/gdb/gdb/utils.h:24:
In file included from /home/simon/src/cheri/gdb/gdb/exceptions.h:23:
/home/simon/src/cheri/gdb/gdb/ui-out.h:200:21: warning: struct 'ui_out' was previously declared as a class [-Wmismatched-tags]
  ui_out_emit_type (struct ui_out *uiout, const char *id)
                    ^
/home/simon/src/cheri/gdb/gdb/ui-out.h:81:7: note: previous use is here
class ui_out
      ^
/home/simon/src/cheri/gdb/gdb/ui-out.h:200:21: note: did you mean class here?
  ui_out_emit_type (struct ui_out *uiout, const char *id)
                    ^~~~~~
                    class
/home/simon/src/cheri/gdb/gdb/ui-out.h:217:3: warning: struct 'ui_out' was previously declared as a class [-Wmismatched-tags]
  struct ui_out *m_uiout;
  ^
/home/simon/src/cheri/gdb/gdb/ui-out.h:81:7: note: previous use is here
class ui_out
      ^
/home/simon/src/cheri/gdb/gdb/ui-out.h:217:3: note: did you mean class here?
  struct ui_out *m_uiout;
  ^~~~~~
  class
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-safe-call.c:23:
In file included from /home/simon/src/cheri/gdb/gdb/defs.h:751:
In file included from /home/simon/src/cheri/gdb/gdb/utils.h:24:
/home/simon/src/cheri/gdb/gdb/exceptions.h:67:1: warning: struct 'ui_out' was previously declared as a class [-Wmismatched-tags]
struct ui_out;
^
/home/simon/src/cheri/gdb/gdb/ui-out.h:81:7: note: previous use is here
class ui_out
      ^
/home/simon/src/cheri/gdb/gdb/exceptions.h:67:1: note: did you mean class here?
struct ui_out;
^~~~~~
class
In file included from In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-ports.c/home/simon/src/cheri/gdb/gdb/guile/scm-string.c::2324:
:
In file included from In file included from /home/simon/src/cheri/gdb/gdb/defs.h/home/simon/src/cheri/gdb/gdb/defs.h::751751:
:
In file included from In file included from /home/simon/src/cheri/gdb/gdb/utils.h/home/simon/src/cheri/gdb/gdb/utils.h::2424:
:
In file included from In file included from /home/simon/src/cheri/gdb/gdb/exceptions.h/home/simon/src/cheri/gdb/gdb/exceptions.h::2323:
:
/home/simon/src/cheri/gdb/gdb/ui-out.h/home/simon/src/cheri/gdb/gdb/ui-out.h::200200::2121::  warningwarning: : struct 'ui_out' was previously declared as a class [-Wmismatched-tags]struct 'ui_out' was previously declared as a class [-Wmismatched-tags]

  ui_out_emit_type (struct ui_out *uiout, const char *id)  ui_out_emit_type (struct ui_out *uiout, const char *id)

                    ^                    ^

/home/simon/src/cheri/gdb/gdb/ui-out.h/home/simon/src/cheri/gdb/gdb/ui-out.h::8181::77::  notenote: : previous use is hereprevious use is here

class ui_outclass ui_out

      ^      ^

/home/simon/src/cheri/gdb/gdb/ui-out.h/home/simon/src/cheri/gdb/gdb/ui-out.h::200200::2121::  notenote: : did you mean class here?did you mean class here?

  ui_out_emit_type (struct ui_out *uiout, const char *id)  ui_out_emit_type (struct ui_out *uiout, const char *id)

                    ^~~~~~                    ^~~~~~

                    class                    class

/home/simon/src/cheri/gdb/gdb/ui-out.h:217/home/simon/src/cheri/gdb/gdb/ui-out.h:3::217 :warning3: :struct 'ui_out' was previously declared as a class [-Wmismatched-tags] 
warning: struct 'ui_out' was previously declared as a class [-Wmismatched-tags]
  struct ui_out *m_uiout;
  ^  struct ui_out *m_uiout;

  ^
/home/simon/src/cheri/gdb/gdb/ui-out.h:/home/simon/src/cheri/gdb/gdb/ui-out.h81::817::7 :note : noteprevious use is here: 
previous use is here
class ui_out
class ui_out      ^

      ^
/home/simon/src/cheri/gdb/gdb/ui-out.h/home/simon/src/cheri/gdb/gdb/ui-out.h::217217::33::  notenote: : did you mean class here?did you mean class here?

  struct ui_out *m_uiout;  struct ui_out *m_uiout;

  ^~~~~~  ^~~~~~

  class  class

In file included from In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-ports.c/home/simon/src/cheri/gdb/gdb/guile/scm-string.c::2324:
:
In file included from In file included from /home/simon/src/cheri/gdb/gdb/defs.h/home/simon/src/cheri/gdb/gdb/defs.h::751751:
:
In file included from In file included from /home/simon/src/cheri/gdb/gdb/utils.h/home/simon/src/cheri/gdb/gdb/utils.h::2424:
:
/home/simon/src/cheri/gdb/gdb/exceptions.h/home/simon/src/cheri/gdb/gdb/exceptions.h::6767::11::  warningwarning: : struct 'ui_out' was previously declared as a class [-Wmismatched-tags]struct 'ui_out' was previously declared as a class [-Wmismatched-tags]

struct ui_out;struct ui_out;

^^

/home/simon/src/cheri/gdb/gdb/ui-out.h/home/simon/src/cheri/gdb/gdb/ui-out.h::8181::77::  notenote: : previous use is hereprevious use is here

class ui_outclass ui_out

      ^      ^

/home/simon/src/cheri/gdb/gdb/exceptions.h:67:1/home/simon/src/cheri/gdb/gdb/exceptions.h: :note67: :1did you mean class here?:
 note: did you mean class here?
struct ui_out;
^~~~~~
struct ui_out;class

^~~~~~
class
13 warnings generated.
13 warnings generated.
/usr/bin/clang++ -ggdb -Wno-mismatched-tags -Wno-unknown-warning-option -Wno-mismatched-tags  -O2 -Wno-mismatched-tags -Wno-unknown-warning-option   -I. -I/home/simon/src/cheri/gdb/gdb -I/home/simon/src/cheri/gdb/gdb/common -I/home/simon/src/cheri/gdb/gdb/config -DLOCALEDIR="\"/home/simon/src/cheri/build/sdk/share/locale\"" -DHAVE_CONFIG_H -I/home/simon/src/cheri/gdb/gdb/../include/opcode -I/home/simon/src/cheri/gdb/gdb/../opcodes/.. -I/home/simon/src/cheri/gdb/gdb/../readline/.. -I/home/simon/src/cheri/gdb/gdb/../zlib -I../bfd -I/home/simon/src/cheri/gdb/gdb/../bfd -I/home/simon/src/cheri/gdb/gdb/../include -I../libdecnumber -I/home/simon/src/cheri/gdb/gdb/../libdecnumber  -I/home/simon/src/cheri/gdb/gdb/gnulib/import -Ibuild-gnulib/import   -DTUI=1   -I/usr/include/guile/2.2 -pthread  -I/usr/include/python3.6m -I/usr/include/python3.6m -Wall -Wpointer-arith -Wno-unused -Wunused-value -Wunused-function -Wno-switch -Wno-char-subscripts -Wempty-body -Wunused-but-set-parameter -Wunused-but-set-variable -Wno-sign-compare -Wno-narrowing -Wformat-nonl/usr/bin/clang++ -ggdb -Wno-mismatched-tags -Wno-unknown-warning-option -Wno-mismatched-tags  -O2 -Wno-mismatched-tags -Wno-unknown-warning-option   -I. -I/home/simon/src/cheri/gdb/gdb -I/home/simon/src/cheri/gdb/gdb/common -I/home/simon/src/cheri/gdb/gdb/config -DLOCALEDIR="\"/home/simon/src/cheri/build/sdk/share/locale\"" -DHAVE_CONFIG_H -I/home/simon/src/cheri/gdb/gdb/../include/opcode -I/home/simon/src/cheri/gdb/gdb/../opcodes/.. -I/home/simon/src/cheri/gdb/gdb/../readline/.. -I/home/simon/src/cheri/gdb/gdb/../zlib -I../bfd -I/home/simon/src/cheri/gdb/gdb/../bfd -I/home/simon/src/cheri/gdb/gdb/../include -I../libdecnumber -I/home/simon/src/cheri/gdb/gdb/../libdecnumber  -I/home/simon/src/cheri/gdb/gdb/gnulib/import -Ibuild-gnulib/import   -DTUI=1   -I/usr/include/guile/2.2 -pthread  -I/usr/include/python3.6m -I/usr/include/python3.6m -Wall -Wpointer-arith -Wno-unused -Wunused-value -Wunused-function -Wno-switch -Wno-char-subscripts -Wempty-body -Wunused-but-set-parameter -Wunused-but-set-variable -Wno-sign-compare -Wno-narrowing -Wformat-nonliteral  -c -o scm-symtab.o -MT scm-symtab.o -MMD -MP -MF .deps/scm-symtab.Tpo /home/simon/src/cheri/gdb/gdb/guile/scm-symtab.c 
clang-6.0: warning: treating 'c' input as 'c++' when in C++ mode, this behavior is deprecated [-Wdeprecated]
clang-6.0: warning: treating 'c' input as 'c++' when in C++ mode, this behavior is deprecated [-Wdeprecated]
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:146:10: error: use of undeclared identifier 'scm_new_port_table_entry'
  port = scm_new_port_table_entry (port_type);
         ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:231:20: error: use of undeclared identifier 'SCM_PTAB_ENTRY'
  scm_t_port *pt = SCM_PTAB_ENTRY (port);
                   ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:240:47: error: member access into incomplete type 'scm_t_port'
  count = ui_file_read (gdb_stdin, (char *) pt->read_buf, pt->read_buf_size);
                                              ^
/usr/include/guile/2.2/libguile/ports.h:82:16: note: forward declaration of 'scm_t_port'
typedef struct scm_t_port scm_t_port;
               ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:240:61: error: member access into incomplete type 'scm_t_port'
  count = ui_file_read (gdb_stdin, (char *) pt->read_buf, pt->read_buf_size);
                                                            ^
/usr/include/guile/2.2/libguile/ports.h:82:16: note: forward declaration of 'scm_t_port'
typedef struct scm_t_port scm_t_port;
               ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:246:5: error: member access into incomplete type 'scm_t_port'
  pt->read_pos = pt->read_buf;
    ^
/usr/include/guile/2.2/libguile/ports.h:82:16: note: forward declaration of 'scm_t_port'
typedef struct scm_t_port scm_t_port;
               ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:247:5: error: member access into incomplete type 'scm_t_port'
  pt->read_end = pt->read_buf + count;
    ^
/usr/include/guile/2.2/libguile/ports.h:82:16: note: forward declaration of 'scm_t_port'
typedef struct scm_t_port scm_t_port;
               ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:248:13: error: member access into incomplete type 'scm_t_port'
  return *pt->read_buf;
            ^
/usr/include/guile/2.2/libguile/ports.h:82:16: note: forward declaration of 'scm_t_port'
typedef struct scm_t_port scm_t_port;
               ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:315:21: error: no matching function for call to 'scm_make_port_type'
  stdio_port_desc = scm_make_port_type (stdio_port_desc_name,
                    ^~~~~~~~~~~~~~~~~~
/usr/include/guile/2.2/libguile/ports.h:93:26: note: candidate function not viable: no known conversion from 'int (SCM)' (aka 'int (scm_unused_struct *)') to 'size_t (*)(SCM, SCM, size_t, size_t)' (aka 'unsigned long (*)(scm_unused_struct *, scm_unused_struct *, unsigned long, unsigned long)') for 2nd argument
SCM_API scm_t_port_type *scm_make_port_type
                         ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:318:3: error: no matching function for call to 'scm_set_port_input_waiting'
  scm_set_port_input_waiting (stdio_port_desc, ioscm_input_waiting);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/guile/2.2/libguile/ports.h:117:14: note: candidate function not viable: no known conversion from 'scm_t_bits' (aka 'unsigned long') to 'scm_t_port_type *' for 1st argument
SCM_API void scm_set_port_input_waiting (scm_t_port_type *ptob,
             ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:319:3: error: use of undeclared identifier 'scm_set_port_flush'; did you mean 'scm_set_port_close'?
  scm_set_port_flush (stdio_port_desc, ioscm_flush);
  ^~~~~~~~~~~~~~~~~~
  scm_set_port_close
/usr/include/guile/2.2/libguile/ports.h:107:14: note: 'scm_set_port_close' declared here
SCM_API void scm_set_port_close (scm_t_port_type *ptob, void (*close) (SCM));
             ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:319:23: error: cannot initialize a parameter of type 'scm_t_port_type *' with an lvalue of type 'scm_t_bits' (aka 'unsigned long')
  scm_set_port_flush (stdio_port_desc, ioscm_flush);
                      ^~~~~~~~~~~~~~~
/usr/include/guile/2.2/libguile/ports.h:107:51: note: passing argument to parameter 'ptob' here
SCM_API void scm_set_port_close (scm_t_port_type *ptob, void (*close) (SCM));
                                                  ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:329:20: error: use of undeclared identifier 'SCM_PTAB_ENTRY'
  scm_t_port *pt = SCM_PTAB_ENTRY (port);
                   ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:338:9: error: member access into incomplete type 'scm_t_port'
      pt->read_buf
        ^
/usr/include/guile/2.2/libguile/ports.h:82:16: note: forward declaration of 'scm_t_port'
typedef struct scm_t_port scm_t_port;
               ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:340:9: error: member access into incomplete type 'scm_t_port'
      pt->read_pos = pt->read_end = pt->read_buf;
        ^
/usr/include/guile/2.2/libguile/ports.h:82:16: note: forward declaration of 'scm_t_port'
typedef struct scm_t_port scm_t_port;
               ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:341:9: error: member access into incomplete type 'scm_t_port'
      pt->read_buf_size = size;
        ^
/usr/include/guile/2.2/libguile/ports.h:82:16: note: forward declaration of 'scm_t_port'
typedef struct scm_t_port scm_t_port;
               ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:345:9: error: member access into incomplete type 'scm_t_port'
      pt->read_pos = pt->read_buf = pt->read_end = &pt->shortbuf;
        ^
/usr/include/guile/2.2/libguile/ports.h:82:16: note: forward declaration of 'scm_t_port'
typedef struct scm_t_port scm_t_port;
               ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:346:9: error: member access into incomplete type 'scm_t_port'
      pt->read_buf_size = 1;
        ^
/usr/include/guile/2.2/libguile/ports.h:82:16: note: forward declaration of 'scm_t_port'
typedef struct scm_t_port scm_t_port;
               ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:351:9: error: member access into incomplete type 'scm_t_port'
      pt->write_buf
        ^
/usr/include/guile/2.2/libguile/ports.h:82:16: note: forward declaration of 'scm_t_port'
typedef struct scm_t_port scm_t_port;
               ^
/home/simon/src/cheri/gdb/gdb/guile/scm-ports.c:353:9: error: member access into incomplete type 'scm_t_port'
      pt->write_pos = pt->write_buf;
        ^
/usr/include/guile/2.2/libguile/ports.h:82:16: note: forward declaration of 'scm_t_port'
typedef struct scm_t_port scm_t_port;
               ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
13 warnings and 20 errors generated.
make[1]: *** [Makefile:1916: scm-ports.o] Error 1
make[1]: *** Waiting for unfinished jobs....
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-symbol.c:23:
In file included from /home/simon/src/cheri/gdb/gdb/defs.h:53:
/home/simon/src/cheri/gdb/gdb/ui-file.h:93:28: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
extern int ui_file_isatty (struct ui_file *);
                           ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:93:28: note: did you mean class here?
extern int ui_file_isatty (struct ui_file *);
                           ^~~~~~
                           class
/home/simon/src/cheri/gdb/gdb/ui-file.h:95:28: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
extern void ui_file_write (struct ui_file *file, const char *buf,
                           ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:95:28: note: did you mean class here?
extern void ui_file_write (struct ui_file *file, const char *buf,
                           ^~~~~~
                           class
/home/simon/src/cheri/gdb/gdb/ui-file.h:98:39: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
extern void ui_file_write_async_safe (struct ui_file *file, const char *buf,
                                      ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:98:39: note: did you mean class here?
extern void ui_file_write_async_safe (struct ui_file *file, const char *buf,
                                      ^~~~~~
                                      class
/home/simon/src/cheri/gdb/gdb/ui-file.h:101:27: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
extern long ui_file_read (struct ui_file *file, char *buf, long length_buf);
                          ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:101:27: note: did you mean class here?
extern long ui_file_read (struct ui_file *file, char *buf, long length_buf);
                          ^~~~~~
                          class
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-symbol.c:23:
/home/simon/src/cheri/gdb/gdb/defs.h:327:8: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
                                   struct ui_file *, int,
                                   ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/defs.h:327:8: note: did you mean class here?
                                   struct ui_file *, int,
                                   ^~~~~~
                                   class
/home/simon/src/cheri/gdb/gdb/defs.h:339:57: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
extern void print_address (struct gdbarch *, CORE_ADDR, struct ui_file *);
                                                        ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/defs.h:339:57: note: did you mean class here?
extern void print_address (struct gdbarch *, CORE_ADDR, struct ui_file *);
                                                        ^~~~~~
                                                        class
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-symbol.c:23:
In file included from /home/simon/src/cheri/gdb/gdb/defs.h:631:
In file included from /home/simon/src/cheri/gdb/gdb/gdbarch.h:38:
In file included from /home/simon/src/cheri/gdb/gdb/frame.h:72:
In file included from /home/simon/src/cheri/gdb/gdb/language.h:26:
In file included from /home/simon/src/cheri/gdb/gdb/symtab.h:25:
/home/simon/src/cheri/gdb/gdb/gdbtypes.h:1938:14: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
                                    int, struct ui_file *);
                                         ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/gdbtypes.h:1938:14: note: did you mean class here?
                                    int, struct ui_file *);
                                         ^~~~~~
                                         class
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-symbol.c:23:
In file included from /home/simon/src/cheri/gdb/gdb/defs.h:631:
In file included from /home/simon/src/cheri/gdb/gdb/gdbarch.h:38:
In file included from /home/simon/src/cheri/gdb/gdb/frame.h:72:
In file included from /home/simon/src/cheri/gdb/gdb/language.h:26:
In file included from /home/simon/src/cheri/gdb/gdb/symtab.h:27:
/home/simon/src/cheri/gdb/gdb/common/function-view.h:208:1: warning: 'function_view' defined as a class template here but previously declared as a struct template [-Wmismatched-tags]
class function_view<Res (Args...)>
^
/home/simon/src/cheri/gdb/gdb/common/function-view.h:205:1: note: did you mean class here?
struct function_view;
^~~~~~
class
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-symbol.c:23:
In file included from /home/simon/src/cheri/gdb/gdb/defs.h:631:
In file included from /home/simon/src/cheri/gdb/gdb/gdbarch.h:38:
In file included from /home/simon/src/cheri/gdb/gdb/frame.h:72:
In file included from /home/simon/src/cheri/gdb/gdb/language.h:26:
/home/simon/src/cheri/gdb/gdb/symtab.h:30:1: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
struct ui_file;
^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/symtab.h:30:1: note: did you mean class here?
struct ui_file;
^~~~~~
class
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-symbol.c:23:
In file included from /home/simon/src/cheri/gdb/gdb/defs.h:751:
In file included from /home/simon/src/cheri/gdb/gdb/utils.h:24:
In file included from /home/simon/src/cheri/gdb/gdb/exceptions.h:23:
/home/simon/src/cheri/gdb/gdb/ui-out.h:81:1: warning: 'ui_out' defined as a class here but previously declared as a struct [-Wmismatched-tags]
class ui_out
^
/home/simon/src/cheri/gdb/gdb/gdbarch.h:68:1: note: did you mean class here?
struct ui_out;
^~~~~~
class
/home/simon/src/cheri/gdb/gdb/frame.h:80:1: note: did you mean class here?
struct ui_out;
^~~~~~
class
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-symbol.c:23:
In file included from /home/simon/src/cheri/gdb/gdb/defs.h:751:
In file included from /home/simon/src/cheri/gdb/gdb/utils.h:24:
In file included from /home/simon/src/cheri/gdb/gdb/exceptions.h:23:
/home/simon/src/cheri/gdb/gdb/ui-out.h:200:21: warning: struct 'ui_out' was previously declared as a class [-Wmismatched-tags]
  ui_out_emit_type (struct ui_out *uiout, const char *id)
                    ^
/home/simon/src/cheri/gdb/gdb/ui-out.h:81:7: note: previous use is here
class ui_out
      ^
/home/simon/src/cheri/gdb/gdb/ui-out.h:200:21: note: did you mean class here?
  ui_out_emit_type (struct ui_out *uiout, const char *id)
                    ^~~~~~
                    class
/home/simon/src/cheri/gdb/gdb/ui-out.h:217:3: warning: struct 'ui_out' was previously declared as a class [-Wmismatched-tags]
  struct ui_out *m_uiout;
  ^
/home/simon/src/cheri/gdb/gdb/ui-out.h:81:7: note: previous use is here
class ui_out
      ^
/home/simon/src/cheri/gdb/gdb/ui-out.h:217:3: note: did you mean class here?
  struct ui_out *m_uiout;
  ^~~~~~
  class
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-symbol.c:23:
In file included from /home/simon/src/cheri/gdb/gdb/defs.h:751:
In file included from /home/simon/src/cheri/gdb/gdb/utils.h:24:
/home/simon/src/cheri/gdb/gdb/exceptions.h:67:1: warning: struct 'ui_out' was previously declared as a class [-Wmismatched-tags]
struct ui_out;
^
/home/simon/src/cheri/gdb/gdb/ui-out.h:81:7: note: previous use is here
class ui_out
      ^
/home/simon/src/cheri/gdb/gdb/exceptions.h:67:1: note: did you mean class here?
struct ui_out;
^~~~~~
class
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-symtab.c:23:
In file included from /home/simon/src/cheri/gdb/gdb/defs.h:53:
/home/simon/src/cheri/gdb/gdb/ui-file.h:93:28: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
extern int ui_file_isatty (struct ui_file *);
                           ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:93:28: note: did you mean class here?
extern int ui_file_isatty (struct ui_file *);
                           ^~~~~~
                           class
/home/simon/src/cheri/gdb/gdb/ui-file.h:95:28: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
extern void ui_file_write (struct ui_file *file, const char *buf,
                           ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:95:28: note: did you mean class here?
extern void ui_file_write (struct ui_file *file, const char *buf,
                           ^~~~~~
                           class
/home/simon/src/cheri/gdb/gdb/ui-file.h:98:39: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
extern void ui_file_write_async_safe (struct ui_file *file, const char *buf,
                                      ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:98:39: note: did you mean class here?
extern void ui_file_write_async_safe (struct ui_file *file, const char *buf,
                                      ^~~~~~
                                      class
/home/simon/src/cheri/gdb/gdb/ui-file.h:101:27: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
extern long ui_file_read (struct ui_file *file, char *buf, long length_buf);
                          ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:101:27: note: did you mean class here?
extern long ui_file_read (struct ui_file *file, char *buf, long length_buf);
                          ^~~~~~
                          class
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-symtab.c:23:
/home/simon/src/cheri/gdb/gdb/defs.h:327:8: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
                                   struct ui_file *, int,
                                   ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/defs.h:327:8: note: did you mean class here?
                                   struct ui_file *, int,
                                   ^~~~~~
                                   class
/home/simon/src/cheri/gdb/gdb/defs.h:339:57: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
extern void print_address (struct gdbarch *, CORE_ADDR, struct ui_file *);
                                                        ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/defs.h:339:57: note: did you mean class here?
extern void print_address (struct gdbarch *, CORE_ADDR, struct ui_file *);
                                                        ^~~~~~
                                                        class
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-symtab.c:23:
In file included from /home/simon/src/cheri/gdb/gdb/defs.h:631:
In file included from /home/simon/src/cheri/gdb/gdb/gdbarch.h:38:
In file included from /home/simon/src/cheri/gdb/gdb/frame.h:72:
In file included from /home/simon/src/cheri/gdb/gdb/language.h:26:
In file included from /home/simon/src/cheri/gdb/gdb/symtab.h:25:
/home/simon/src/cheri/gdb/gdb/gdbtypes.h:1938:14: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
                                    int, struct ui_file *);
                                         ^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/gdbtypes.h:1938:14: note: did you mean class here?
                                    int, struct ui_file *);
                                         ^~~~~~
                                         class
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-symtab.c:23:
In file included from /home/simon/src/cheri/gdb/gdb/defs.h:631:
In file included from /home/simon/src/cheri/gdb/gdb/gdbarch.h:38:
In file included from /home/simon/src/cheri/gdb/gdb/frame.h:72:
In file included from /home/simon/src/cheri/gdb/gdb/language.h:26:
In file included from /home/simon/src/cheri/gdb/gdb/symtab.h:27:
/home/simon/src/cheri/gdb/gdb/common/function-view.h:208:1: warning: 'function_view' defined as a class template here but previously declared as a struct template [-Wmismatched-tags]
class function_view<Res (Args...)>
^
/home/simon/src/cheri/gdb/gdb/common/function-view.h:205:1: note: did you mean class here?
struct function_view;
^~~~~~
class
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-symtab.c:23:
In file included from /home/simon/src/cheri/gdb/gdb/defs.h:631:
In file included from /home/simon/src/cheri/gdb/gdb/gdbarch.h:38:
In file included from /home/simon/src/cheri/gdb/gdb/frame.h:72:
In file included from /home/simon/src/cheri/gdb/gdb/language.h:26:
/home/simon/src/cheri/gdb/gdb/symtab.h:30:1: warning: struct 'ui_file' was previously declared as a class [-Wmismatched-tags]
struct ui_file;
^
/home/simon/src/cheri/gdb/gdb/ui-file.h:26:7: note: previous use is here
class ui_file
      ^
/home/simon/src/cheri/gdb/gdb/symtab.h:30:1: note: did you mean class here?
struct ui_file;
^~~~~~
class
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-symtab.c:23:
In file included from /home/simon/src/cheri/gdb/gdb/defs.h:751:
In file included from /home/simon/src/cheri/gdb/gdb/utils.h:24:
In file included from /home/simon/src/cheri/gdb/gdb/exceptions.h:23:
/home/simon/src/cheri/gdb/gdb/ui-out.h:81:1: warning: 'ui_out' defined as a class here but previously declared as a struct [-Wmismatched-tags]
class ui_out
^
/home/simon/src/cheri/gdb/gdb/gdbarch.h:68:1: note: did you mean class here?
struct ui_out;
^~~~~~
class
/home/simon/src/cheri/gdb/gdb/frame.h:80:1: note: did you mean class here?
struct ui_out;
^~~~~~
class
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-symtab.c:23:
In file included from /home/simon/src/cheri/gdb/gdb/defs.h:751:
In file included from /home/simon/src/cheri/gdb/gdb/utils.h:24:
In file included from /home/simon/src/cheri/gdb/gdb/exceptions.h:23:
/home/simon/src/cheri/gdb/gdb/ui-out.h:200:21: warning: struct 'ui_out' was previously declared as a class [-Wmismatched-tags]
  ui_out_emit_type (struct ui_out *uiout, const char *id)
                    ^
/home/simon/src/cheri/gdb/gdb/ui-out.h:81:7: note: previous use is here
class ui_out
      ^
/home/simon/src/cheri/gdb/gdb/ui-out.h:200:21: note: did you mean class here?
  ui_out_emit_type (struct ui_out *uiout, const char *id)
                    ^~~~~~
                    class
/home/simon/src/cheri/gdb/gdb/ui-out.h:217:3: warning: struct 'ui_out' was previously declared as a class [-Wmismatched-tags]
  struct ui_out *m_uiout;
  ^
/home/simon/src/cheri/gdb/gdb/ui-out.h:81:7: note: previous use is here
class ui_out
      ^
/home/simon/src/cheri/gdb/gdb/ui-out.h:217:3: note: did you mean class here?
  struct ui_out *m_uiout;
  ^~~~~~
  class
In file included from /home/simon/src/cheri/gdb/gdb/guile/scm-symtab.c:23:
In file included from /home/simon/src/cheri/gdb/gdb/defs.h:751:
In file included from /home/simon/src/cheri/gdb/gdb/utils.h:24:
/home/simon/src/cheri/gdb/gdb/exceptions.h:67:1: warning: struct 'ui_out' was previously declared as a class [-Wmismatched-tags]
struct ui_out;
^
/home/simon/src/cheri/gdb/gdb/ui-out.h:81:7: note: previous use is here
class ui_out
      ^
/home/simon/src/cheri/gdb/gdb/exceptions.h:67:1: note: did you mean class here?
struct ui_out;
^~~~~~
class
13 warnings generated.
13 warnings generated.
make[1]: Leaving directory '/home/simon/src/cheri/build/gdb-native-build/gdb' 
make: *** [Makefile:9781: all-gdb] Error 2
Restoring ['as', 'ld', 'objcopy', 'objdump'] in /home/simon/src/cheri/build/sdk/bin
Command "nice make all-gdb -j3" failed with exit code 2.
See /home/simon/src/cheri/build/gdb-native-build/make.all-gdb.log for details.
```

</details>