### PR TITLE
Don't force a default cap table ABI.

### DIFF
--- a/pycheribuild/config/chericonfig.py
+++ b/pycheribuild/config/chericonfig.py
@@ -406,12 +406,6 @@ class CheriConfig(object):
         if "CLICOLOR" in os.environ:
             del os.environ["CLICOLOR"]
 
-    def _initialize_derived_paths(self):
-        # Set CHERI_BITS variable to allow e.g. { cheribsd": { "install-directory": "~/rootfs${CHERI_BITS}" } }
-        os.environ["CHERI_BITS"] = self.mips_cheri_bits_str
-        if self.cheri_cap_table_abi:
-            os.environ["CHERI_CAPTABLE_ABI"] = self.cheri_cap_table_abi
-
     @property
     def dollar_path_with_other_tools(self) -> str:
         return str(self.other_tools_dir / "bin") + ":" + os.getenv("PATH")

--- a/pycheribuild/config/chericonfig.py
+++ b/pycheribuild/config/chericonfig.py
@@ -158,8 +158,8 @@ class CheriConfig(object):
             "libcompat-buildenv", "-libcheri-buildenv", group=loader.freebsd_group,
             help="Open a shell with the right environment for building compat libraries.")
 
-        self.cheri_cap_table_abi = loader.add_option("cap-table-abi", help_hidden=True, default="pcrel",
-                                                     choices=("pcrel", "plt", "legacy", "fn-desc"),
+        self.cheri_cap_table_abi = loader.add_option("cap-table-abi", help_hidden=True,
+                                                     choices=("pcrel", "plt", "fn-desc"),
                                                      help="The ABI to use for cap-table mode")
         self.cross_target_suffix = loader.add_option("cross-target-suffix", help_hidden=True, default="",
                                                      help="Add a suffix to the cross build and install directories. "
@@ -409,7 +409,8 @@ class CheriConfig(object):
     def _initialize_derived_paths(self):
         # Set CHERI_BITS variable to allow e.g. { cheribsd": { "install-directory": "~/rootfs${CHERI_BITS}" } }
         os.environ["CHERI_BITS"] = self.mips_cheri_bits_str
-        os.environ["CHERI_CAPTABLE_ABI"] = self.cheri_cap_table_abi
+        if self.cheri_cap_table_abi:
+            os.environ["CHERI_CAPTABLE_ABI"] = self.cheri_cap_table_abi
 
     @property
     def dollar_path_with_other_tools(self) -> str:

--- a/pycheribuild/config/defaultconfig.py
+++ b/pycheribuild/config/defaultconfig.py
@@ -132,6 +132,5 @@ class DefaultCheriConfig(CheriConfig):
         self.cheri_sdk_dir = self.tools_root / self.cheri_sdk_directory_name  # qemu and binutils (and llvm/clang)
         self.other_tools_dir = self.tools_root / "bootstrap"
         self.cheribsd_image_root = self.output_root  # TODO: allow this to be different?
-        self._initialize_derived_paths()
 
         assert self._ensure_required_properties_set()

--- a/pycheribuild/config/jenkinsconfig.py
+++ b/pycheribuild/config/jenkinsconfig.py
@@ -176,9 +176,9 @@ class JenkinsConfig(CheriConfig):
 
     @property
     def cheri_sdk_isa_name(self):
-        guessed_abi_suffix = "cap-table-" + self.cheri_cap_table_abi
-        if self.cheri_cap_table_abi == "legacy":
-            guessed_abi_suffix = "legacy"
+        guessed_abi_suffix = ""
+        if self.cheri_cap_table_abi:
+            guessed_abi_suffix = "cap-table-" + self.cheri_cap_table_abi
         return os.getenv("ISA", guessed_abi_suffix)
 
     @property

--- a/pycheribuild/config/jenkinsconfig.py
+++ b/pycheribuild/config/jenkinsconfig.py
@@ -272,8 +272,6 @@ class JenkinsConfig(CheriConfig):
         if self.cheri_sdk_path is not None:
             assert self.cheri_sdk_bindir == self.cheri_sdk_path / "bin"
 
-        self._initialize_derived_paths()
-
         assert self._ensure_required_properties_set()
         if os.getenv("DEBUG") is not None:
             import pprint

--- a/pycheribuild/config/target_info.py
+++ b/pycheribuild/config/target_info.py
@@ -408,7 +408,6 @@ class MipsFloatAbi(Enum):
 
 class CrossCompileTarget(object):
     # Currently the same for all targets
-    DEFAULT_CAP_TABLE_ABI = "pcrel"
     DEFAULT_SUBOBJECT_BOUNDS = "conservative"
 
     def __init__(self, suffix: str, cpu_architecture: CPUArchitecture, target_info_cls: "typing.Type[TargetInfo]",
@@ -491,7 +490,7 @@ class CrossCompileTarget(object):
             # MIPS supports 128/256 -> include that in the configuration
             result += config.mips_cheri_bits_str
         if self.is_hybrid_or_purecap_cheri():
-            if config.cheri_cap_table_abi != self.DEFAULT_CAP_TABLE_ABI:
+            if config.cheri_cap_table_abi:
                 result += "-" + str(config.cheri_cap_table_abi)
             if config.subobject_bounds is not None and config.subobject_bounds != self.DEFAULT_SUBOBJECT_BOUNDS:
                 result += "-" + str(config.subobject_bounds)

--- a/pycheribuild/projects/project.py
+++ b/pycheribuild/projects/project.py
@@ -1711,17 +1711,18 @@ class Project(SimpleProject):
                            # "-Xclang", "-cheri-bounds=everywhere-unsafe"])
                            ])
         # Add mxcaptable for projects that need it
-        if self.compiling_for_cheri():
-            if self.force_static_linkage and self.needs_mxcaptable_static:
-                result.append("-mxcaptable")
-            if self.force_dynamic_linkage and self.needs_mxcaptable_dynamic:
-                result.append("-mxcaptable")
-        # Do the same for MIPS to get even performance comparisons
-        elif self.compiling_for_mips(include_purecap=False):
-            if self.force_static_linkage and self.needs_mxcaptable_static:
-                result.extend(["-mxgot", "-mllvm", "-mxmxgot"])
-            if self.force_dynamic_linkage and self.needs_mxcaptable_dynamic:
-                result.extend(["-mxgot", "-mllvm", "-mxmxgot"])
+        if self.compiling_for_mips():
+            if self.compiling_for_cheri():
+                if self.force_static_linkage and self.needs_mxcaptable_static:
+                    result.append("-mxcaptable")
+                if self.force_dynamic_linkage and self.needs_mxcaptable_dynamic:
+                    result.append("-mxcaptable")
+            # Do the same for MIPS to get even performance comparisons
+            else:
+                if self.force_static_linkage and self.needs_mxcaptable_static:
+                    result.extend(["-mxgot", "-mllvm", "-mxmxgot"])
+                if self.force_dynamic_linkage and self.needs_mxcaptable_dynamic:
+                    result.extend(["-mxgot", "-mllvm", "-mxmxgot"])
         return result
 
     @property

--- a/pycheribuild/projects/project.py
+++ b/pycheribuild/projects/project.py
@@ -1711,7 +1711,7 @@ class Project(SimpleProject):
                            # "-Xclang", "-cheri-bounds=everywhere-unsafe"])
                            ])
         # Add mxcaptable for projects that need it
