### PR TITLE
llvm: use internal c++ goodies

### DIFF
--- a/pycheribuild/projects/llvm.py
+++ b/pycheribuild/projects/llvm.py
@@ -73,7 +73,7 @@ class BuildLLVMBase(CMakeProject):
                      "needed by default (e.g. llvm-mca, llvm-pdbutil)")
         cls.build_everything = cls.add_bool_option("build-everything", default=False,
             help="Also build documentation,examples and bindings")
-        cls.use_llvm_cxx = cls.add_bool_option("use-tree-cxx", default=False,
+        cls.use_llvm_cxx = cls.add_bool_option("use-in-tree-cxx-libs", default=False,
             help="Use in-tree, not host, C++ runtime")
         cls.dylib = cls.add_bool_option("dylib", default=False,
             help="Build dynamic-link LLVM")

--- a/pycheribuild/projects/llvm.py
+++ b/pycheribuild/projects/llvm.py
@@ -75,6 +75,8 @@ class BuildLLVMBase(CMakeProject):
             help="Also build documentation,examples and bindings")
         cls.use_llvm_cxx = cls.add_bool_option("use-tree-cxx", default=False,
             help="Use in-tree, not host, C++ runtime")
+        cls.dylib = cls.add_bool_option("dylib", default=False,
+            help="Build dynamic-link LLVM")
 
     def setup(self):
         super().setup()
@@ -122,6 +124,8 @@ class BuildLLVMBase(CMakeProject):
                 CLANG_DEFAULT_CXX_STDLIB="libc++",
                 CLANG_DEFAULT_RTLIB="compiler-rt",
                 )
+        if self.dylib:
+            self.add_cmake_options(LLVM_LINK_LLVM_DYLIB=True)
         if self.skip_static_analyzer:
             # save some build time by skipping the static analyzer
             self.add_cmake_options(CLANG_ENABLE_STATIC_ANALYZER=False,

--- a/pycheribuild/projects/llvm.py
+++ b/pycheribuild/projects/llvm.py
@@ -73,6 +73,8 @@ class BuildLLVMBase(CMakeProject):
                      "needed by default (e.g. llvm-mca, llvm-pdbutil)")
         cls.build_everything = cls.add_bool_option("build-everything", default=False,
             help="Also build documentation,examples and bindings")
+        cls.use_llvm_cxx = cls.add_bool_option("use-tree-cxx", default=False,
+            help="Use in-tree, not host, C++ runtime")
 
     def setup(self):
         super().setup()
@@ -112,6 +114,13 @@ class BuildLLVMBase(CMakeProject):
                 LLVM_INCLUDE_DOCS=False,
                 # This saves some CMake time since it is used as a sub-project
                 LLVM_INCLUDE_BENCHMARKS=False,
+                )
+        if self.use_llvm_cxx:
+            self.included_projects += ["libcxx", "libcxxabi", "compiler-rt", "libunwind"]
+            self.add_cmake_options(
+                LIBCXXABI_USE_LLVM_UNWINDER=True,
+                CLANG_DEFAULT_CXX_STDLIB="libc++",
+                CLANG_DEFAULT_RTLIB="compiler-rt",
                 )
         if self.skip_static_analyzer:
             # save some build time by skipping the static analyzer


### PR DESCRIPTION
Add libcxx, libcxxabi, compiler-rt, and libunwind to the llvm target.
This avoid the need to use the host equivalents, and works around the
fact that newish GCC's bits/regex.tcc names a variable "__output", which
we take to be a reserved word.