### PR TITLE
Initial Morello support

### DIFF
--- a/pycheribuild/config/chericonfig.py
+++ b/pycheribuild/config/chericonfig.py
@@ -245,6 +245,7 @@ class CheriConfig(object):
         # Path to kernel/disk images (this is the same as output_root by default but different in Jenkins)
         self.cheribsd_image_root = None  # type: Optional[Path]
         self.cheri_sdk_dir = None  # type: Optional[Path]
+        self.morello_sdk_dir = None  # type: Optional[Path]
         self.other_tools_dir = None  # type: Optional[Path]
         self.sysroot_install_dir = None  # type: Optional[Path]
         self.docker = loader.add_bool_option("docker", help="Run the build inside a docker container",
@@ -421,8 +422,12 @@ class CheriConfig(object):
         return str(self.mips_cheri_bits)
 
     @property
-    def cheri_sdk_directory_name(self) -> str:
+    def default_cheri_sdk_directory_name(self) -> str:
         return "sdk"
+
+    @property
+    def default_morello_sdk_directory_name(self) -> str:
+        return "morello-sdk"
 
     @property
     def cheri_sdk_bindir(self):

--- a/pycheribuild/config/defaultconfig.py
+++ b/pycheribuild/config/defaultconfig.py
@@ -124,8 +124,9 @@ class DefaultCheriConfig(CheriConfig):
                                                  default=lambda p, cls: p.output_root, group=loader.path_group,
                                                  help="The directory to find sdk and bootstrap tools (default: "
                                                       "'<OUTPUT_ROOT>')")
-        default_morello_sdk = ComputedDefaultValue(function=lambda p, cls: (p.output_root / "morello-sdk"),
-                                                   as_string="'<OUTPUT_ROOT>/morello-sdk'")
+        default_morello_sdk = ComputedDefaultValue(
+            function=lambda p, cls: (p.output_root / p.default_morello_sdk_directory_name),
+            as_string="'<OUTPUT_ROOT>/morello-sdk'")
         self.morello_sdk_dir = loader.add_path_option("morello-sdk-root",
                                                       default=default_morello_sdk, group=loader.path_group,
                                                       help="The directory to find/install the Morello SDK")
@@ -138,8 +139,8 @@ class DefaultCheriConfig(CheriConfig):
         super().load()
         self.preferred_xtarget = None
         # now set some generic derived config options
-        self.cheri_sdk_dir = self.tools_root / self.cheri_sdk_directory_name  # qemu and binutils (and llvm/clang)
-        self.sysroot_install_dir = self.sysroot_pfx / self.cheri_sdk_directory_name
+        self.cheri_sdk_dir = self.tools_root / self.default_cheri_sdk_directory_name
+        self.sysroot_install_dir = self.sysroot_pfx / self.default_cheri_sdk_directory_name
         self.other_tools_dir = self.tools_root / "bootstrap"
         self.cheribsd_image_root = self.output_root  # TODO: allow this to be different?
 

--- a/pycheribuild/config/defaultconfig.py
+++ b/pycheribuild/config/defaultconfig.py
@@ -32,7 +32,7 @@ from enum import Enum
 from pathlib import Path
 
 from .chericonfig import CheriConfig
-from .loader import ConfigLoaderBase, JsonAndCommandLineConfigLoader
+from .loader import ComputedDefaultValue, ConfigLoaderBase, JsonAndCommandLineConfigLoader
 from ..utils import default_make_jobs_count
 
 
@@ -124,6 +124,11 @@ class DefaultCheriConfig(CheriConfig):
                                                  default=lambda p, cls: p.output_root, group=loader.path_group,
                                                  help="The directory to find sdk and bootstrap tools (default: "
                                                       "'<OUTPUT_ROOT>')")
