### PR TITLE
Remove duplicated RTEMS target infos

### DIFF
--- a/pycheribuild/config/jenkinsconfig.py
+++ b/pycheribuild/config/jenkinsconfig.py
@@ -35,7 +35,7 @@ from pathlib import Path
 from .loader import ConfigLoaderBase
 from .chericonfig import CheriConfig
 from .target_info import CompilationTargets
-from ..utils import defaultNumberOfMakeJobs, fatalError, IS_MAC, IS_LINUX, IS_FREEBSD
+from ..utils import defaultNumberOfMakeJobs, fatalError, IS_MAC, IS_LINUX, IS_FREEBSD, warningMessage
 
 
 def default_install_prefix(conf: "JenkinsConfig", unused):
@@ -145,7 +145,8 @@ class JenkinsConfig(CheriConfig):
             if self.cpu == "hybrid-cheri128":
                 return "cheri128"
             else:
-                fatalError("SDK_CPU variable not set, cannot infer the name of the SDK archive")
+                warningMessage("SDK_CPU variable not set, cannot infer the name of the SDK archive")
+                return "unknown-cpu"
         return sdk_cpu
 
     @property

--- a/pycheribuild/projects/cross/compiler-rt.py
+++ b/pycheribuild/projects/cross/compiler-rt.py
@@ -42,7 +42,7 @@ class BuildCompilerRt(CrossCompileCMakeProject):
     _default_architecture = CompilationTargets.CHERIBSD_MIPS_PURECAP
     supported_architectures = [_default_architecture] + \
                               CompilationTargets.ALL_SUPPORTED_BAREMETAL_TARGETS + \
-                              [CompilationTargets.RTEMS_NEWLIB_RISCV64]
+                              [CompilationTargets.RTEMS_RISCV64_PURECAP]
 
     def __init__(self, config: CheriConfig):
         super().__init__(config)
@@ -96,7 +96,11 @@ class BuildCompilerRtBuiltins(CrossCompileCMakeProject):
     project_name = "compiler-rt-builtins"
     default_install_dir = DefaultInstallDir.COMPILER_RESOURCE_DIR
     _check_install_dir_conflict = False
-    supported_architectures =CompilationTargets.ALL_SUPPORTED_BAREMETAL_TARGETS + [CompilationTargets.RTEMS_NEWLIB_RISCV64]
+    is_sdk_target = True
+    dependencies = ["newlib"]
+    needs_sysroot = False  # We don't need a complete sysroot
+    supported_architectures = CompilationTargets.ALL_SUPPORTED_BAREMETAL_TARGETS + [
+        CompilationTargets.RTEMS_RISCV64_PURECAP]
     _default_architecture = CompilationTargets.BAREMETAL_NEWLIB_MIPS64
 
     def __init__(self, config: CheriConfig):

