### PR TITLE
Don't force shell scripts to be interactive

### DIFF
--- a/pycheribuild/projects/project.py
+++ b/pycheribuild/projects/project.py
@@ -815,9 +815,9 @@ class SimpleProject(FileSystemUtils, metaclass=ProjectSubclassDefinitionHook):
         print_args = dict(**kwargs)
         if "capture_output" in print_args:
             del print_args["capture_output"]
-        print_command(shell, "-xe" if self.config.verbose else "-e", "-i", "-c", script, **print_args)
+        print_command(shell, "-xe" if self.config.verbose else "-e", "-c", script, **print_args)
         kwargs["no_print"] = True
-        return runCmd(shell, "-xe" if self.config.verbose else "-e", "-i", "-c", script, **kwargs)
+        return runCmd(shell, "-xe" if self.config.verbose else "-e", "-c", script, **kwargs)
 
     def print(self, *args, **kwargs):
         if not self.config.quiet:


### PR DESCRIPTION
bash in particular does some truly egregiously strange things involving
"kill(0, SIGTTIN);" in `jobs.c:/^initialize_job_control` (shortly after
compensating for bugs arising from NeXT and Alliant systems...).

In any case, this logic interacts poorly with itself across time: if
multiple interactive shells run sequentially on the same tty, the first
one will successfully declare its PID the foreground process group for
its tty, but the second one will see that the earlier (now dead) task as
the foreground process group and will resist installing itself.

We can verify that this is what's going on with something like

     sh <<HERE
     ps -o pid,pgid,tty,tpgid,cmd \$\$
     bash -i -c "ps -o pid,pgid,tty,tpgid,cmd \\$\\$"
     bash -c "ps -o pid,pgid,tty,tpgid,cmd \$\$ \\$\\$"
     HERE

which produces something like

       PID   PGID TT        TPGID CMD
     18159  18159 pts/41    18159 sh
       PID   PGID TT        TPGID CMD
     18161  18161 pts/41    18161 ps -o pid,pgid,tty,tpgid,cmd 18161
       PID   PGID TT        TPGID CMD
     18159  18159 pts/41    18161 sh
     18163  18159 pts/41    18161 ps -o pid,pgid,tty,tpgid,cmd 18159 18163

We see that the `sh` controlling all of this now has the (exited!) `ps`
task as its terminal foreground process and does not reclaim or update
this value before spawning the second `bash` task (as it is inherited by
the second `ps`).  And indeed, making that second `bash` interactive
with `-i` results in the dreaded

       PID   PGID TT        TPGID CMD
     18498  18498 pts/41    18498 sh
       PID   PGID TT        TPGID CMD
     18500  18500 pts/41    18500 ps -o pid,pgid,tty,tpgid,cmd 18500
    zsh: suspended (tty input)  sh <<<""