+        default_morello_sdk = ComputedDefaultValue(function=lambda p, cls: (p.output_root / "morello-sdk"),
+                                                   as_string="'<OUTPUT_ROOT>/morello-sdk'")
+        self.morello_sdk_dir = loader.add_path_option("morello-sdk-root",
+                                                      default=default_morello_sdk, group=loader.path_group,
+                                                      help="The directory to find/install the Morello SDK")
         self.sysroot_pfx = loader.add_path_option("sysroot-install-dir",
                                                   default=lambda p, cls: p.tools_root, group=loader.path_group,
                                                   help="Sysroot prefix (default: '<TOOLS_ROOT>')")

--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -626,8 +626,6 @@ class BuildFreeBSD(BuildFreeBSDBase):
             # Disable CTF for now to avoid the following errors:
             # ERROR: cam_periph.c: die 25130: unknown base type encoding 0xffffffffffffffa1
             kernel_options.set_with_options(CTF=False)
-            # Morello is currently not WERROR-clean:
-            kernel_options.set(WERROR="", NO_WERROR="yes")
             # Only build SMB module (since e.g. Linux module is broken)
             kernel_options.set(MODULES_OVERRIDE="smbfs libiconv libmchain")
         if not self.use_bootstrapped_toolchain:

--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -410,7 +410,6 @@ class BuildFreeBSD(BuildFreeBSDBase):
             if self.crosscompile_target.is_hybrid_or_purecap_cheri():
                 # FIXME: still needed?
                 result["WITH_CHERI"] = True
-                result["WITH_CHERI128"] = True
         else:
             assert False, "This should not be reached!"
         if self.crosscompile_target.is_hybrid_or_purecap_cheri():

--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -623,6 +623,9 @@ class BuildFreeBSD(BuildFreeBSDBase):
         elif self.compiling_for_riscv(include_purecap=True):
             kernel_options.set_with_options(CTF=False)  # FIXME: restore once debugged
         elif self.crosscompile_target.is_hybrid_or_purecap_cheri([CPUArchitecture.AARCH64]):
+            # Disable CTF for now to avoid the following errors:
+            # ERROR: cam_periph.c: die 25130: unknown base type encoding 0xffffffffffffffa1
+            kernel_options.set_with_options(CTF=False)
             # Morello is currently not WERROR-clean:
             kernel_options.set(WERROR="", NO_WERROR="yes")
             # Only build SMB module (since e.g. Linux module is broken)

--- a/pycheribuild/projects/llvm.py
+++ b/pycheribuild/projects/llvm.py
@@ -456,6 +456,16 @@ class BuildMorelloLLVM(BuildLLVMMonoRepoBase):
     native_install_dir = DefaultInstallDir.MORELLO_SDK
     supported_architectures = [CompilationTargets.NATIVE]
 
+    @property
+    def triple_prefixes_for_binaries(self) -> typing.Iterable[str]:
+        triples = [
+            CheriBSDMorelloTargetInfo.triple_for_target(CompilationTargets.CHERIBSD_MORELLO_PURECAP, self.config,
+                                                        include_version=False),
+            CheriBSDMorelloTargetInfo.triple_for_target(CompilationTargets.CHERIBSD_MORELLO_PURECAP, self.config,
+                                                        include_version=True),
+            ]
+        return [x + "-" for x in triples]
+
     def configure(self, **kwargs):
         # Unless we set the default target triple, CMake will not be able to determine the compiler ID.
         # The other alternative to fix this problem is to build the host backend. To save build time we do the former.

--- a/pycheribuild/projects/llvm.py
+++ b/pycheribuild/projects/llvm.py
@@ -448,7 +448,7 @@ class BuildCheriLLVM(BuildLLVMMonoRepoBase):
 
 
 class BuildMorelloLLVM(BuildLLVMMonoRepoBase):
-    repository = GitRepository("You must set --morello-llvm/source-directory for now!")
+    repository = GitRepository("https://git.morello-project.org/morello/llvm-project.git")
     project_name = "morello-llvm-project"
     target = "morello-llvm"
     skip_cheri_symlinks = False  # add target-specific symlinks