--- a/pycheribuild/projects/cross/compiler-rt.py
+++ b/pycheribuild/projects/cross/compiler-rt.py
@@ -54,7 +54,7 @@ class BuildCompilerRt(CrossCompileCMakeProject):
             self.add_cmake_options(COMPILER_RT_DEFAULT_TARGET_ARCH=self.target_info.target_triple.split('-')[0])
 
         self.add_cmake_options(
-            LLVM_CONFIG_PATH=BuildCheriLLVM.getInstallDir(self, cross_target=CompilationTargets.NATIVE) / "bin/llvm-config",
+            LLVM_CONFIG_PATH=BuildCheriLLVM.getBuildDir(self, cross_target=CompilationTargets.NATIVE) / "bin/llvm-config",
             LLVM_EXTERNAL_LIT=BuildCheriLLVM.getBuildDir(self, cross_target=CompilationTargets.NATIVE) / "bin/llvm-lit",
             COMPILER_RT_BUILD_BUILTINS=True,
             COMPILER_RT_BUILD_SANITIZERS=True,
@@ -123,7 +123,7 @@ class BuildCompilerRtBuiltins(CrossCompileCMakeProject):
         if self.target_info.is_rtems():
             self.add_cmake_options(CMAKE_TRY_COMPILE_TARGET_TYPE="STATIC_LIBRARY")  # RTEMS only needs static libs
         self.add_cmake_options(
-            LLVM_CONFIG_PATH=BuildCheriLLVM.getInstallDir(self, cross_target=CompilationTargets.NATIVE) / "bin/llvm-config",
+            LLVM_CONFIG_PATH=BuildCheriLLVM.getBuildDir(self, cross_target=CompilationTargets.NATIVE) / "bin/llvm-config",
             LLVM_EXTERNAL_LIT=BuildCheriLLVM.getBuildDir(self, cross_target=CompilationTargets.NATIVE) / "bin/llvm-lit",
             COMPILER_RT_BUILD_BUILTINS=True,
             COMPILER_RT_BUILD_SANITIZERS=False,

--- a/pycheribuild/projects/cross/newlib.py
+++ b/pycheribuild/projects/cross/newlib.py
@@ -65,7 +65,8 @@ class BuildNewlib(CrossCompileAutotoolsProject):
         self._installPrefix = self._installPrefix.parent  # newlib install already appends the triple
         self._installDir = self._installDir.parent  # newlib install already appends the triple
         self.destdir = self._installDir
-        print("after:", self.installDir, "_=", self._installDir, "dest=", self.destdir, "real=", self.real_install_root_dir)
+        self.verbose_print("installDir=", self.installDir, "_installPrefix=", self._installPrefix, "_installDir=",
+            self._installDir, "dest=", self.destdir, "real=", self.real_install_root_dir)
         #self.configureCommand = Path("/this/path/does/not/exist")
         self.configureCommand = self.sourceDir / "configure"
         # FIXME: how can I force it to run a full configure step (this is needed because it runs the newlib configure

--- a/pycheribuild/projects/cross/newlib.py
+++ b/pycheribuild/projects/cross/newlib.py
@@ -64,7 +64,6 @@ class BuildNewlib(CrossCompileAutotoolsProject):
         super().__init__(config)
         self._installPrefix = self._installPrefix.parent  # newlib install already appends the triple
         self._installDir = self._installDir.parent  # newlib install already appends the triple
-        self.destdir = self._installDir
         self.verbose_print("installDir=", self.installDir, "_installPrefix=", self._installPrefix, "_installDir=",
             self._installDir, "dest=", self.destdir, "real=", self.real_install_root_dir)
         #self.configureCommand = Path("/this/path/does/not/exist")

--- a/pycheribuild/projects/cross/newlib.py
+++ b/pycheribuild/projects/cross/newlib.py
@@ -43,6 +43,7 @@ class BuildNewlib(CrossCompileAutotoolsProject):
     target = "newlib"
     project_name = "newlib"
     make_kind = MakeCommandKind.GnuMake
+    is_sdk_target = True
     needs_sysroot = False  # We are building newlib so we don't need a sysroot
     add_host_target_build_config_options = False
     _configure_supports_libdir = False
@@ -51,7 +52,7 @@ class BuildNewlib(CrossCompileAutotoolsProject):
     supported_architectures = [CompilationTargets.BAREMETAL_NEWLIB_MIPS64,
                                CompilationTargets.BAREMETAL_NEWLIB_MIPS64_PURECAP,
                                CompilationTargets.BAREMETAL_NEWLIB_RISCV64,
-                               CompilationTargets.RTEMS_NEWLIB_RISCV64]
+                               CompilationTargets.RTEMS_RISCV64_PURECAP]
     # build_in_source_dir = True  # we have to build in the source directory
 
     @classmethod

--- a/pycheribuild/projects/cross/rtems.py
+++ b/pycheribuild/projects/cross/rtems.py
@@ -76,5 +76,7 @@ class BuildRtems(CrossCompileProject):
         self.run_cmd(self.sourceDir / "waf", "-t", self.sourceDir, "-o", self.buildDir, "install")
 
     def process(self):
-        with setEnv(PATH=str(self.sdk_bindir) + ":" + os.getenv("PATH", "")):
+        with setEnv(PATH=str(self.sdk_bindir) + ":" + os.getenv("PATH", ""),
+                    CFLAGS="--sysroot=" + str(self.sdk_sysroot),
+                    LDFLAGS="--sysroot=" + str(self.sdk_sysroot)):
             super().process()

--- a/pycheribuild/projects/cross/rtems.py
+++ b/pycheribuild/projects/cross/rtems.py
@@ -43,6 +43,9 @@ class BuildRtems(CrossCompileProject):
             })
     target = "rtems"
     project_name = "rtems"
+    dependencies = ["newlib", "compiler-rt-builtins"]
+    is_sdk_target = True
+    needs_sysroot = False  # We don't need a complete sysroot
     supported_architectures = [CompilationTargets.RTEMS_RISCV64_PURECAP]
     default_install_dir = DefaultInstallDir.SYSROOT
 

--- a/pycheribuild/projects/project.py
+++ b/pycheribuild/projects/project.py
@@ -1805,8 +1805,8 @@ class Project(SimpleProject):
                 if self.target_info.is_baremetal():
                     self.destdir = self.sdk_sysroot.parent
                     self._installPrefix = Path("/", self.target_info.target_triple)
-                elif  self.target_info.is_rtems():
-                    self.destdir = self.sdk_sysroot
+                elif self.target_info.is_rtems():
+                    self.destdir = self.sdk_sysroot.parent
                     self._installPrefix = Path("/", self.target_info.target_triple)
                 else:
                     self._installPrefix = Path("/usr/local", self.crosscompile_target.generic_suffix)

--- a/pycheribuild/projects/project.py
+++ b/pycheribuild/projects/project.py
@@ -226,10 +226,11 @@ class SimpleProject(FileSystemUtils, metaclass=ProjectSubclassDefinitionHook):
                     statusUpdate("Not adding ", cls.target, "dependency", dep_target.name,
                                  "since it is an SDK target and --skip-sdk was passed.")
                 continue
-            if not config.include_toolchain_dependencies and dep_target.projectClass.is_toolchain_target():
+            if config.includeDependencies and (
+                    not config.include_toolchain_dependencies and dep_target.projectClass.is_toolchain_target()):
                 if config.verbose:
                     statusUpdate("Not adding ", cls.target, "dependency", dep_target.name,
-                                 "since it is a Toolchain target and --include-toolchain-dependencies was not passed.")
+                                 "since it is a toolchain target and --include-toolchain-dependencies was not passed.")
                 continue
             # Now find the actual crosscompile targets for target aliases:
             if isinstance(dep_target, MultiArchTargetAlias):


### PR DESCRIPTION
This also installs rtems into $SDK/sysroot-rtems-riscv64-purecap.

Seems to work for me, but would be good if you could also check.