### PR TITLE
Build against rootfs instead of sysroot

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ usage: cheribuild.py [-h] [--config-file FILE] [--help-all] [--pretend] [--build
                      [--no-include-toolchain-dependencies] [--compilation-db-in-source-dir] [--generate-cmakelists]
                      [--make-without-nice] [--make-jobs MAKE_JOBS] [--source-root SOURCE_ROOT]
                      [--output-root OUTPUT_ROOT] [--build-root BUILD_ROOT] [--tools-root TOOLS_ROOT]
-                     [--morello-sdk-root MORELLO_SDK_ROOT] [--sysroot-install-dir SYSROOT_INSTALL_DIR] [--qemu/gui]
+                     [--morello-sdk-root MORELLO_SDK_ROOT] [--sysroot-install-root SYSROOT_INSTALL_ROOT] [--qemu/gui]
                      [--qemu/targets QEMU/TARGETS] [--qemu/unaligned] [--qemu/statistics]
                      [--freebsd-universe/build-options OPTIONS] [--freebsd-universe/minimal]
                      [--freebsd-universe/no-build-tests] [--go/bootstrap-toolchain GO/BOOTSTRAP_TOOLCHAIN]
@@ -449,7 +449,7 @@ Configuration of default paths:
                         The directory to find sdk and bootstrap tools (default: '<OUTPUT_ROOT>')
   --morello-sdk-root MORELLO_SDK_ROOT
                         The directory to find/install the Morello SDK (default: ''<OUTPUT_ROOT>/morello-sdk'')
-  --sysroot-install-dir SYSROOT_INSTALL_DIR
+  --sysroot-install-root SYSROOT_INSTALL_ROOT
                         Sysroot prefix (default: '<TOOLS_ROOT>')
 
 Adjust flags used when compiling MIPS/CHERI projects:

--- a/githooks/pre-push.sh
+++ b/githooks/pre-push.sh
@@ -48,7 +48,10 @@ check_bad_commit_msg() {
     range=$1
     pattern=$2
     msg=$3
-    bad_commit=$(git rev-list --grep "$pattern" "$range" | grep -v fbb3f6dad35497ed5dcea7e96d0a228b3e383741 | grep -v 4063bcdfe4fcd33b9dd43bf39bd8be3771274ced)
+    # Don't scan commits already in origin/master when creating new branches
+    # for pull requests: At least fbb3f6dad35497ed5dcea7e96d0a228b3e383741 and
+    # 4063bcdfe4fcd33b9dd43bf39bd8be3771274ced have a bad commit message.
+    bad_commit=$(git rev-list --grep "$pattern" "$range" ^origin/master)
     if [ -n "$bad_commit" ]
     then
         echo >&2 "Found $msg commit $bad_commit, not pushing"

--- a/githooks/pre-push.sh
+++ b/githooks/pre-push.sh
@@ -48,7 +48,7 @@ check_bad_commit_msg() {
     range=$1
     pattern=$2
     msg=$3
-    bad_commit=$(git rev-list -n 1 --grep "$pattern" "$range")
+    bad_commit=$(git rev-list --grep "$pattern" "$range" | grep -v fbb3f6dad35497ed5dcea7e96d0a228b3e383741 | grep -v 4063bcdfe4fcd33b9dd43bf39bd8be3771274ced)
     if [ -n "$bad_commit" ]
     then
         echo >&2 "Found $msg commit $bad_commit, not pushing"

--- a/pycheribuild/config/chericonfig.py
+++ b/pycheribuild/config/chericonfig.py
@@ -153,12 +153,6 @@ class CheriConfig(ConfigBase):
             "freebsd-host-tools-only", help_hidden=True, group=loader.freebsd_group,
             help="Stop the FreeBSD/CheriBSD build after the host tools have been built")
 
-        self.install_subdir_to_sysroot = loader.add_bool_option("install-subdir-to-sysroot", group=loader.freebsd_group,
-                                                                help="When using the --subdir option for CheriBSD "
-                                                                     "targets also install the built libraries into "
-                                                                     "the "
-                                                                     "sysroot.", default=True)
-
         self.buildenv = loader.add_commandline_only_bool_option(
             "buildenv", group=loader.freebsd_group,
             help="Open a shell with the right environment for building the project. Currently only works for "

--- a/pycheribuild/config/chericonfig.py
+++ b/pycheribuild/config/chericonfig.py
@@ -251,7 +251,7 @@ class CheriConfig(ConfigBase):
         self.cheri_sdk_dir = None  # type: Optional[Path]
         self.morello_sdk_dir = None  # type: Optional[Path]
         self.other_tools_dir = None  # type: Optional[Path]
-        self.sysroot_install_dir = None  # type: Optional[Path]
+        self.sysroot_output_root = None  # type: Optional[Path]
         self.docker = loader.add_bool_option("docker", help="Run the build inside a docker container",
                                              group=loader.docker_group)
         self.docker_container = loader.add_option("docker-container", help="Name of the docker container to use",

--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -248,8 +248,9 @@ class FreeBSDTargetInfo(_ClangBasedTargetInfo):
                                                          cross_target=self.target)
 
     def get_non_rootfs_sysroot_dir(self) -> Path:
-        return Path(self.config.sysroot_install_dir,
+        return Path(self.config.sysroot_output_root / self.config.default_cheri_sdk_directory_name,
                     "sysroot" + self.target.build_suffix(self.config, include_os=True))
+
     @classmethod
     def is_freebsd(cls):
         return True
@@ -599,6 +600,10 @@ class CheriBSDMorelloTargetInfo(CheriBSDTargetInfo):
     def linker(self) -> Path:
         return self._compiler_dir / "ld.lld"
 
+    def get_non_rootfs_sysroot_dir(self) -> Path:
+        return Path(self.config.sysroot_output_root / self.config.default_morello_sdk_directory_name,
+                    "sysroot" + self.target.build_suffix(self.config, include_os=True))
+
     @classmethod
     def toolchain_targets(cls, target: "CrossCompileTarget", config: "CheriConfig"):
         return ["morello-llvm"]
@@ -682,7 +687,8 @@ class RTEMSTargetInfo(_ClangBasedTargetInfo):
     @property
     def sysroot_dir(self):
         # Install to target triple as RTEMS' LLVM/Clang Driver expects
-        return self.config.sysroot_install_dir / ("sysroot-" + self.target.generic_suffix) / self.target_triple
+        return self.config.sysroot_output_root / self.config.default_cheri_sdk_directory_name / (
+                    "sysroot-" + self.target.generic_suffix) / self.target_triple
 
     def _get_sdk_root_dir_lazy(self) -> Path:
         return self.config.cheri_sdk_dir
@@ -725,7 +731,8 @@ class NewlibBaremetalTargetInfo(_ClangBasedTargetInfo):
             suffix = "cheri" + self.config.mips_cheri_bits_str
         else:
             suffix = self.target.generic_suffix
-        return self.config.sysroot_install_dir / "baremetal" / suffix / self.target_triple
+        sysroot_dir = self.config.sysroot_output_root / self.config.default_cheri_sdk_directory_name
+        return sysroot_dir / "baremetal" / suffix / self.target_triple
 
     @property
     def must_link_statically(self):

--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -86,6 +86,14 @@ class _ClangBasedTargetInfo(TargetInfo, metaclass=ABCMeta):
         return self._compiler_dir / "llvm-ar"
 
     @property
+    def ranlib(self) -> Path:
+        return self._compiler_dir / "llvm-ranlib"
+
+    @property
+    def nm(self) -> Path:
+        return self._compiler_dir / "llvm-nm"
+
+    @property
     def strip_tool(self) -> Path:
         return self._compiler_dir / "llvm-strip"
 
@@ -878,6 +886,14 @@ class ArmNoneEabiGccTargetInfo(TargetInfo):
     @property
     def ar(self) -> Path:
         return self.bindir / (self.binary_prefix + "ar")
+
+    @property
+    def ranlib(self) -> Path:
+        return self.bindir / (self.binary_prefix + "ranlib")
+
+    @property
+    def nm(self) -> Path:
+        return self.bindir / (self.binary_prefix + "nm")
 
     @property
     def strip_tool(self) -> Path:

--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -596,10 +596,6 @@ class CheriBSDMorelloTargetInfo(CheriBSDTargetInfo):
             return "aarch64-unknown-freebsd{}".format(cls.FREEBSD_VERSION if include_version else "")
         return super().triple_for_target(target, config, include_version=include_version)
 
-    @property
-    def linker(self) -> Path:
-        return self._compiler_dir / "ld.lld"
-
     def get_non_rootfs_sysroot_dir(self) -> Path:
         return Path(self.config.sysroot_output_root / self.config.default_morello_sdk_directory_name,
                     "sysroot" + self.target.build_suffix(self.config, include_os=True))

--- a/pycheribuild/config/defaultconfig.py
+++ b/pycheribuild/config/defaultconfig.py
@@ -136,9 +136,9 @@ class DefaultCheriConfig(CheriConfig):
         self.morello_sdk_dir = loader.add_path_option("morello-sdk-root",
                                                       default=default_morello_sdk, group=loader.path_group,
                                                       help="The directory to find/install the Morello SDK")
-        self.sysroot_pfx = loader.add_path_option("sysroot-install-dir",
-                                                  default=lambda p, cls: p.tools_root, group=loader.path_group,
-                                                  help="Sysroot prefix (default: '<TOOLS_ROOT>')")
+        self.sysroot_output_root = loader.add_path_option("sysroot-install-root", "-sysroot-install-dir",
+                                                          default=lambda p, cls: p.tools_root, group=loader.path_group,
+                                                          help="Sysroot prefix (default: '<TOOLS_ROOT>')")
         loader.finalize_options(available_targets)
 
     def load(self):
@@ -146,7 +146,6 @@ class DefaultCheriConfig(CheriConfig):
         self.preferred_xtarget = None
         # now set some generic derived config options
         self.cheri_sdk_dir = self.tools_root / self.default_cheri_sdk_directory_name
-        self.sysroot_install_dir = self.sysroot_pfx / self.default_cheri_sdk_directory_name
         self.other_tools_dir = self.tools_root / "bootstrap"
         self.cheribsd_image_root = self.output_root  # TODO: allow this to be different?
 

--- a/pycheribuild/config/jenkinsconfig.py
+++ b/pycheribuild/config/jenkinsconfig.py
@@ -159,7 +159,7 @@ class JenkinsConfig(CheriConfig):
                                               "$WORKSPACE/" + self.default_output_path)
         self.output_root = loader.add_commandline_only_option("output-path", default=default_output, type=Path,
                                                               help="Path for the output (relative to $WORKSPACE)")
-        self.sysroot_install_dir = loader.add_commandline_only_option(
+        self.sysroot_output_root = loader.add_commandline_only_option(
             "sysroot-output-path",
             default=ComputedDefaultValue(function=lambda c, _: c.output_root,
                                          as_string="$WORKSPACE/" + self.default_output_path),
@@ -189,6 +189,7 @@ class JenkinsConfig(CheriConfig):
 
     @property
     def default_cheri_sdk_directory_name(self):
+        # FIXME: remove this difference between jenkins and non-jenkins builds
         return "cherisdk"
 
     @property
@@ -221,7 +222,7 @@ class JenkinsConfig(CheriConfig):
             self.keep_install_dir = True
         if os.path.relpath(str(self.output_root), str(self.workspace)).startswith(".."):
             fatal_error("Output path", self.output_root, "must be inside workspace", self.workspace)
-        if os.path.relpath(str(self.sysroot_install_dir), str(self.workspace)).startswith(".."):
+        if os.path.relpath(str(self.sysroot_output_root), str(self.workspace)).startswith(".."):
             fatal_error("Sysroot output path", self.sysroot_output_path, "must be inside workspace", self.workspace)
 
         # expect the CheriBSD disk images in the workspace root

--- a/pycheribuild/config/target_info.py
+++ b/pycheribuild/config/target_info.py
@@ -151,6 +151,16 @@ class TargetInfo(ABC):
 
     @property
     @abstractmethod
+    def ranlib(self) -> Path:
+        ...
+
+    @property
+    @abstractmethod
+    def nm(self) -> Path:
+        ...
+
+    @property
+    @abstractmethod
     def strip_tool(self) -> Path:
         ...
 
@@ -393,8 +403,15 @@ class NativeTargetInfo(TargetInfo):
 
     @property
     def ar(self) -> Path:
-        # Should rarely be needed
         return self.c_compiler.parent / "ar"
+
+    @property
+    def ranlib(self) -> Path:
+        return self.c_compiler.parent / "ranlib"
+
+    @property
+    def nm(self) -> Path:
+        return self.c_compiler.parent / "nm"
 
     @property
     def strip_tool(self) -> Path:

--- a/pycheribuild/projects/cross/asio.py
+++ b/pycheribuild/projects/cross/asio.py
@@ -33,7 +33,7 @@ from .crosscompileproject import CrossCompileAutotoolsProject, DefaultInstallDir
 class BuildAsio(CrossCompileAutotoolsProject):
     repository = GitRepository("https://github.com/chriskohlhoff/asio/")
     native_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
-    cross_install_dir = DefaultInstallDir.SYSROOT
+    cross_install_dir = DefaultInstallDir.ROOTFS_LOCALBASE
 
     def setup(self):
         super().setup()

--- a/pycheribuild/projects/cross/bash.py
+++ b/pycheribuild/projects/cross/bash.py
@@ -32,7 +32,7 @@ class BuildBash(CrossCompileAutotoolsProject):
     repository = GitRepository("https://github.com/CTSRD-CHERI/bash",
                                default_branch="cheri")
     native_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
     path_in_rootfs = "/usr/local"
 
     def setup(self):

--- a/pycheribuild/projects/cross/bbl.py
+++ b/pycheribuild/projects/cross/bbl.py
@@ -86,8 +86,8 @@ class BuildBBLBase(CrossCompileAutotoolsProject):
         # Fortunetaly we don't need this when building only BBL.
         self.add_configure_and_make_env_arg("OBJCOPY", self.sdk_bindir / "llvm-objcopy")
         self.add_configure_and_make_env_arg("READELF", self.sdk_bindir / "llvm-readelf")
-        self.add_configure_and_make_env_arg("RANLIB", self.sdk_bindir / "llvm-ranlib")
-        self.add_configure_and_make_env_arg("AR", self.sdk_bindir / "llvm-ar")
+        self.add_configure_and_make_env_arg("RANLIB", self.target_info.ranlib)
+        self.add_configure_and_make_env_arg("AR", self.target_info.ar)
 
         if self.without_payload:
             # Build an OpenSBI fw_jump style BBL

--- a/pycheribuild/projects/cross/bbl.py
+++ b/pycheribuild/projects/cross/bbl.py
@@ -45,7 +45,7 @@ class BuildBBLBase(CrossCompileAutotoolsProject):
     is_sdk_target = False
     needs_sysroot = False  # Should be buildable without a sysroot
     kernel_class = None
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
     without_payload = False
     mem_start = "0x80000000"
 

--- a/pycheribuild/projects/cross/benchmarks.py
+++ b/pycheribuild/projects/cross/benchmarks.py
@@ -45,7 +45,7 @@ from ...utils import is_jenkins_build
 class BuildMibench(CrossCompileProject):
     repository = GitRepository("git@github.com:CTSRD-CHERI/mibench")
     native_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
     project_name = "mibench"
     # Needs bsd make to build
     make_kind = MakeCommandKind.BsdMake
@@ -163,7 +163,7 @@ class BuildMiBenchNew(CrossCompileCMakeProject):
     default_build_type = BuildType.RELEASE
     target = "mibench-new"
     project_name = "mibench-new"
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
     native_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
 
     def setup(self):
@@ -193,7 +193,7 @@ class BuildMiBenchNew(CrossCompileCMakeProject):
 class BuildOlden(CrossCompileProject):
     repository = GitRepository("git@github.com:CTSRD-CHERI/olden")
     native_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
     project_name = "olden"
     # Needs bsd make to build
     make_kind = MakeCommandKind.BsdMake
@@ -292,7 +292,7 @@ class BuildSpec2006(CrossCompileProject):
     # No repository to clone (just hack around this):
     repository = ExternallyManagedSourceRepository()
     native_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
     make_kind = MakeCommandKind.GnuMake
 
     @classmethod
@@ -413,7 +413,7 @@ class BuildSpec2006(CrossCompileProject):
             self.default_compiler_flags + self.CXXFLAGS + ["-ggdb"]))
         config_file_text = config_file_text.replace("@LDFLAGS@",
                                                     self.commandline_to_str(self.default_ldflags + self.LDFLAGS))
-        config_file_text = config_file_text.replace("@SYSROOT@",
+        config_file_text = config_file_text.replace("@ROOTFS_LOCALBASE@",
                                                     str(self.sdk_sysroot) if not self.compiling_for_host() else "/")
         config_file_text = config_file_text.replace("@SYS_BIN@",
                                                     str(self.sdk_bindir) if not self.compiling_for_host() else "/")
@@ -559,7 +559,7 @@ class BuildSpec2006New(CrossCompileCMakeProject):
     default_build_type = BuildType.RELEASE
     target = "spec2006-new"
     project_name = "spec2006-new"
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
     native_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
 
     @classmethod
@@ -639,7 +639,7 @@ class BuildSpec2006New(CrossCompileCMakeProject):
 class BuildLMBench(CrossCompileProject):
     repository = GitRepository("git@github.com:CTSRD-CHERI/cheri-lmbench", default_branch="cheri-lmbench")
     native_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
     project_name = "lmbench"
     # Needs bsd make to build
     make_kind = MakeCommandKind.GnuMake
@@ -722,7 +722,7 @@ class BuildLMBench(CrossCompileProject):
 class BuildUnixBench(CrossCompileProject):
     repository = GitRepository("git@github.com:CTSRD-CHERI/cheri-unixbench", default_branch="cheri-unixbench")
     native_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
     project_name = "unixbench"
     # Needs bsd make to build
     make_kind = MakeCommandKind.GnuMake

--- a/pycheribuild/projects/cross/cheri_exercises.py
+++ b/pycheribuild/projects/cross/cheri_exercises.py
@@ -42,7 +42,7 @@ class BuildCheriExercises(CrossCompileProject):
                                CompilationTargets.CHERIBSD_MORELLO_PURECAP,
                                CompilationTargets.CHERIBSD_MIPS_PURECAP,  # untested, but should work
                                ]
-    default_install_dir = DefaultInstallDir.ROOTFS
+    default_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
     path_in_rootfs = "/opt/cheri-exercises"
 
     def __init__(self, *args, **kwargs):

--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -995,13 +995,6 @@ class BuildFreeBSD(BuildFreeBSDBase):
                 sysroot_var = "\"$$$${SYSROOT}\""
                 install_to_sysroot_cmd = "if [ -n {sysroot} ]; then {make} install {i} MK_TESTS=no DESTDIR={sysroot};" \
                                          " fi".format(make=make_in_subdir, sysroot=sysroot_var, i=install_nometalog_cmd)
-            if self.config.install_subdir_to_sysroot and self.has_installsysroot_target and \
-                    self.get_corresponding_sysroot() is not None:
-                if install_to_sysroot_cmd:
-                    install_to_sysroot_cmd += " && "
-                install_to_sysroot_cmd += "{make} install {i} MK_TESTS=no DESTDIR={sysroot}".format(
-                    make=make_in_subdir, sysroot=self.get_corresponding_sysroot(), i=install_nometalog_cmd)
-
         if skip_install:
             if install_to_sysroot_cmd:
                 install_cmd = install_to_sysroot_cmd

--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -988,8 +988,8 @@ class BuildFreeBSD(BuildFreeBSDBase):
         install_nometalog_cmd = "INSTALL=\"install -N " + str(self.source_dir / "etc") + " -U\" METALOG=/dev/null"
         if is_lib:
             if install_to_internal_sysroot:
-                # Due to all the bmake + shell escaping I need 4 dollars here to get it to expand SYSROOT
-                sysroot_var = "\"$$$${SYSROOT}\""
+                # Due to all the bmake + shell escaping I need 4 dollars here to get it to expand ROOTFS_LOCALBASE
+                sysroot_var = "\"$$$${ROOTFS_LOCALBASE}\""
                 install_to_sysroot_cmd = "if [ -n {sysroot} ]; then {make} install {i} MK_TESTS=no DESTDIR={sysroot};" \
                                          " fi".format(make=make_in_subdir, sysroot=sysroot_var, i=install_nometalog_cmd)
         if skip_install:

--- a/pycheribuild/projects/cross/compiler-rt.py
+++ b/pycheribuild/projects/cross/compiler-rt.py
@@ -129,7 +129,7 @@ class BuildCompilerRtBuiltins(CrossCompileCMakeProject):
     def default_install_dir(self):
         # Install compiler-rt to the sysroot to handle purecap and non-CHERI RTEMS
         if self._xtarget is CompilationTargets.RTEMS_RISCV64_PURECAP:
-            return DefaultInstallDir.SYSROOT
+            return DefaultInstallDir.ROOTFS_LOCALBASE
         return DefaultInstallDir.COMPILER_RESOURCE_DIR
 
     def __init__(self, config: CheriConfig):

--- a/pycheribuild/projects/cross/device-model.py
+++ b/pycheribuild/projects/cross/device-model.py
@@ -40,7 +40,7 @@ class BuildDeviceModel(CrossCompileAutotoolsProject):
     is_sdk_target = True
     needs_sysroot = False  # We don't need a complete sysroot
     supported_architectures = [CompilationTargets.BAREMETAL_NEWLIB_MIPS64]
-    default_install_dir = DefaultInstallDir.SYSROOT
+    default_install_dir = DefaultInstallDir.ROOTFS_LOCALBASE
     build_in_source_dir = True  # Cannot build out-of-source
 
     def install(self, **kwargs):

--- a/pycheribuild/projects/cross/dlmalloc.py
+++ b/pycheribuild/projects/cross/dlmalloc.py
@@ -37,7 +37,7 @@ class DLMalloc(CrossCompileProject):
     repository = GitRepository("https://github.com/CTSRD-CHERI/dlmalloc_nonreuse")
     make_kind = MakeCommandKind.GnuMake
     native_install_dir = DefaultInstallDir.CHERI_SDK
-    cross_install_dir = DefaultInstallDir.SYSROOT
+    cross_install_dir = DefaultInstallDir.ROOTFS_LOCALBASE
 
     @classmethod
     def setup_config_options(cls, **kwargs):

--- a/pycheribuild/projects/cross/eigen.py
+++ b/pycheribuild/projects/cross/eigen.py
@@ -35,4 +35,4 @@ class BuildEigen(CrossCompileCMakeProject):
     project_name = "eigen"
     repository = GitRepository("https://gitlab.com/libeigen/eigen.git")
     native_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
-    cross_install_dir = DefaultInstallDir.SYSROOT
+    cross_install_dir = DefaultInstallDir.ROOTFS_LOCALBASE

--- a/pycheribuild/projects/cross/fett.py
+++ b/pycheribuild/projects/cross/fett.py
@@ -51,7 +51,7 @@ class BuildFettConfig(FettProjectMixin, CrossCompileProject):
     dependencies = ["fett-nginx", "fett-openssh", "fett-sqlite", "fett-voting"]
 
     native_install_dir = DefaultInstallDir.DO_NOT_INSTALL
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
 
     def __init__(self, config):
         super().__init__(config)
@@ -172,7 +172,7 @@ class BuildFettVoting(FettProjectMixin, CrossCompileProject):
     dependencies = ["fett-kcgi", "fett-sqlbox", "fett-sqlite", "fett-zlib", "openradtool"]
 
     native_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
 
     make_kind = MakeCommandKind.GnuMake
     build_in_source_dir = True

--- a/pycheribuild/projects/cross/freertos.py
+++ b/pycheribuild/projects/cross/freertos.py
@@ -47,7 +47,7 @@ class BuildFreeRTOS(CrossCompileAutotoolsProject):
     supported_architectures = [
         CompilationTargets.BAREMETAL_NEWLIB_RISCV64_PURECAP,
         CompilationTargets.BAREMETAL_NEWLIB_RISCV64]
-    default_install_dir = DefaultInstallDir.SYSROOT
+    default_install_dir = DefaultInstallDir.ROOTFS_LOCALBASE
 
     # FreeRTOS Demos to build
     supported_freertos_demos = [

--- a/pycheribuild/projects/cross/freetype.py
+++ b/pycheribuild/projects/cross/freetype.py
@@ -34,7 +34,7 @@ from ..project import DefaultInstallDir
 class BuildFreeType2(CrossCompileCMakeProject):
     project_name = "freetype2"
     repository = GitRepository("https://github.com/freetype/freetype2.git")
-    cross_install_dir = DefaultInstallDir.SYSROOT_AND_ROOTFS
+    cross_install_dir = DefaultInstallDir.SYSROOT
     native_install_dir = DefaultInstallDir.DO_NOT_INSTALL
     path_in_rootfs = "/usr/local"
 

--- a/pycheribuild/projects/cross/freetype.py
+++ b/pycheribuild/projects/cross/freetype.py
@@ -34,7 +34,7 @@ from ..project import DefaultInstallDir
 class BuildFreeType2(CrossCompileCMakeProject):
     project_name = "freetype2"
     repository = GitRepository("https://github.com/freetype/freetype2.git")
-    cross_install_dir = DefaultInstallDir.SYSROOT
+    cross_install_dir = DefaultInstallDir.ROOTFS_LOCALBASE
     native_install_dir = DefaultInstallDir.DO_NOT_INSTALL
     path_in_rootfs = "/usr/local"
 

--- a/pycheribuild/projects/cross/gdb.py
+++ b/pycheribuild/projects/cross/gdb.py
@@ -197,9 +197,9 @@ class BuildGDB(CrossCompileAutotoolsProject):
         self.configure_environment["CXXFLAGS_FOR_BUILD"] = "-g -fcommon"
 
         if not self.compiling_for_host():
-            self.add_configure_env_arg("AR", self.sdk_bindir / "ar")
-            self.add_configure_env_arg("RANLIB", self.sdk_bindir / "ranlib")
-            self.add_configure_env_arg("NM", self.sdk_bindir / "nm")
+            self.add_configure_env_arg("AR", self.target_info.ar)
+            self.add_configure_env_arg("RANLIB", self.target_info.ranlib)
+            self.add_configure_env_arg("NM", self.target_info.nm)
 
         # Some of the configure scripts are invoked lazily (during the make invocation instead of from ./configure)
         # Therefore we need to set all the enviroment variables when compiling, too.

--- a/pycheribuild/projects/cross/gdb.py
+++ b/pycheribuild/projects/cross/gdb.py
@@ -81,7 +81,8 @@ class BuildGDB(CrossCompileAutotoolsProject):
     is_sdk_target = True
     default_build_type = BuildType.RELEASE
     supported_architectures = (CompilationTargets.ALL_CHERIBSD_NON_MORELLO_TARGETS +
-                               CompilationTargets.ALL_CHERIBSD_MORELLO_TARGETS + [CompilationTargets.NATIVE])
+                               CompilationTargets.ALL_CHERIBSD_MORELLO_TARGETS +
+                               CompilationTargets.ALL_SUPPORTED_FREEBSD_TARGETS + [CompilationTargets.NATIVE])
     default_architecture = CompilationTargets.NATIVE
 
     @classmethod

--- a/pycheribuild/projects/cross/gdb.py
+++ b/pycheribuild/projects/cross/gdb.py
@@ -65,7 +65,7 @@ class TemporarilyRemoveProgramsFromSdk(object):
 class BuildGDB(CrossCompileAutotoolsProject):
     path_in_rootfs = "/usr/local"  # Always install gdb as /usr/local/bin/gdb
     native_install_dir = DefaultInstallDir.CHERI_SDK
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
     repository = GitRepository(
         "https://github.com/CTSRD-CHERI/gdb.git",
         # Branch name is changed for every major GDB release:

--- a/pycheribuild/projects/cross/kcgi.py
+++ b/pycheribuild/projects/cross/kcgi.py
@@ -40,7 +40,7 @@ class BuildKCGI(CrossCompileAutotoolsProject):
     repository = GitRepository("https://github.com/kristapsdz/kcgi.git")
 
     native_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
 
     make_kind = MakeCommandKind.BsdMake
     add_host_target_build_config_options = False

--- a/pycheribuild/projects/cross/libmemwalk.py
+++ b/pycheribuild/projects/cross/libmemwalk.py
@@ -33,7 +33,7 @@ from .crosscompileproject import BuildType, CheriConfig, CrossCompileCMakeProjec
 class BuildLibMemwalk(CrossCompileCMakeProject):
     repository = GitRepository("https://github.com/zxombie/libmemwalk.git")
     native_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
     default_build_type = BuildType.DEBUG
     project_name = "libmemwalk"
 

--- a/pycheribuild/projects/cross/mrs.py
+++ b/pycheribuild/projects/cross/mrs.py
@@ -36,7 +36,7 @@ class MRS(CrossCompileCMakeProject):
     project_name = "mrs"
     repository = GitRepository("https://github.com/CTSRD-CHERI/mrs")
     supported_architectures = [CompilationTargets.CHERIBSD_MIPS_PURECAP]
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
 
     # set --mrs/build-type <type> to control build type, default is RelWithDebInfo
 

--- a/pycheribuild/projects/cross/newlib.py
+++ b/pycheribuild/projects/cross/newlib.py
@@ -48,7 +48,7 @@ class BuildNewlib(CrossCompileAutotoolsProject):
     # CC,CFLAGS, etc. are the compilers for the build host not the target -> don't set automatically
     _autotools_add_default_compiler_args = False
 
-    cross_install_dir = DefaultInstallDir.SYSROOT
+    cross_install_dir = DefaultInstallDir.ROOTFS_LOCALBASE
     supported_architectures = \
         [CompilationTargets.BAREMETAL_NEWLIB_MIPS64,
          CompilationTargets.BAREMETAL_NEWLIB_MIPS64_PURECAP,

--- a/pycheribuild/projects/cross/newlib.py
+++ b/pycheribuild/projects/cross/newlib.py
@@ -108,10 +108,10 @@ class BuildNewlib(CrossCompileAutotoolsProject):
             AS_FOR_TARGET=str(self.CC),  # + target_cflags,
             CC_FOR_TARGET=str(self.CC),  # + target_cflags,
             CXX_FOR_TARGET=str(self.CXX),  # + target_cflags,
-            AR_FOR_TARGET=bindir / "ar", STRIP_FOR_TARGET=bindir / "strip",
-            OBJCOPY_FOR_TARGET=bindir / "objcopy", RANLIB_FOR_TARGET=bindir / "ranlib",
+            AR_FOR_TARGET=self.target_info.ar, STRIP_FOR_TARGET=self.target_info.strip_tool,
+            OBJCOPY_FOR_TARGET=bindir / "objcopy", RANLIB_FOR_TARGET=self.target_info.ranlib,
             OBJDUMP_FOR_TARGET=bindir / "llvm-objdump",
-            READELF_FOR_TARGET=bindir / "readelf", NM_FOR_TARGET=bindir / "nm",
+            READELF_FOR_TARGET=bindir / "readelf", NM_FOR_TARGET=self.target_info.nm,
             # Set all the flags:
             CFLAGS_FOR_TARGET=target_cflags,
             CCASFLAGS_FOR_TARGET=target_cflags,

--- a/pycheribuild/projects/cross/nginx.py
+++ b/pycheribuild/projects/cross/nginx.py
@@ -45,7 +45,7 @@ class BuildNginx(CrossCompileAutotoolsProject):
     _configure_supports_variables_on_cmdline = False
     _configure_understands_enable_static = False
     native_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
 
     def __init__(self, config: CheriConfig):
         super().__init__(config)

--- a/pycheribuild/projects/cross/openssh.py
+++ b/pycheribuild/projects/cross/openssh.py
@@ -41,7 +41,7 @@ class BuildOpenSSH(CrossCompileAutotoolsProject):
     repository = GitRepository("https://github.com/CTSRD-CHERI/openssh-portable.git")
 
     native_install_dir = DefaultInstallDir.DO_NOT_INSTALL
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
     # LD is used with CFLAGS so don't set to ld/ld.lld
     _define_ld = False
 

--- a/pycheribuild/projects/cross/openssl.py
+++ b/pycheribuild/projects/cross/openssl.py
@@ -41,7 +41,7 @@ class BuildOpenSSL(CrossCompileProject):
     repository = GitRepository("https://github.com/CTSRD-CHERI/openssl.git")
 
     native_install_dir = DefaultInstallDir.DO_NOT_INSTALL
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
 
     def setup(self):
         super().setup()

--- a/pycheribuild/projects/cross/pkg.py
+++ b/pycheribuild/projects/cross/pkg.py
@@ -35,7 +35,7 @@ class BuildPkg(CrossCompileAutotoolsProject):
     _default_architecture = CompilationTargets.NATIVE
     _configure_understands_enable_static = False
     native_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
     path_in_rootfs = "/usr/local"
     build_in_source_dir = True  # Seems to fail when using out-of-source builds
 

--- a/pycheribuild/projects/cross/poco.py
+++ b/pycheribuild/projects/cross/poco.py
@@ -35,7 +35,7 @@ class BuildPoco(CrossCompileCMakeProject):
     project_name = "poco"
     repository = GitRepository("https://github.com/dodsonmg/poco.git", default_branch="cheri", force_branch=True)
     native_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
-    cross_install_dir = DefaultInstallDir.SYSROOT_AND_ROOTFS
+    cross_install_dir = DefaultInstallDir.SYSROOT
 
     def __init__(self, config: CheriConfig, *args, **kwargs):
         super().__init__(config, *args, **kwargs)

--- a/pycheribuild/projects/cross/poco.py
+++ b/pycheribuild/projects/cross/poco.py
@@ -35,7 +35,7 @@ class BuildPoco(CrossCompileCMakeProject):
     project_name = "poco"
     repository = GitRepository("https://github.com/dodsonmg/poco.git", default_branch="cheri", force_branch=True)
     native_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
-    cross_install_dir = DefaultInstallDir.SYSROOT
+    cross_install_dir = DefaultInstallDir.ROOTFS_LOCALBASE
 
     def __init__(self, config: CheriConfig, *args, **kwargs):
         super().__init__(config, *args, **kwargs)

--- a/pycheribuild/projects/cross/postgres.py
+++ b/pycheribuild/projects/cross/postgres.py
@@ -46,7 +46,7 @@ class BuildPostgres(CrossCompileAutotoolsProject):
     # warning: added 31332 entries to .cap_table but current maximum is 16384; try recompiling non-performance
     # critical source files with -mxcaptable
     native_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
 
     def __init__(self, config: CheriConfig):
         super().__init__(config)

--- a/pycheribuild/projects/cross/python.py
+++ b/pycheribuild/projects/cross/python.py
@@ -38,7 +38,7 @@ from ...utils import is_case_sensitive_dir
 class BuildPython(CrossCompileAutotoolsProject):
     repository = GitRepository("https://github.com/CTSRD-CHERI/cpython.git", default_branch="3.8", force_branch=True)
     native_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
     default_build_type = BuildType.RELWITHDEBINFO
 
     @classmethod

--- a/pycheribuild/projects/cross/qt5.py
+++ b/pycheribuild/projects/cross/qt5.py
@@ -40,7 +40,7 @@ from ...utils import OSInfo
 # This class is used to build qtbase and all of qt5
 class BuildQtWithConfigureScript(CrossCompileProject):
     native_install_dir = DefaultInstallDir.CHERI_SDK
-    cross_install_dir = DefaultInstallDir.SYSROOT
+    cross_install_dir = DefaultInstallDir.ROOTFS_LOCALBASE
     do_not_add_to_targets = True
     add_host_target_build_config_options = False
     # Should not be needed, but it seems like some of the tests are broken otherwise
@@ -205,7 +205,7 @@ class BuildQtBaseDev(CrossCompileCMakeProject):
         as_string=lambda cls: "$SOURCE_ROOT/qt5" + cls.project_name.lower())
     # native_install_dir = DefaultInstallDir.CHERI_SDK
     native_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
-    cross_install_dir = DefaultInstallDir.SYSROOT
+    cross_install_dir = DefaultInstallDir.ROOTFS_LOCALBASE
     needs_mxcaptable_static = True  # Currently over the limit, maybe we need -ffunction-sections/-fdata-sections
     # default_build_type = BuildType.MINSIZERELWITHDEBINFO  # Default to -Os with debug info:
     default_build_type = BuildType.RELWITHDEBINFO
@@ -394,7 +394,7 @@ class BuildICU4C(CrossCompileAutotoolsProject):
     target = "icu4c"
     build_dir_suffix = "4c"
     native_install_dir = DefaultInstallDir.CHERI_SDK
-    cross_install_dir = DefaultInstallDir.SYSROOT
+    cross_install_dir = DefaultInstallDir.ROOTFS_LOCALBASE
     make_kind = MakeCommandKind.GnuMake
 
     @classmethod
@@ -449,7 +449,7 @@ class BuildICU4C(CrossCompileAutotoolsProject):
 class BuildLibXml2(CrossCompileAutotoolsProject):
     repository = GitRepository("https://github.com/CTSRD-CHERI/libxml2")
     native_install_dir = DefaultInstallDir.CHERI_SDK
-    cross_install_dir = DefaultInstallDir.SYSROOT
+    cross_install_dir = DefaultInstallDir.ROOTFS_LOCALBASE
     make_kind = MakeCommandKind.GnuMake
 
     def linkage(self):
@@ -482,7 +482,7 @@ class BuildQtWebkit(CrossCompileCMakeProject):
     default_build_type = BuildType.RELWITHDEBINFO
 
     native_install_dir = DefaultInstallDir.CHERI_SDK
-    cross_install_dir = DefaultInstallDir.SYSROOT
+    cross_install_dir = DefaultInstallDir.ROOTFS_LOCALBASE
     default_source_dir = ComputedDefaultValue(
         function=lambda config, project: BuildQt5.get_source_dir(project, config) / "qtwebkit",
         as_string=lambda cls: "$SOURCE_ROOT/qt5" + cls.project_name.lower())

--- a/pycheribuild/projects/cross/ros2.py
+++ b/pycheribuild/projects/cross/ros2.py
@@ -39,7 +39,7 @@ class BuildRos2(CrossCompileCMakeProject):
     # as a library for building other applications using cheribuild
     # therefore, the _install_dir doesn't do anything, but cheribuild requires them
     native_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
     dependencies = ["poco"]
     _extra_git_clean_excludes = ["--exclude=src"]  # don't delete src/ when running clean
 

--- a/pycheribuild/projects/cross/rsync.py
+++ b/pycheribuild/projects/cross/rsync.py
@@ -34,7 +34,7 @@ from .crosscompileproject import CrossCompileAutotoolsProject, DefaultInstallDir
 class BuildRsync(CrossCompileAutotoolsProject):
     repository = GitRepository("https://github.com/CTSRD-CHERI/rsync.git")
     native_install_dir = DefaultInstallDir.BOOTSTRAP_TOOLS
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
     build_in_source_dir = True  # Cannot build out-of-source
 
     def configure(self, **kwargs):

--- a/pycheribuild/projects/cross/rtems.py
+++ b/pycheribuild/projects/cross/rtems.py
@@ -44,7 +44,7 @@ class BuildRtems(CrossCompileProject):
     is_sdk_target = True
     needs_sysroot = False  # We don't need a complete sysroot
     supported_architectures = CompilationTargets.ALL_SUPPORTED_RTEMS_TARGETS
-    default_install_dir = DefaultInstallDir.SYSROOT
+    default_install_dir = DefaultInstallDir.ROOTFS_LOCALBASE
 
     # RTEMS BSPs to build
     rtems_bsps = []

--- a/pycheribuild/projects/cross/simple_benchmark.py
+++ b/pycheribuild/projects/cross/simple_benchmark.py
@@ -37,7 +37,7 @@ from .crosscompileproject import CrossCompileCMakeProject, DefaultInstallDir, Gi
 class BuildSimpleCheriBenchmarks(CrossCompileCMakeProject):
     repository = GitRepository("https://github.com/arichardson/simple-cheri-benchmarks.git")
     native_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
     project_name = "simple-cheri-benchmarks"
 
     def create_test_dir(self, outdir: Path):

--- a/pycheribuild/projects/cross/snmalloc.py
+++ b/pycheribuild/projects/cross/snmalloc.py
@@ -35,7 +35,7 @@ class SNMalloc(CrossCompileCMakeProject):
     project_name = "snmalloc"
     repository = GitRepository("https://github.com/nwf/snmalloc")
     native_install_dir = DefaultInstallDir.CHERI_SDK
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
     default_build_type = BuildType.DEBUG
 
     @classmethod

--- a/pycheribuild/projects/cross/sqlbox.py
+++ b/pycheribuild/projects/cross/sqlbox.py
@@ -40,7 +40,7 @@ class BuildSQLbox(CrossCompileAutotoolsProject):
     repository = GitRepository("https://github.com/kristapsdz/sqlbox.git")
 
     native_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
 
     make_kind = MakeCommandKind.BsdMake
     add_host_target_build_config_options = False

--- a/pycheribuild/projects/cross/sqlite.py
+++ b/pycheribuild/projects/cross/sqlite.py
@@ -36,7 +36,7 @@ class BuildSQLite(CrossCompileAutotoolsProject):
     repository = GitRepository("https://github.com/CTSRD-CHERI/sqlite.git",
                                default_branch="branch-3.19", force_branch=True)
     native_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
-    cross_install_dir = DefaultInstallDir.SYSROOT
+    cross_install_dir = DefaultInstallDir.ROOTFS_LOCALBASE
 
     def linkage(self):
         if not self.compiling_for_host() and BuildQtWebkit.get_instance(self, self.config).force_static_linkage:
@@ -82,7 +82,7 @@ class BuildSQLite(CrossCompileAutotoolsProject):
 class BuildFettSQLite(FettProjectMixin, BuildSQLite):
     project_name = "fett-sqlite"
     repository = GitRepository("https://github.com/CTSRD-CHERI/sqlite.git", default_branch="fett")
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
 
     def __init__(self, config: CheriConfig):
         super().__init__(config)

--- a/pycheribuild/projects/cross/webkit.py
+++ b/pycheribuild/projects/cross/webkit.py
@@ -46,7 +46,7 @@ class BuildMorelloWebkit(CrossCompileCMakeProject):
     project_name = "webkit"
     dependencies = ["icu4c"]
     native_install_dir = DefaultInstallDir.DO_NOT_INSTALL
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
 
     @classmethod
     def setup_config_options(cls, **kwargs):

--- a/pycheribuild/projects/cross/zlib.py
+++ b/pycheribuild/projects/cross/zlib.py
@@ -43,7 +43,7 @@ class BuildZlib(CrossCompileAutotoolsProject):
     _configure_supports_variables_on_cmdline = False
 
     native_install_dir = DefaultInstallDir.DO_NOT_INSTALL
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
 
     def setup(self):
         super().setup()

--- a/pycheribuild/projects/disk_image.py
+++ b/pycheribuild/projects/disk_image.py
@@ -389,10 +389,7 @@ class _BuildDiskImageBase(SimpleProject):
 
         if self.include_gdb or self.include_kgdb:
             cross_target = self.source_project.get_crosscompile_target(self.config)
-            # We always want to include the MIPS GDB for CHERI targets (purecap doesn't work and would be slower):
-            if cross_target.is_cheri_purecap():
-                cross_target = cross_target.get_cheri_hybrid_target()
-            if not any(x is cross_target for x in BuildGDB.supported_architectures):
+            if cross_target not in BuildGDB.supported_architectures:
                 self.warning("GDB cannot be built for architecture ", cross_target, " -> not addding it")
             else:
                 if self.include_kgdb:

--- a/pycheribuild/projects/disk_image.py
+++ b/pycheribuild/projects/disk_image.py
@@ -1092,7 +1092,7 @@ class BuildFreeBSDImage(BuildMultiArchDiskImage):
         if self.crosscompile_target.is_x86_64(include_purecap=False):
             # remove the old -x86, -x86_64 and -native disk images
             self._cleanup_old_files(self.disk_image_path,
-                                    "-" + self.crosscompile_target.generic_suffix + self.cheri_config_suffix,
+                                    "-" + self.crosscompile_target.base_suffix + self.cheri_config_suffix,
                                     ["-x86", "-x86_64", "-native"])
 
 

--- a/pycheribuild/projects/llvm.py
+++ b/pycheribuild/projects/llvm.py
@@ -434,7 +434,7 @@ class BuildCheriLLVM(BuildLLVMMonoRepoBase):
     skip_cheri_symlinks = False
     is_sdk_target = True
     native_install_dir = DefaultInstallDir.CHERI_SDK
-    cross_install_dir = DefaultInstallDir.ROOTFS
+    cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
     default_architecture = CompilationTargets.NATIVE
     supported_architectures = CompilationTargets.ALL_SUPPORTED_CHERIBSD_AND_HOST_TARGETS
 

--- a/pycheribuild/projects/project.py
+++ b/pycheribuild/projects/project.py
@@ -1612,9 +1612,9 @@ class GitRepository(SourceRepository):
 class DefaultInstallDir(Enum):
     DO_NOT_INSTALL = "Should not be installed"
     IN_BUILD_DIRECTORY = "$BUILD_DIR/test-install-prefix"
-    ROOTFS = "The rootfs for this target"
+    ROOTFS = "The rootfs for this target (<rootfs>/opt/<arch>/<program> by default)"
     COMPILER_RESOURCE_DIR = "The compiler resource directory"
-    SYSROOT = "The sysroot for this target"
+    SYSROOT = "The sysroot for this target (<rootfs>/usr/local/<arch> by default)"
     CHERI_SDK = "The CHERI SDK directory"
     MORELLO_SDK = "The Morello SDK directory"
     BOOTSTRAP_TOOLS = "The bootstap tools directory"

--- a/pycheribuild/projects/run_qemu.py
+++ b/pycheribuild/projects/run_qemu.py
@@ -290,7 +290,7 @@ class LaunchQEMUBase(SimpleProject):
 
             def gdb_command(main_binary, bp=None, extra_binary=None) -> str:
                 gdb_cmd = BuildGDB.get_install_dir(self, cross_target=CompilationTargets.NATIVE) / "bin/gdb"
-                # Set the sysroot to ensure that the .debug file is loaded from $SYSROOT/usr/lib/debug/boot/kernel
+                # Set the sysroot to ensure that the .debug file is loaded from <ROOTFS>/usr/lib/debug/boot/kernel
                 result = [gdb_cmd, main_binary, "--init-eval-command=set sysroot " + str(self.rootfs_path)]
                 # Once the file has been loaded set a breakpoint on panic() and connect to the remote host
                 if bp:

--- a/tests/setup_mock_chericonfig.py
+++ b/tests/setup_mock_chericonfig.py
@@ -56,7 +56,7 @@ class MockConfig(CheriConfig):
         self.output_root = source_root / "output"
         self.cheri_sdk_dir = self.output_root / "sdk"
         self.morello_sdk_dir = self.output_root / "morello-sdk"
-        self.sysroot_install_dir = self.cheri_sdk_dir
+        self.sysroot_output_root = self.output_root
         self.other_tools_dir = self.output_root / "other"
 
         assert self._ensure_required_properties_set()

--- a/tests/test_argument_parsing.py
+++ b/tests/test_argument_parsing.py
@@ -721,8 +721,9 @@ def test_default_rootfs_and_sysroot_dir(target: str, args: list, expected_sysroo
     # Check that the cheribsd build dir is correct
     config = _parse_arguments(args)
     project = _get_target_instance(target, config, BuildFreeBSD)
-    sysroot_dir = project.cross_sysroot_path
-    assert sysroot_dir == project.target_info.sysroot_dir
+    assert project.cross_sysroot_path == project.target_info.sysroot_dir
+    assert isinstance(project.target_info, FreeBSDTargetInfo)
+    sysroot_dir = project.target_info.get_non_rootfs_sysroot_dir()
     assert str(sysroot_dir.relative_to(config.output_root)) == expected_sysroot
     rootfs_dir = project.install_dir
     assert str(rootfs_dir.relative_to(config.output_root)) == expected_rootfs


### PR DESCRIPTION
This should make it easier to install 3rd-party software
since we no longer have to install to both the sysroot
and the rootfs.

This patch keeps the existing SYSROOT/ROOTFS install
directories: the latter installs to /opt (and any libraries installed
are not part of the compiler search path), the former installs
to /usr/local. It probably makes sense to remove this distinction
in a follow-up change, but for now this should be sufficient to
build against the rootfs instead of the sysroot.

This PR also adds support for building GDB against the FreeBSD
sysroot and can be used to get a debugger in the disk image
without building LLDB or installing packages.


I've built a few things with these changes (e.g. gdb-freebsd-amd64),
but it would be good if someone could verify that I haven't broken
anything before I merge this.
@brettferdosi could you check whether webkit still builds with these
changes (you'll need at least --reconfigure, maybe even --clean for the dependencies).