### PR TITLE
Various fixes for docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && apt-get install -y \
   git \
   python3-minimal \
   lsb-release \
-  wget
+  wget \
+  samba
 
 # RUN git config --global http.sslVerify false
 # RUN cd /tmp && git clone https://github.com/arichardson/bmake && cd bmake \

--- a/pycheribuild/__main__.py
+++ b/pycheribuild/__main__.py
@@ -168,7 +168,7 @@ def real_main():
             docker_dir_mappings = [
                 # map cheribuild and the sources read-only into the container
                 "-v", cheribuild_dir + ":/cheribuild:ro",
-                "-v", str(cheri_config.source_root.absolute()) + ":/source:ro",
+                "-v", str(cheri_config.source_root.absolute()) + ":/source",
                 # build and output are read-write:
                 "-v", str(cheri_config.build_root.absolute()) + ":/build",
                 "-v", str(cheri_config.output_root.absolute()) + ":/output",

--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -1235,10 +1235,11 @@ class BuildCHERIBSD(BuildFreeBSD):
                 self.warning("Unsupported architecture for FETT kernels")
 
     def _remove_schg_flag(self, *paths: "typing.Iterable[str]"):
-        for i in paths:
-            file = self.install_dir / i
-            if file.exists():
-                self.run_cmd("chflags", "noschg", str(file))
+        if shutil.which("chflags"):
+            for i in paths:
+                file = self.install_dir / i
+                if file.exists():
+                    self.run_cmd("chflags", "noschg", str(file))
 
     def _remove_old_rootfs(self):
         if not self.config.skip_buildworld:


### PR DESCRIPTION
Fix a number of issues that prevented running cheribuild in the docker configuration. I'm new to this, so hopefully these are all reasonable fixes!

- Install missing samba dependency in Dockerfile
- Install missing texinfo dependency in Dockerfile (required for building GDB)
- Don't attempt to remove schg flag on non-BSD systems, the chflags command doesn't exist on Linux