### PR TITLE
Add pdksh target

### DIFF
--- a/pycheribuild/projects/cross/ksh.py
+++ b/pycheribuild/projects/cross/ksh.py
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2020 Nicolo' Mazzucato
+# All rights reserved.
+#
+# This software was developed by SRI International and the University of
+# Cambridge Computer Laboratory under DARPA/AFRL contract FA8750-10-C-0237
+# ("CTSRD"), as part of the DARPA CRASH research programme.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+
+from .crosscompileproject import CrossCompileAutotoolsProject
+from ..project import *
+
+
+class BuildKsh(CrossCompileAutotoolsProject):
+    repository = GitRepository("git@github.com:tomgrean/pdksh.git")
+    native_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
+    cross_install_dir = DefaultInstallDir.SYSROOT

--- a/pycheribuild/projects/cross/ksh.py
+++ b/pycheribuild/projects/cross/ksh.py
@@ -36,3 +36,10 @@ class BuildKsh(CrossCompileAutotoolsProject):
     repository = GitRepository("git@github.com:tomgrean/pdksh.git")
     native_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
     cross_install_dir = DefaultInstallDir.SYSROOT
+    _configure_supports_variables_on_cmdline = False
+
+    def setup(self):
+        super().setup()
+        self.cross_warning_flags.append("-Wno-error=format-security")
+        self.cross_warning_flags.append("-Wno-error=string-plus-int")
+        self.cross_warning_flags.append("-Wno-error=format-conversion")


### PR DESCRIPTION
It doesn't work already.
It fails with 
```
configure: error: can only configure for one host and one target at a time
Fatal error: Command `/home/nm712/cheri/ksh/configure --host=mips64-unknown-freebsd13 --target=mips64-unknown-freebsd13 --build=x86_64-portbld-freebsd12.1 --disable-static --enable-shared --libdir=/usr/local/mips-purecap/libcheri 'CC=/home/nm712/cheri/output/sdk/bin/clang -target mips64-unknown-freebsd13 -pipe --sysroot=/home/nm712/cheri/output/sdk/sysroot128 -B/home/nm712/cheri/output/sdk/bin -integrated-as -G0 -msoft-float -stdlib=libc++ -mcpu=beri -mabi=purecap -mcpu=beri -cheri=128 -cheri-cap-table-abi=pcrel -Wno-unused-command-line-argument -Wall -Werror=cheri-capability-misuse -Werror=implicit-function-declaration -Werror=format -Werror=undefined-internal -Werror=incompatible-pointer-types -Werror=cheri-prototypes -Werror=cheri-bitwise-operations -Werror=pass-failed' 'CXX=/home/nm712/cheri/output/sdk/bin/clang++ -target mips64-unknown-freebsd13 -pipe --sysroot=/home/nm712/cheri/output/sdk/sysroot128 -B/home/nm712/cheri/output/sdk/bin -integrated-as -G0 -msoft-float -stdlib=libc++ -mcpu=beri -mabi=purecap -mcpu=beri -cheri=128 -cheri-cap-table-abi=pcrel -Wno-unused-command-line-argument -Wall -Werror=cheri-capability-misuse -Werror=implicit-function-declaration -Werror=format -Werror=undefined-internal -Werror=incompatible-pointer-types -Werror=cheri-prototypes -Werror=cheri-bitwise-operations -Werror=pass-failed' 'CFLAGS=-target mips64-unknown-freebsd13 -pipe --sysroot=/home/nm712/cheri/output/sdk/sysroot128 -B/home/nm712/cheri/output/sdk/bin -integrated-as -G0 -msoft-float -stdlib=libc++ -mcpu=beri -mabi=purecap -mcpu=beri -cheri=128 -cheri-cap-table-abi=pcrel -Wno-unused-command-line-argument -Wall -Werror=cheri-capability-misuse -Werror=implicit-function-declaration -Werror=format -Werror=undefined-internal -Werror=incompatible-pointer-types -Werror=cheri-prototypes -Werror=cheri-bitwise-operations -Werror=pass-failed' 'CXXFLAGS=-target mips64-unknown-freebsd13 -pipe --sysroot=/home/nm712/cheri/output/sdk/sysroot128 -B/home/nm712/cheri/output/sdk/bin -integrated-as -G0 -msoft-float -stdlib=libc++ -mcpu=beri -mabi=purecap -mcpu=beri -cheri=128 -cheri-cap-table-abi=pcrel -Wno-unused-command-line-argument -Wall -Werror=cheri-capability-misuse -Werror=implicit-function-declaration -Werror=format -Werror=undefined-internal -Werror=incompatible-pointer-types -Werror=cheri-prototypes -Werror=cheri-bitwise-operations -Werror=pass-failed' 'LDFLAGS=-target mips64-unknown-freebsd13 -pipe --sysroot=/home/nm712/cheri/output/sdk/sysroot128 -B/home/nm712/cheri/output/sdk/bin -integrated-as -G0 -msoft-float -stdlib=libc++ -mcpu=beri -mabi=purecap -mcpu=beri -cheri=128 -cheri-cap-table-abi=pcrel -fuse-ld=/home/nm712/cheri/output/sdk/bin/ld.lld' 'CPP=/home/nm712/cheri/output/sdk/bin/clang-cpp -target mips64-unknown-freebsd13 -pipe --sysroot=/home/nm712/cheri/output/sdk/sysroot128 -B/home/nm712/cheri/output/sdk/bin -integrated-as -G0 -msoft-float -stdlib=libc++ -mcpu=beri -mabi=purecap -mcpu=beri -cheri=128 -cheri-cap-table-abi=pcrel -Wno-unused-command-line-argument -Wall -Werror=cheri-capability-misuse -Werror=implicit-function-declaration -Werror=format -Werror=undefined-internal -Werror=incompatible-pointer-types -Werror=cheri-prototypes -Werror=cheri-bitwise-operations -Werror=pass-failed' LD=/home/nm712/cheri/output/sdk/bin/ld.lld --prefix=/usr/local/mips-purecap` failed with non-zero exit code 1
```

[here](https://github.com/tomgrean/pdksh/blob/master/configure#L448) in configure. Any Idea?