### PR TITLE
Move TARGET_ARCH computation to common code

### DIFF
--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -256,6 +256,18 @@ class FreeBSDTargetInfo(_ClangBasedTargetInfo):
         # TODO: do we need any special cases here?
         return target.cpu_architecture.value + common_suffix
 
+    @property
+    def freebsd_target_arch(self):
+        mapping = {
+            CPUArchitecture.AARCH64: "aarch64",
+            CPUArchitecture.ARM32: "armv7",
+            CPUArchitecture.I386: "i386",
+            CPUArchitecture.MIPS64: self.config.mips_float_abi.freebsd_target_arch(),
+            CPUArchitecture.RISCV64: "riscv64",
+            CPUArchitecture.X86_64: "amd64",
+            }
+        return mapping[self.target.cpu_architecture]
+
     @classmethod
     def base_sysroot_targets(cls, target: "CrossCompileTarget", config: "CheriConfig") -> typing.List[str]:
         return ["freebsd"]
@@ -517,6 +529,17 @@ exec {cheribuild_path}/beri-fpga-bsd-boot.py {basic_args} -vvvvv runbench {runbe
             else:
                 assert False, "Unsuported purecap target" + str(cls)
         return super().triple_for_target(target, config, include_version=include_version)
+
+    @property
+    def freebsd_target_arch(self):
+        base = super().freebsd_target_arch
+        if self.target.is_cheri_purecap():
+            purecap_suffix = "c"
+            if self.target.is_mips(include_purecap=True):
+                purecap_suffix += self.config.mips_cheri_bits_str
+        else:
+            purecap_suffix = ""
+        return base + purecap_suffix
 
     @classmethod
     def toolchain_targets(cls, target: "CrossCompileTarget", config: "CheriConfig") -> typing.List[str]:

--- a/pycheribuild/config/target_info.py
+++ b/pycheribuild/config/target_info.py
@@ -40,12 +40,12 @@ if typing.TYPE_CHECKING:  # no-combine
 
 
 class CPUArchitecture(Enum):
-    X86_64 = "x86_64"
-    MIPS64 = "mips64"
-    RISCV64 = "riscv64"
-    I386 = "i386"
     AARCH64 = "aarch64"
     ARM32 = "arm32"
+    I386 = "i386"
+    MIPS64 = "mips64"
+    RISCV64 = "riscv64"
+    X86_64 = "x86_64"
 
 
 class TargetInfo(ABC):

--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -39,7 +39,7 @@ from pathlib import Path
 from ..llvm import BuildCheriLLVM, BuildUpstreamLLVM
 from ..project import (CheriConfig, CPUArchitecture, DefaultInstallDir, flush_stdio, GitRepository,
                        MakeCommandKind, MakeOptions, Project, SimpleProject, TargetBranchInfo)
-from ...config.compilation_targets import CompilationTargets
+from ...config.compilation_targets import CompilationTargets, FreeBSDTargetInfo
 from ...config.loader import ComputedDefaultValue
 from ...config.target_info import AutoVarInit, CrossCompileTarget
 from ...targets import target_manager
@@ -352,27 +352,22 @@ class BuildFreeBSD(BuildFreeBSDBase):
 
     @property
     def arch_build_flags(self):
+        assert isinstance(self.target_info, FreeBSDTargetInfo)
+        result = {
+            "TARGET_ARCH": self.target_info.freebsd_target_arch,
+            }
         if self.compiling_for_mips(include_purecap=True):
-            target_arch = self.config.mips_float_abi.freebsd_target_arch()
-            if self.crosscompile_target.is_cheri_purecap():
-                target_arch += "c" + self.config.mips_cheri_bits_str  # build purecap
-            result = {"TARGET": "mips", "TARGET_ARCH": target_arch}
+            result["TARGET"] = "mips"
             if self.crosscompile_target.is_hybrid_or_purecap_cheri():
                 result["CHERI"] = self.config.mips_cheri_bits_str
         elif self.crosscompile_target.is_x86_64():
-            result = {"TARGET": "amd64", "TARGET_ARCH": "amd64"}
+            result["TARGET"] = "amd64"
         elif self.crosscompile_target.is_riscv(include_purecap=True):
-            target_arch = "riscv64"  # TODO: allow building softfloat?
-            if self.crosscompile_target.is_cheri_purecap():
-                target_arch += "c"  # build purecap
-            result = {"TARGET": "riscv", "TARGET_ARCH": target_arch}
+            result["TARGET"] = "riscv"
         elif self.crosscompile_target.is_i386():
-            result = {"TARGET": "i386", "TARGET_ARCH": "i386"}
+            result["TARGET"] = "i386"
         elif self.crosscompile_target.is_aarch64(include_purecap=True):
-            target_arch = "aarch64"
-            if self.crosscompile_target.is_cheri_purecap():
-                target_arch += "c"  # build purecap
-            result = {"TARGET": "arm64", "TARGET_ARCH": target_arch}
+            result["TARGET"] = "arm64"
             if self.crosscompile_target.is_hybrid_or_purecap_cheri():
                 # FIXME: still needed?
                 result["WITH_CHERI"] = True


### PR DESCRIPTION
This is motivated by perl, where I want to include the FreeBSD TARGET_ARCH in its targetarch variable that gets printed in perl --version (and used in some directory names).
