### PR TITLE
Avoid unnecessary updates

### DIFF
--- a/pycheribuild/projects/project.py
+++ b/pycheribuild/projects/project.py
@@ -1295,6 +1295,15 @@ class GitRepository(SourceRepository):
                     if current_project.query_yes_no("Update to correct URL?"):
                         runCmd("git", "remote", "set-url", "origin", self.url, runInPretendMode=True, cwd=src_dir)
 
+        # see if we have an upstream
+        head = runCmd("git", "symbolic-ref", "-q", "HEAD",
+                      captureOutput=True, cwd=src_dir, print_verbose_only=True, runInPretendMode=True).stdout.strip().decode("utf-8")
+        upstream_branch = runCmd("git", "for-each-ref", '--format=%(upstream:short)', head, "origin/mainline",
+                                 captureOutput=True, cwd=src_dir, print_verbose_only=True, runInPretendMode=True).stdout.strip().decode("utf-8")
+        if len(upstream_branch) == 0:
+            print(coloured(AnsiColour.blue, "No upstream to update from"))
+            return
+
         # make sure we run git stash if we discover any local changes
         has_changes = len(runCmd("git", "diff", "--stat", "--ignore-submodules",
                                  captureOutput=True, cwd=src_dir, print_verbose_only=True).stdout) > 1

--- a/pycheribuild/projects/project.py
+++ b/pycheribuild/projects/project.py
@@ -1304,6 +1304,18 @@ class GitRepository(SourceRepository):
             print(coloured(AnsiColour.blue, "No upstream to update from"))
             return
 
+	# make sure there's work to do before touching the repo
+        upstream_remote = upstream_branch.split("/", 1)[0]
+        print(coloured(AnsiColour.red, "upstream_remote " + upstream_remote))
+        runCmd("git", "fetch", upstream_remote)
+        head_rev = runCmd("git", "rev-parse", "HEAD",
+                          captureOutput=True, cwd=src_dir, print_verbose_only=True, runInPretendMode=True).stdout.strip().decode("utf-8")
+        upstream_rev = runCmd("git", "rev-parse", upstream_branch,
+                              captureOutput=True, cwd=src_dir, print_verbose_only=True, runInPretendMode=True).stdout.strip().decode("utf-8")
+        if (head_rev == upstream_rev):
+            print(coloured(AnsiColour.blue, "HEAD is up to date with", upstream_branch, "at", upstream_rev[:11]))
+            return
+
         # make sure we run git stash if we discover any local changes
         has_changes = len(runCmd("git", "diff", "--stat", "--ignore-submodules",
                                  captureOutput=True, cwd=src_dir, print_verbose_only=True).stdout) > 1

--- a/pycheribuild/projects/project.py
+++ b/pycheribuild/projects/project.py
@@ -1280,6 +1280,8 @@ class GitRepository(SourceRepository):
                            skip_submodules=skip_submodules)
         if current_project.skipUpdate:
             return
+        if not src_dir.exists():
+            return
 
         # handle repositories that have moved
         if src_dir.exists() and self.old_urls:


### PR DESCRIPTION
Don't perform any updates if the current branch doesn't have an upstream.  Also, avoid an attempt to update if our current revision is equal to that of the upstream branch.  Most usefully, that avoids a prompt to stash outstanding changes and update when there is no work to do.