### PR TITLE
Bump up cheribsd boot timeout for login prompt

### DIFF
--- a/pycheribuild/boot_cheribsd/__init__.py
+++ b/pycheribuild/boot_cheribsd/__init__.py
@@ -704,7 +704,7 @@ def boot_and_login(child: CheriBSDInstance, *, starttime, kernel_init_only=False
             success("===> got login prompt")
             child.sendline("root")
 
-            i = child.expect([INITIAL_PROMPT_CSH, INITIAL_PROMPT_SH], timeout=3 * 60,
+            i = child.expect([INITIAL_PROMPT_CSH, INITIAL_PROMPT_SH], timeout=10 * 60,
                              timeout_msg="timeout awaiting command prompt ")  # give CheriABI csh 3 minutes to start
             if i == 0:  # /bin/csh prompt
                 success("===> got csh command prompt, starting POSIX sh")

--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -1728,6 +1728,7 @@ class BuildCheriBsdDeviceModel(BuildCHERIBSD):
                                default_branch="device-model")
     # kernel_config = "CHERI_DE4_USBROOT"
     default_extra_make_options = ["DM_IOMMU=1", "DM_PCI=1"]
+
     # def compile(self, **kwargs):
     #    self.kernel_config = "CHERI_DE4_USBROOT"
     #    super().compile(all_kernel_configs=self.kernel_config, **kwargs)


### PR DESCRIPTION
This is needed to account for purecap kernel slowness.