### PR TITLE
Don't force to static.

### DIFF
--- a/pycheribuild/projects/cross/nginx.py
+++ b/pycheribuild/projects/cross/nginx.py
@@ -48,8 +48,6 @@ class BuildNginx(CrossCompileAutotoolsProject):
         super().__init__(config)
         self.configureCommand = self.sourceDir / "auto/configure"
         if not self.compiling_for_host():
-            self.LDFLAGS.append("-static")
-            self.COMMON_FLAGS.append("-static")  # adding it to LDFLAGS only doesn't seem to be enough
             self.COMMON_FLAGS.extend(["-pedantic",
                                       "-Wno-gnu-statement-expression",
                                       "-Wno-flexible-array-extensions",  # TODO: could this cause errors?


### PR DESCRIPTION
The default config fails due to dlopen() failing...