### PR TITLE
Add --benchmark-fpga-extra-args

### DIFF
--- a/pycheribuild/config/chericonfig.py
+++ b/pycheribuild/config/chericonfig.py
@@ -264,6 +264,9 @@ class CheriConfig(object):
         self.tests_env_only = loader.addCommandLineOnlyBoolOption("test-environment-only", group=loader.testsGroup,
             help="Don't actually run the tests. Instead setup a QEMU instance with the right paths set up.")
 
+        self.benchmark_fpga_extra_args = loader.addCommandLineOnlyOption("benchmark-fpga-extra-args", group=loader.benchmarkGroup,
+                                                                         type=list, metavar="ARGS",
+                                                                         help="Extra options for beri-fpga-bsd-boot.py")
         self.cherilibs_svn_checkout = loader.addPathOption("cherilibs-svn-checkout", group=loader.benchmarkGroup,
                                                            default="/missing/--cherilibs-svn-checkout/config/option",
                                                            help="PATH to the CTSRD SVN cherilibs/trunk checkout")

--- a/pycheribuild/projects/cross/crosscompileproject.py
+++ b/pycheribuild/projects/cross/crosscompileproject.py
@@ -550,6 +550,8 @@ class CrossCompileMixin(MultiArchBaseMixin):
         self.run_cmd("du", "-sh", benchmarks_dir)
         runbench_args = [benchmarks_dir, "--target=" + self.config.benchmark_ssh_host, "--out-path=" + output_file]
         basic_args = []
+        if self.config.benchmark_fpga_extra_args:
+            basic_args.extend(self.config.benchmark_fpga_extra_args)
         if self.config.benchmark_extra_args:
             runbench_args.extend(self.config.benchmark_extra_args)
         if self.config.tests_interact:


### PR DESCRIPTION
Useful for specifying the cable id when a system has multiple attached
FPGAs, for example: --benchmark-fpga-extra-args="-c 2"