### PR TITLE
Add options to use the local FPGA build environment.

### DIFF
--- a/pycheribuild/config/chericonfig.py
+++ b/pycheribuild/config/chericonfig.py
@@ -289,6 +289,9 @@ class CheriConfig(object):
             help="Perform a shallow `git clone` when cloning new projects. This can save a lot of time for large"
             "repositories such as FreeBSD or LLVM. Use `git fetch --unshallow` to convert to a non-shallow clone")
 
+        self.fpga_custom_env_setup_script = loader.add_path_option("beri-fpga-env-setup-script",
+            help="Custom script to source to setup PATH and quartus, default to using cheri-cpu/cheri/setup.sh")
+
         self.targets = None  # type: typing.Optional[typing.List[str]]
         self.FS = None  # type: Optional[FileSystemUtils]
         self.__optionalProperties = ["preferred_xtarget"]

--- a/pycheribuild/projects/build_qemu.py
+++ b/pycheribuild/projects/build_qemu.py
@@ -181,6 +181,7 @@ class BuildQEMUBase(AutotoolsProject):
 
         self.configureArgs.extend([
             "--target-list=" + self.qemu_targets,
+            "--enable-slirp=git",
             "--disable-linux-user",
             "--disable-bsd-user",
             "--disable-xen",

--- a/pycheribuild/projects/project.py
+++ b/pycheribuild/projects/project.py
@@ -2661,7 +2661,7 @@ class CMakeProject(Project):
     # cheri libraries are found in /usr/libcheri:
     if("${CMAKE_VERSION}" VERSION_LESS 3.9)
       # message(STATUS "CMAKE < 3.9 HACK to find libcheri libraries")
-      # need to create a <sysroot>/usr/lib/cheri -> <sysroot>/usr/libcheri symlink 
+      # need to create a <sysroot>/usr/lib/cheri -> <sysroot>/usr/libcheri symlink
       set(CMAKE_LIBRARY_ARCHITECTURE "cheri")
       set(CMAKE_SYSTEM_LIBRARY_PATH "${CMAKE_FIND_ROOT_PATH}/usr/libcheri;${CMAKE_FIND_ROOT_PATH}/usr/local/cheri/lib;${CMAKE_FIND_ROOT_PATH}/usr/local/cheri/libcheri")
     else()

--- a/pycheribuild/projects/run_fpga.py
+++ b/pycheribuild/projects/run_fpga.py
@@ -78,13 +78,18 @@ class LaunchFPGABase(SimpleProject):
             subcmd_and_args = ["console"]
         else:
             subcmd_and_args = ["bootonly", *bootonly_args]
+        if self.config.fpga_custom_env_setup_script:
+            env_setup_script = self.config.fpga_custom_env_setup_script
+        else:
+            env_setup_script = "{cheri_dir}/setup.sh".format(cheri_dir=cheri_dir)
+
         beri_fpga_bsd_boot_script = """
 set +x
-source "{cheri_dir}/setup.sh"
+source "{env_setup_script}"
 set -x
 export PATH="$PATH:{cherilibs_dir}/tools:{cherilibs_dir}/tools/debug"
 exec {cheribuild_path}/beri-fpga-bsd-boot.py {basic_args} -vvvvv {subcmd_and_args}
-            """.format(cheri_dir=cheri_dir, cherilibs_dir=cherilibs_dir, basic_args=commandline_to_str(basic_args),
+            """.format(env_setup_script=env_setup_script, cherilibs_dir=cherilibs_dir, basic_args=commandline_to_str(basic_args),
                        subcmd_and_args=commandline_to_str(subcmd_and_args), cheribuild_path=cheribuild_path)
         self.runShellScript(beri_fpga_bsd_boot_script, shell="bash")  # the setup script needs bash not sh
 


### PR DESCRIPTION
This makes it easier to setup a dev environment outside the CL, with a local quartus install.
- Add option to use a custom environment setup script instead of the cheri-cpu ones. This is useful if   you are not running within the CL NFS or have different NFS mount-points.
- Always build the qemu SLIRP from git as it may complain when looking for the system one. 