--- a/pycheribuild/projects/project.py
+++ b/pycheribuild/projects/project.py
@@ -1363,6 +1363,7 @@ class DefaultInstallDir(Enum):
     SYSROOT = "The sysroot for this target"
     SYSROOT_AND_ROOTFS = "The sysroot for this target and the sysroot"
     CHERI_SDK = "The CHERI SDK directory"
+    MORELLO_SDK = "The Morello SDK directory"
     BOOTSTRAP_TOOLS = "The bootstap tools directory"
     CUSTOM_INSTALL_DIR = "Custom install directory"
     SYSROOT_FOR_BAREMETAL_ROOTFS_OTHERWISE = "Sysroot for baremetal projects, rootfs otherwise"
@@ -1400,6 +1401,10 @@ def _default_install_dir_handler(config: CheriConfig, project: "Project") -> Pat
         assert project.compiling_for_host(), "CHERI_SDK is only a valid install dir for native, " \
                                              "use SYSROOT/ROOTFS for cross"
         return config.cheri_sdk_dir
+    elif install_dir == DefaultInstallDir.MORELLO_SDK:
+        assert project.compiling_for_host(), "MORELLO_SDK is only a valid install dir for native, " \
+                                             "use SYSROOT/ROOTFS for cross"
+        return config.morello_sdk_dir
     elif install_dir == DefaultInstallDir.BOOTSTRAP_TOOLS:
         assert project.compiling_for_host(), "BOOTSTRAP_TOOLS is only a valid install dir for native, " \
                                              "use SYSROOT/ROOTS for cross"

--- a/pycheribuild/qemu_utils.py
+++ b/pycheribuild/qemu_utils.py
@@ -61,7 +61,7 @@ class QemuOptions:
             self.can_boot_kernel_directly = False  # boot from disk
             # Try to use KVM instead of TCG if possible to speed up emulation
             self.machine_flags = ["-M", "accel=kvm:xen:hax:tcg"]  # default CPU (and NOT -M virt!)
-        elif xtarget.is_aarch64():
+        elif xtarget.is_aarch64(include_purecap=False):  # No morello QEMU (yet)
             self.qemu_arch_sufffix = "aarch64"
             self.can_boot_kernel_directly = False  # boot from disk
             self.machine_flags = ["-M", "virt,gic-version=3", "-cpu", "cortex-a72", "-bios", "edk2-aarch64-code.fd"]

--- a/tests/setup_mock_chericonfig.py
+++ b/tests/setup_mock_chericonfig.py
@@ -54,6 +54,7 @@ class MockConfig(CheriConfig):
         self.build_root = source_root / "build"
         self.output_root = source_root / "output"
         self.cheri_sdk_dir = self.output_root / "sdk"
+        self.morello_sdk_dir = self.output_root / "morello-sdk"
         self.sysroot_install_dir = self.cheri_sdk_dir
         self.other_tools_dir = self.output_root / "other"
 


### PR DESCRIPTION
Not 100% sure I got the compiler flags and make options for CheriBSD right.

I have the following in my cheribuild.json to find the right repositories:
```json
	"morello-sdk-root": "$MORELLO_ROOT/output/morello-sdk",
	"morello-llvm": {
		"source-directory": "$MORELLO_ROOT/git/morello-llvm-project/",
		"build-directory": "$MORELLO_ROOT/build/morello-llvm-project-build/"
	},
	"cheribsd-morello-hybrid": {
		"source-directory": "$MORELLO_ROOT/git/morello-cheribsd/",
		"build-directory": "$MORELLO_ROOT/build/cheribsd-morello-hybrid-build/",
		"install-directory": "$MORELLO_ROOT/output/rootfs-morello-hybrid/"
	},
	"cheribsd-morello-purecap": {
		"source-directory": "$MORELLO_ROOT/git/morello-cheribsd/",
		"build-directory": "$MORELLO_ROOT/build/cheribsd-morello-purecap-build/",
		"install-directory": "$MORELLO_ROOT/output/rootfs-morello-purecap/"
	},
```