### PR TITLE
cherios vs. run_qemu: override qemu binary in setup()

### DIFF
--- a/pycheribuild/projects/run_qemu.py
+++ b/pycheribuild/projects/run_qemu.py
@@ -494,7 +494,6 @@ class LaunchCheriOSQEMU(LaunchQEMUBase):
         # FIXME: these should be config options
         cherios = BuildCheriOS.get_instance(self, config)
         self.currentKernel = BuildCheriOS.getBuildDir(self) / "boot/cherios.elf"
-        self.qemuBinary = BuildCheriOSQEMU.qemu_binary(self)
         self.disk_image = self.config.outputRoot / "cherios-disk.img"
         self._projectSpecificOptions = ["-no-reboot"]
 
@@ -510,6 +509,10 @@ class LaunchCheriOSQEMU(LaunchQEMUBase):
 
         self.qemu_options.virtio_disk = True  # CheriOS needs virtio
         self._qemuUserNetworking = False
+
+    def setup(self):
+        super().setup()
+        self.qemuBinary = BuildCheriOSQEMU.qemu_binary(self)
 
     def process(self):
         if not self.disk_image.exists():


### PR DESCRIPTION
Otherwise we go to great lenghts to compute the correct path in
LaunchCheriOSQEMU.__init__ only to clobber it in LaunchQEMUBase.setup().