### PR TITLE
Add a couple FETT build targets

### DIFF
--- a/pycheribuild/projects/cross/nginx.py
+++ b/pycheribuild/projects/cross/nginx.py
@@ -107,3 +107,9 @@ class BuildNginx(CrossCompileAutotoolsProject):
     def compile(self, **kwargs):
         # The cwd for make needs to be the source dir and it expects an empty target name
         self.run_make(cwd=self.sourceDir)
+
+class BuildFettNginx(BuildNginx):
+    target = "fett-nginx"
+    project_name = "fett-nginx"
+    repository = GitRepository("https://github.com/CTSRD-CHERI/nginx.git",
+        default_branch="fett")

--- a/pycheribuild/projects/cross/sqlite.py
+++ b/pycheribuild/projects/cross/sqlite.py
@@ -71,3 +71,13 @@ class BuildSQLite(CrossCompileAutotoolsProject):
     def needsConfigure(self):
         return not (self.buildDir / "Makefile").exists()
 
+
+class BuildFettSQLite(BuildSQLite):
+    target = "fett-sqlite"
+    project_name = "fett-sqlite"
+    repository = GitRepository("https://github.com/CTSRD-CHERI/sqlite.git",
+                               default_branch="fett")
+
+    def __init__(self, config: CheriConfig):
+        super().__init__(config)
+        self.configureArgs.extend(["--enable-fts3"])


### PR DESCRIPTION
Currently these are barely modified from the existing targets.  nginx needs to use the vulnerable openssl once we've created a target.