### PR TITLE
Add --sysroot-install-dir configuration option

### DIFF
--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -215,7 +215,7 @@ class FreeBSDTargetInfo(_ClangBasedTargetInfo):
 
     @property
     def sysroot_dir(self):
-        return Path(self.sdk_root_dir, "sysroot-freebsd-" + str(self.target.cpu_architecture.value))
+        return Path(self.config.sysroot_install_dir, "sysroot-freebsd-" + str(self.target.cpu_architecture.value))
 
     @classmethod
     def is_freebsd(cls):
@@ -270,7 +270,7 @@ class CheriBSDTargetInfo(FreeBSDTargetInfo):
     def sysroot_dir(self):
         if is_jenkins_build():
             # TODO: currently we need this to be unprefixed since that is what the archives created by jenkins look like
-            return self.config.cheri_sdk_dir / "sysroot"
+            return self.config.sysroot_install_dir / "sysroot"
         return self.get_cheribsd_sysroot_path()
 
     def get_cheribsd_sysroot_path(self) -> Path:
@@ -279,15 +279,15 @@ class CheriBSDTargetInfo(FreeBSDTargetInfo):
         """
         config = self.config
         if self.target.is_mips(include_purecap=True):
-            return self._sysroot_path(config.cheri_sdk_dir, purecap_prefix="-purecap", hybrid_prefix="",
+            return self._sysroot_path(config.sysroot_install_dir, purecap_prefix="-purecap", hybrid_prefix="",
                                       nocheri_name="-mips")
         elif self.target.is_riscv(include_purecap=True):
-            return self._sysroot_path(config.cheri_sdk_dir, purecap_prefix="-riscv64-purecap",
+            return self._sysroot_path(config.sysroot_install_dir, purecap_prefix="-riscv64-purecap",
                                       hybrid_prefix="-riscv64-hybrid", nocheri_name="-riscv64")
         elif self.target.is_aarch64():
-            return config.cheri_sdk_dir / "sysroot-aarch64"
+            return config.sysroot_install_dir / "sysroot-aarch64"
         elif self.target.is_x86_64():
-            return config.cheri_sdk_dir / "sysroot-amd64"
+            return config.sysroot_install_dir / "sysroot-amd64"
         else:
             assert False, "Invalid cross_compile_target: " + str(self.target)
 
@@ -580,7 +580,7 @@ class CheriOSTargetInfo(CheriBSDTargetInfo):
 
     @property
     def sysroot_dir(self):
-        return self.sdk_root_dir / "sysroot"
+        return self.config.sysroot_install_dir / "sysroot"
 
     @classmethod
     def is_cheribsd(cls):
@@ -632,7 +632,7 @@ class RTEMSTargetInfo(_ClangBasedTargetInfo):
     @property
     def sysroot_dir(self):
         # Install to target triple as RTEMS' LLVM/Clang Driver expects
-        return self.sdk_root_dir / ("sysroot-" + self.target.generic_suffix) / self.target_triple
+        return self.config.sysroot_install_dir / ("sysroot-" + self.target.generic_suffix) / self.target_triple
 
     def _get_sdk_root_dir_lazy(self) -> Path:
         return self.config.cheri_sdk_dir
@@ -674,7 +674,7 @@ class NewlibBaremetalTargetInfo(_ClangBasedTargetInfo):
             suffix = "cheri" + self.config.mips_cheri_bits_str
         else:
             suffix = self.target.generic_suffix
-        return self.config.cheri_sdk_dir / "baremetal" / suffix / self.target_triple
+        return self.config.sysroot_install_dir / "baremetal" / suffix / self.target_triple
 
     @property
     def must_link_statically(self):

--- a/pycheribuild/config/defaultconfig.py
+++ b/pycheribuild/config/defaultconfig.py
@@ -123,6 +123,9 @@ class DefaultCheriConfig(CheriConfig):
                                                  default=lambda p, cls: p.output_root, group=loader.path_group,
                                                  help="The directory to find sdk and bootstrap tools (default: "
                                                       "'<OUTPUT_ROOT>')")
+        self.sysroot_pfx = loader.add_path_option("sysroot-install-dir",
+                                                  default=lambda p, cls: p.tools_root, group=loader.path_group,
+                                                  help="Sysroot prefix (default: '<TOOLS_ROOT>')")
         loader.finalize_options(available_targets)
 
     def load(self):
@@ -130,6 +133,7 @@ class DefaultCheriConfig(CheriConfig):
         self.preferred_xtarget = None
         # now set some generic derived config options
         self.cheri_sdk_dir = self.tools_root / self.cheri_sdk_directory_name  # qemu and binutils (and llvm/clang)
+        self.sysroot_install_dir = self.sysroot_pfx / self.cheri_sdk_directory_name
         self.other_tools_dir = self.tools_root / "bootstrap"
         self.cheribsd_image_root = self.output_root  # TODO: allow this to be different?
 

--- a/pycheribuild/config/jenkinsconfig.py
+++ b/pycheribuild/config/jenkinsconfig.py
@@ -222,6 +222,7 @@ class JenkinsConfig(CheriConfig):
             self.cheri_sdk_dir = Path("/cheri-sdk")
         else:
             self.cheri_sdk_dir = self.workspace / self.cheri_sdk_directory_name
+        self.sysroot_install_dir = self.cheri_sdk_dir
         self.preferred_xtarget = None  # type: typing.Optional[CrossCompileTarget]
         if self.cpu == "default":
             self.preferred_xtarget = None

--- a/tests/setup_mock_chericonfig.py
+++ b/tests/setup_mock_chericonfig.py
@@ -54,6 +54,7 @@ class MockConfig(CheriConfig):
         self.build_root = source_root / "build"
         self.output_root = source_root / "output"
         self.cheri_sdk_dir = self.output_root / "sdk"
+        self.sysroot_install_dir = self.cheri_sdk_dir
         self.other_tools_dir = self.output_root / "other"
 
         assert self._ensure_required_properties_set()


### PR DESCRIPTION
cheribuild currently installs the sysroots under the sdk dir, which is derived
from the tools_root, which, in turn, defaults to the output_dir.  When
attempting to share tools directories between long-lived branches of cheribsd
(for example), this derivation chain implies that the sysroots end up in the
nominally shared tools directory, which is not desirable.  This change allows
cheribuild to still use a shared compiler and qemu (and so on) and yet use
different sysroots.