### PR TITLE
freertos:  run make clean on the demo/app combination about to be built

### DIFF
--- a/pycheribuild/projects/cross/freertos.py
+++ b/pycheribuild/projects/cross/freertos.py
@@ -97,8 +97,8 @@ class BuildFreeRTOS(CrossCompileAutotoolsProject):
             for app in self.demo_apps[demo]:
                 # Need to clean before/between building apps, otherwise
                 # irrelevant objs will be picked up from incompatible apps/builds
-                self.run_make("clean", cwd=self.source_dir / str("FreeRTOS/Demo/" + demo))
                 self.make_args.set(PROG=app)
+                self.run_make("clean", cwd=self.source_dir / str("FreeRTOS/Demo/" + demo))
                 self.run_make(cwd=self.source_dir / str("FreeRTOS/Demo/" + demo))
                 self.move_file(self.source_dir / str("FreeRTOS/Demo/" + demo + "/" + app + ".elf"),
                                self.source_dir / str("FreeRTOS/Demo/" + demo + "/" + demo + app + ".elf"))


### PR DESCRIPTION
The current ordering attempts to clean the app built in the previous iteration of the loop.  If the outer loop also iterates, then it's also trying to clean a program built for a different demo (RISC-V-Generic versus RISC-V_Galois_P1).

This doesn't become an obvious problem if you're only building apps in RISC-V-Generic that also exist for RISC-V_Galois_P1, because the app name is hardcoded in the Makefiles for both demos, therefore `make clean` happily runs, though it may be cleaning the wrong app:demo combination.

In my case, however, I added an app (`main_modbus`) only to the RISC-V-Generic demo.  It built `RISC-V-Generic:main_modbus`, then the outer loop iterated to RISC-V_Galois_P1.  Since PROG was still set to main_modbus, it then tried to clean `RISC-V_Galois_P1:main_modbus`, which failed because my demo isn't encoded in the RISC-V_Galois_P1 Makefile.