### PR TITLE
point CMAKE_PREFIX_PATH to Find[PROJECT].cmake files

### DIFF
--- a/pycheribuild/config/target_info.py
+++ b/pycheribuild/config/target_info.py
@@ -496,7 +496,7 @@ class FreeBSDTargetInfo(_ClangBasedTargetInfo):
 
     @property
     def cmake_prefix_paths(self) -> list:
-        return [self.local_install_root]
+        return [self.local_install_root, self.local_install_root / "libcheri/cmake"]
 
     def get_rootfs_target(self) -> "Project":
         from ..projects.cross.cheribsd import BuildFreeBSD


### PR DESCRIPTION
Function to populate `CMAKE_PREFIX_PATH` in `CrossToolchain.cmake` should include the subdirectory `libcheri/cmake` for `find_packages()` to find the right `Find[Project].cmake` file.