-        if self.compiling_for_cheri() and self.config.cheri_cap_table_abi != "legacy":
+        if self.compiling_for_cheri():
             if self.force_static_linkage and self.needs_mxcaptable_static:
                 result.append("-mxcaptable")
             if self.force_dynamic_linkage and self.needs_mxcaptable_dynamic:

--- a/pycheribuild/projects/project.py
+++ b/pycheribuild/projects/project.py
@@ -1711,8 +1711,8 @@ class Project(SimpleProject):
                            # "-Xclang", "-cheri-bounds=everywhere-unsafe"])
                            ])
         # Add mxcaptable for projects that need it
-        if self.compiling_for_mips():
-            if self.compiling_for_cheri():
+        if self.compiling_for_mips(include_purecap=True):
+            if self.crosscompile_target.is_cheri_purecap():
                 if self.force_static_linkage and self.needs_mxcaptable_static:
                     result.append("-mxcaptable")
                 if self.force_dynamic_linkage and self.needs_mxcaptable_dynamic:

--- a/tests/test_argument_parsing.py
+++ b/tests/test_argument_parsing.py
@@ -627,9 +627,10 @@ def test_freebsd_toolchains_cheribsd_purecap():
                  "cheribsd-purecap-128-subobject-safe-build"),
     pytest.param("cheribsd-purecap", ["--subobject-bounds=subobject-safe", "--no-subobject-debug"],
                  "cheribsd-purecap-128-subobject-safe-subobject-nodebug-build"),
-    # No change for pcrel:
+    # Passing "--cap-table-abi=pcrel" also changes the build dir even though it's (currently) the default for all
+    # architectures.
     pytest.param("cheribsd", ["--cap-table-abi=pcrel", "--subobject-bounds=conservative"],
-                 "cheribsd-mips-hybrid128-build"),
+                 "cheribsd-mips-hybrid128-pcrel-build"),
     # plt should be encoded
     pytest.param("cheribsd", ["--cap-table-abi=plt", "--subobject-bounds=conservative"],
                  "cheribsd-mips-hybrid128-plt-build"),


### PR DESCRIPTION
The ABI is now only forced if --cap-table-abi is given explicitly.

While here, remove support for the legacy ABI.