### PR TITLE
With recent changes by arichardson we can now build on Big Sur (11.1)

### DIFF
--- a/pycheribuild/__main__.py
+++ b/pycheribuild/__main__.py
@@ -29,7 +29,6 @@
 #
 import fcntl
 import os
-import platform
 import shutil
 import subprocess
 import sys
@@ -49,7 +48,7 @@ from .projects.cross import *  # noqa: F401,F403
 from .projects.project import SimpleProject
 from .targets import target_manager
 from .processutils import (get_program_version, print_command, run_and_kill_children_on_exit, run_command)
-from .utils import (AnsiColour, OSInfo, coloured, fatal_error, have_working_internet_connection, init_global_config,
+from .utils import (AnsiColour, coloured, fatal_error, have_working_internet_connection, init_global_config,
                     status_update)
 DIRS_TO_CHECK_FOR_UPDATES = [Path(__file__).parent.parent]
 

--- a/pycheribuild/__main__.py
+++ b/pycheribuild/__main__.py
@@ -101,22 +101,6 @@ def check_not_root():
                     " Please re-run as a non-root user.", pretend=False)
 
 
-def check_macos_big_sur(config: DefaultCheriConfig):
-    if not OSInfo.IS_MAC:
-        return
-    macos_version_str = platform.mac_ver()[0]
-    # Note: os.uname().release 20.0.0 and 20.1.0 are broken, once we know a version where it's fixed, we can change
-    # this to an os.uname() range check.
-    macos_version = tuple(map(int, macos_version_str.split('.')))
-    if macos_version[0] == 10:
-        return
-    if macos_version[0] != 11:  # if next year's macOS 12 suffers from the same bug I will be very sad
-        fatal_error("Unknown macOS major version " + str(macos_version[0]) + "!", pretend=False)
-    fatal_error("You are using macOS Big Sur; this is known to be unstable and lead to lockups, requiring a machine "
-                "reboot when building CheriBSD. Please use a pre-Big Sur version of macOS or a different OS entirely.",
-                pretend=os.getenv("CHERIBUILD_BIG_SUR_NON_FATAL"))
-
-
 def real_main():
     # avoid weird errors with macos terminal:
     ensure_fd_is_blocking(sys.stdin.fileno())
@@ -175,8 +159,6 @@ def real_main():
 
     assert any(x in cheri_config.action for x in (CheribuildAction.TEST, CheribuildAction.PRINT_CHOSEN_TARGETS,
                                                   CheribuildAction.BUILD, CheribuildAction.BENCHMARK))
-
-    check_macos_big_sur(cheri_config)
 
     if cheri_config.docker:
         cheribuild_dir = str(Path(__file__).absolute().parent.parent)


### PR DESCRIPTION
Builds have now been done against a variety of targets including riscv64-hybrid, riscv64-purecap and morello.  All of them succeeded on Big Sur (11.1) and the system did not require a reboot.,