### PR TITLE
DNM: minimal disk-image: use minimal rootfs

### DIFF
--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -1308,7 +1308,7 @@ class BuildCHERIBSDMinimal(BuildCHERIBSD):
 
     def install(self, **kwargs):
         self.makedirs(self.installDir)
-        for i in ("bin", "sbin", "usr/sbin", "usr/bin", "lib", "usr/lib", "usr/libcheri"):
+        for i in ("bin", "dev", "mnt", "root", "sbin", "usr/sbin", "usr/bin", "lib", "usr/lib", "usr/libcheri"):
             self.makedirs(self.installDir / i)
         # install all the needed libs
         args = self.installworld_args

--- a/pycheribuild/projects/disk_image.py
+++ b/pycheribuild/projects/disk_image.py
@@ -581,7 +581,7 @@ class BuildMinimalCheriBSDDiskImage(_BuildDiskImageBase):
                                                   help="Also add cheritest/cheriabitest to the disk image")
 
     def __init__(self, config: CheriConfig):
-        super().__init__(config, source_class=BuildCHERIBSD)
+        super().__init__(config, source_class=BuildCHERIBSDMinimal)
         self.minimumImageSize = "20m"  # let's try to shrink the image size
         # The base input is only cheribsdbox and all the symlinks
         self.input_METALOG = self.rootfsDir / "cheribsdbox.mtree"


### PR DESCRIPTION
This half-corrects a problem, in that it now points at the correct
rootfs dir, and some more blank directories are made, but the builds
will fail because not all the requisite targets for the files listed
in cheribsdbox.manifest are currently built by the cheribsd-minimal
target.

The PR is not, as such, ready to merge, but I would like to make sure
I'm not barking up the wrong tree.