### PR TITLE
Add -DWITH_DTRACE_TEST cmd line option

### DIFF
--- a/pycheribuild/__main__.py
+++ b/pycheribuild/__main__.py
@@ -235,7 +235,8 @@ def real_main():
 def main():
     error = False
     try:
-        os.setpgrp()  # create new process group, become its leader
+        if os.getpgrp() != os.getpid():
+            os.setpgrp()  # create new process group, become its leader
         real_main()
     except KeyboardInterrupt:
         error = True

--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -188,6 +188,7 @@ class BuildFreeBSDBase(Project):
         # tests off by default because they take a long time and often seems to break
         # the creation of disk-image (METALOG is invalid)
         self.make_args.set_with_options(TESTS=self.build_tests)
+        self.make_args.set_with_options(DTRACE_TESTS=self.build_tests)
 
         if not self.config.verbose and not self.config.quiet:
             # By default we only want to print the status updates -> use make -s so we have to do less filtering


### PR DESCRIPTION
in addition to -DWITH_TESTS dtrace also requires -DWITH_DTRACE_TESTS.

Other than this, there are minor fixes to boot_and_login.
The question is: should the boot be stopped when there is a USER_CHERI_EXCEPTION?
if so, then the change in boot_cheribsd/__init__.py should be reverted