### PR TITLE
Allow forcing clean build using a .require_clean_build in the git repo

### DIFF
--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -1148,7 +1148,6 @@ class BuildCHERIBSD(BuildFreeBSD):
     crossbuild = True  # changes have been merged into master
     use_llvm_binutils = True
     has_installsysroot_target = True
-    full_rebuild_if_older_than = datetime.datetime(2020, 5, 11, 20, 0, tzinfo=datetime.timezone.utc)
 
     @property
     def build_dir_suffix(self):


### PR DESCRIPTION
This file is parsed by cheribuild to determine whether a clean build is
required. It will read the last non-empty, non-comment line as an integer and
compare that to the value read from this file at the last time.
The previous logic using timestamps was fragile and did not consider git
branches. Reading a file that is committed to the repository fixes this
issue:

I will commit the following file to CheriBSD once this change has landed:

```
# Add a new line containing a larger number than the last (e.g. YYYYMMDD) for
# every change that breaks ABI or requires a full rebuild for some other reason.
# Only the last entry is required, but having the full list may be useful for
# looking at frequency of ABI breakage, etc.

# Building all programs hybrid
# https://github.com/CTSRD-CHERI/cheribsd/commit/cc876df741e840569cc3032f2536fe8abbe39030
20200526
```