### PR TITLE
compiler-rt: Use self.sed_bindir to set LLVM_CONFIG_PATH

### DIFF
--- a/pycheribuild/config/target_info.py
+++ b/pycheribuild/config/target_info.py
@@ -714,10 +714,13 @@ class NewlibBaremetalTargetInfo(_ClangBasedTargetInfo):
 
     def required_compile_flags(self) -> typing.List[str]:
         # Currently we need these flags to build anything against newlib baremetal
-        return [
-            "-D_GNU_SOURCE=1" if self.target.is_mips(include_purecap=True) else "",  # needed for the locale functions
-            "-D_POSIX_TIMERS=1", "-D_POSIX_MONOTONIC_CLOCK=1",  # pretend that we have a monotonic clock
-            ]
+        if self.target.is_mips(include_purecap=True):
+            return [
+                "-D_GNU_SOURCE=1",  # needed for the locale functions
+                "-D_POSIX_TIMERS=1", "-D_POSIX_MONOTONIC_CLOCK=1",  # pretend that we have a monotonic clock
+                ]
+        else:
+            return []
 
     @property
     def additional_executable_link_flags(self):

--- a/pycheribuild/projects/cross/compiler-rt.py
+++ b/pycheribuild/projects/cross/compiler-rt.py
@@ -32,6 +32,7 @@ from .crosscompileproject import *
 from ..llvm import BuildCheriLLVM
 from ..project import ReuseOtherProjectDefaultTargetRepository
 from ...utils import classproperty
+from ...utils import setEnv, commandline_to_str, is_jenkins_build
 
 
 class BuildCompilerRt(CrossCompileCMakeProject):
@@ -53,8 +54,10 @@ class BuildCompilerRt(CrossCompileCMakeProject):
             self.add_cmake_options(COMPILER_RT_DEFAULT_TARGET_ARCH=self.target_info.target_triple.split('-')[0])
 
         self.add_cmake_options(
-            LLVM_CONFIG_PATH=BuildCheriLLVM.getBuildDir(self, cross_target=CompilationTargets.NATIVE) / "bin/llvm-config",
-            LLVM_EXTERNAL_LIT=BuildCheriLLVM.getBuildDir(self, cross_target=CompilationTargets.NATIVE) / "bin/llvm-lit",
+            LLVM_CONFIG_PATH=self.sdk_bindir / "llvm-config" if is_jenkins_build() and not self.compiling_for_host() else
+              BuildCheriLLVM.getBuildDir(self, cross_target=CompilationTargets.NATIVE) / "bin/llvm-config",
+            LLVM_EXTERNAL_LIT=self.sdk_bindir/ "llvm-lit" if is_jenkins_build() and not self.compiling_for_host() else
+              BuildCheriLLVM.getBuildDir(self, cross_target=CompilationTargets.NATIVE) / "bin/llvm-lit",
             COMPILER_RT_BUILD_BUILTINS=True,
             COMPILER_RT_BUILD_SANITIZERS=True,
             COMPILER_RT_BUILD_XRAY=False,
@@ -122,8 +125,10 @@ class BuildCompilerRtBuiltins(CrossCompileCMakeProject):
         if self.target_info.is_rtems():
             self.add_cmake_options(CMAKE_TRY_COMPILE_TARGET_TYPE="STATIC_LIBRARY")  # RTEMS only needs static libs
         self.add_cmake_options(
-            LLVM_CONFIG_PATH=BuildCheriLLVM.getBuildDir(self, cross_target=CompilationTargets.NATIVE) / "bin/llvm-config",
-            LLVM_EXTERNAL_LIT=BuildCheriLLVM.getBuildDir(self, cross_target=CompilationTargets.NATIVE) / "bin/llvm-lit",
+            LLVM_CONFIG_PATH=self.sdk_bindir / "llvm-config" if is_jenkins_build() and not self.compiling_for_host() else
+              BuildCheriLLVM.getBuildDir(self, cross_target=CompilationTargets.NATIVE) / "bin/llvm-config",
+            LLVM_EXTERNAL_LIT=self.sdk_bindir/ "llvm-lit" if is_jenkins_build() and not self.compiling_for_host() else
+              BuildCheriLLVM.getBuildDir(self, cross_target=CompilationTargets.NATIVE) / "bin/llvm-lit",
             COMPILER_RT_BUILD_BUILTINS=True,
             COMPILER_RT_BUILD_SANITIZERS=False,
             COMPILER_RT_BUILD_XRAY=False,

--- a/pycheribuild/projects/cross/compiler-rt.py
+++ b/pycheribuild/projects/cross/compiler-rt.py
@@ -48,7 +48,7 @@ class BuildCompilerRt(CrossCompileCMakeProject):
     def __init__(self, config: CheriConfig):
         super().__init__(config)
 
-        if self.target_info.is_rtems():
+        if self.target_info.is_rtems() or self.target_info.is_baremetal():
             self.add_cmake_options(CMAKE_TRY_COMPILE_TARGET_TYPE="STATIC_LIBRARY") # RTEMS only needs static libs
             # Get default target (arch) from the triple
             self.add_cmake_options(COMPILER_RT_DEFAULT_TARGET_ARCH=self.target_info.target_triple.split('-')[0])
@@ -122,8 +122,9 @@ class BuildCompilerRtBuiltins(CrossCompileCMakeProject):
         if self.compiling_for_mips(include_purecap=False):
             self.add_cmake_options(COMPILER_RT_HAS_FPIC_FLAG=False)  # HACK: currently we build everything as -fno-pic
 
-        if self.target_info.is_rtems():
+        if self.target_info.is_rtems() or self.target_info.is_baremetal():
             self.add_cmake_options(CMAKE_TRY_COMPILE_TARGET_TYPE="STATIC_LIBRARY")  # RTEMS only needs static libs
+
         self.add_cmake_options(
             LLVM_CONFIG_PATH=self.sdk_bindir / "llvm-config" if is_jenkins_build() and not self.compiling_for_host() else
               BuildCheriLLVM.getBuildDir(self, cross_target=CompilationTargets.NATIVE) / "bin/llvm-config",


### PR DESCRIPTION
Otherwise it fails to find it in the build dir with this error:

llvm-config failed with status No such file or directory