### PR TITLE
run_qemu: look for "ss" on Linux when reporting port usage

### DIFF
--- a/pycheribuild/projects/run_qemu.py
+++ b/pycheribuild/projects/run_qemu.py
@@ -329,9 +329,16 @@ class LaunchQEMUBase(SimpleProject):
         if OSInfo.IS_FREEBSD:
             self.run_cmd("sockstat", "-P", "tcp", "-p", str(port))
         elif OSInfo.IS_LINUX:
-            self.run_cmd("sh", "-c", "netstat -tulpne | grep \":" + str(port) + "\"")
+            if shutil.which("ss"):
+              self.run_cmd("sh", "-c", "ss -tulpne | grep \":" + str(port) + "\"")
+            elif shutil.which("netstat"):
+              self.run_cmd("sh", "-c", "netstat -tulpne | grep \":" + str(port) + "\"")
+            else:
+              self.info(coloured(AnsiColour.yellow, "Missing ss and netstat; unable to report port usage"))
         elif OSInfo.IS_MAC:
             self.run_cmd("lsof", "-nP", "-iTCP:" + str(port))
+        else:
+            self.info(coloured(AnsiColour.yellow, "Don't know how to report port usage on this OS"))
 
     @staticmethod
     def is_port_available(port: int):


### PR DESCRIPTION
And report when we can't find either "ss" or "netstat" on Linux, and
report (rather than silently saying nothing) if we're on an unknown
platform.

@anaaktge reported some rather ugly spew from a system lacking `netstat`:

```
sh -c 'netstat -tulpne | grep ":10005"'
sh: 1: netstat: not found
Fatal error: Command `sh -c 'netstat -tulpne | grep ":10005"'` failed with non-zero exit code 1. Working directory was /home/a
```

As `ss` is the new hotness on Linux (part of the `iproute2` suite), hopefully this clears that up.