### PR TITLE
CheriBSD: Disable GOOGLETEST by default

### DIFF
--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -339,6 +339,10 @@ class BuildFreeBSD(BuildFreeBSDBase):
             default=True)
         cls.with_manpages = cls.add_bool_option("with-manpages", help="Also install manpages. This is off by default"
                                                                       " since they can just be read from the host.")
+        cls.with_googletest = cls.add_bool_option("build-googletest", default=False,
+                                                  help="Build the googletest test framework. This is off by default "
+                                                       "since it is currently barely used and takes many minutes to "
+                                                       "compile with an assertions-enabled LLVM.")
         cls.fast_rebuild = cls.add_bool_option("fast",
             help="Skip some (usually) unnecessary build steps to speed up rebuilds")
 
@@ -417,7 +421,7 @@ class BuildFreeBSD(BuildFreeBSDBase):
             self.make_args.set_with_options(MAN=self.with_manpages)
             # GOOGLETEST takes many minutes to compile and link with an assertions-enabled clang
             # Since the only user of GOOGLETEST is capsicum-test, disable it by default.
-            self.make_args.set_with_options(GOOGLETEST=False)
+            self.make_args.set_with_options(GOOGLETEST=self.with_googletest)
             # we want to build makefs for the disk image (makefs depends on libnetbsd which will not be
             # bootstrapped on FreeBSD)
             # TODO: upstream a patch to bootstrap them by default

--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -415,6 +415,9 @@ class BuildFreeBSD(BuildFreeBSDBase):
             self.make_args.set_with_options(DEBUG_FILES=False)
             # Don't build manpages by default
             self.make_args.set_with_options(MAN=self.with_manpages)
+            # GOOGLETEST takes many minutes to compile and link with an assertions-enabled clang
+            # Since the only user of GOOGLETEST is capsicum-test, disable it by default.
+            self.make_args.set_with_options(GOOGLETEST=False)
             # we want to build makefs for the disk image (makefs depends on libnetbsd which will not be
             # bootstrapped on FreeBSD)
             # TODO: upstream a patch to bootstrap them by default


### PR DESCRIPTION
GOOGLETEST takes many minutes to compile and link with an
assertions-enabled clang (some of the tests take 30 seconds to compile and
about 6 minutes to link). Since the only user of GOOGLETEST in CheriBSD is
capsicum-test, disable it by default.

It's marked as BROKEN_OPTIONS on MIPS so we weren't building it at all until
https://github.com/CTSRD-CHERI/cheribsd/pull/544 enabled C++ support for RISC-V.