### PR TITLE
Changes for sail-from-source

### DIFF
--- a/pycheribuild/projects/sail.py
+++ b/pycheribuild/projects/sail.py
@@ -446,11 +446,12 @@ class BuildSailFromSource(OcamlProject):
                                   install_instructions="Try running `opam install menhir`")
 
     def compile(self, **kwargs):
-        self.run_in_ocaml_env("""
-make
-make -C mips mips mips_c
-make -C cheri cheri cheri_c
-make -C cheri cheri128 cheri128_c""")
+        pass
+
+    def install(self, **kwargs):
+        # Use ./opam to just build sail, not coq-sail.  Using '.' will try to
+        # build both and we probably don't need all of coq installed just now
+        self.run_in_ocaml_env("opam install -y ./opam")
 
     def process(self):
         lemdir = BuildLem.get_source_dir(self)

--- a/pycheribuild/projects/sail.py
+++ b/pycheribuild/projects/sail.py
@@ -403,7 +403,7 @@ class OcamlProject(OpamMixin, Project):
             try:
                 self.run_in_ocaml_env("ocamlfind query " + shlex.quote(pkg), cwd="/", print_verbose_only=True)
             except CalledProcessError:
-                instrs = "Try running `" + self._opam_cmd_str("install", _add_switch=False) + pkg + "`"
+                instrs = "Try running `" + self._opam_cmd_str("install", _add_switch=False) + " " + pkg + "`"
                 self.dependency_error("missing opam package " + pkg, install_instructions=instrs)
 
     def install(self, **kwargs):
@@ -467,18 +467,21 @@ class BuildLem(OcamlProject):
     needed_ocaml_packages = OcamlProject.needed_ocaml_packages + ["zarith"]
 
     def compile(self, **kwargs):
-        # Note: this all breaks on MacOS if ocamlfind is installed via opam
-        self.run_in_ocaml_env("make && make -C ocaml-lib local-install")
+        pass
 
     def install(self, **kwargs):
-        pass
+        self.run_in_ocaml_env("opam install -y .")
 
 
 class BuildOtt(OcamlProject):
     repository = GitRepository("https://github.com/ott-lang/ott")
 
     def compile(self, **kwargs):
-        self.run_in_ocaml_env("make")
+        pass
+
+    def install(self, **kwargs):
+        # Use ./ott.opam to dodge coq-ott
+        self.run_in_ocaml_env("opam install -y ./ott.opam")
 
 
 class BuildLinksem(OcamlProject):
@@ -486,10 +489,10 @@ class BuildLinksem(OcamlProject):
     dependencies = ["lem", "ott"]
 
     def compile(self, **kwargs):
-        self.run_in_ocaml_env("""
-make USE_OCAMLBUILD=false
-make -C src USE_OCAMLBUILD=false local-install
-        """)
+        pass
+
+    def install(self, **kwargs):
+        self.run_in_ocaml_env("opam install -y .")
 
     def process(self):
         lemdir = BuildLem.get_source_dir(self)


### PR DESCRIPTION
I still have to do a little bit of a dance to make it work, but it's much less exciting with these deltas in place.  Sail ends up installed as if via opam (i.e., in the opamroot, in the versioned switch that cheribuild creates).

```
git clone ... ott
git clone ... lem
git clone ... linksem
git clone ... sail
ln -s sail sailfromsource

# This will fail, but it will create and switch to the opam switch
./cheribuild/cheribuild.py sail-from-source

# Manually install ocamlbuild, ignoring its presence on the host machine
CHECK_IF_PREINSTALLED=false /usr/bin/opam install --root=/cheri/out/mainline/sdk/opamroot ocamlbuild

# Install the rest of the transitive dependencies; maybe not all of this is necessary, but certainly some of it is.
/usr/bin/opam install --root=/cheri/out/mainline/sdk/opamroot zarith menhir num base64 pprint yojson omd

# And now for real; hold cheribuild's hand a little through the dependency chain.
./cheribuild/cheribuild.py ott
./cheribuild/cheribuild.py lem
./cheribuild/cheribuild.py linksem
./cheribuild/cheribuild.py sail-from-source
```

* Most of that dance would go away if cheribuild knew a little more about dependency resolution (both its own and opam's).

* The need to checkout first is because the `cd $DIR && opam switch` game will fail if $DIR doesn't exist, but cheribuild won't understand that and will try to rebuild the switch.

* I don't understand the need for the `sailfromsource` directory.

* The need for `CHECK_IF_PREINSTALLED=false` for `ocamlbuild` is upstream's fault and really grinds my gears.