### PR TITLE
gdb: add -lmd when compiling for target

### DIFF
--- a/pycheribuild/projects/cross/gdb.py
+++ b/pycheribuild/projects/cross/gdb.py
@@ -176,6 +176,7 @@ class BuildGDB(CrossCompileAutotoolsProject):
             # Currently there are a lot of `undefined symbol 'elf_version'`, etc errors
             # Add -lelf to the linker command line until the source is fixed
             self.LDFLAGS.append("-lelf")
+            self.LDFLAGS.append("-lmd")
             self.configure_environment.update(CONFIGURED_M4="m4", CONFIGURED_BISON="byacc", TMPDIR="/tmp", LIBS="")
         if self.make_args.command == "gmake":
             self.configure_environment["MAKE"] = "gmake"


### PR DESCRIPTION
After 6edd51bc7326 (FreeBSD) / 6c4dac25e39d (CheriBSD), liblzma depends on
libmd, but this isn't automagically picked up by configure, so hold the build
system's hand.