### PR TITLE
llvm: always build X86 backend

### DIFF
--- a/pycheribuild/projects/llvm.py
+++ b/pycheribuild/projects/llvm.py
@@ -396,7 +396,7 @@ class BuildCheriLLVM(BuildLLVMMonoRepoBase):
         super().setup()
         if not self.build_all_targets:
             # Save some time by only building the targets that we need.
-            self.add_cmake_options(LLVM_TARGETS_TO_BUILD="Mips;RISCV;host")
+            self.add_cmake_options(LLVM_TARGETS_TO_BUILD="Mips;RISCV;X86;host")
 
     def install(self, **kwargs):
         super().install(**kwargs)


### PR DESCRIPTION
Some of our tests depend on having this target available.  Most often, it's
going to be synonymous with "host" and so should produce no extra work.