### PR TITLE
Make the minimal AArch64/Morello images bootable

### DIFF
--- a/pycheribuild/projects/disk_image.py
+++ b/pycheribuild/projects/disk_image.py
@@ -875,6 +875,9 @@ class BuildMinimalCheriBSDDiskImage(_BuildDiskImageBase):
                         include_local_file("files/minimal-image/etc.files")]
         if self._have_cplusplus_support(["lib", "usr/lib"]):
             files_to_add.append(include_local_file("files/minimal-image/need-cplusplus.files"))
+        # AArch64 boots from UEFI, include the kernel for loader.efi to load
+        if self.crosscompile_target.is_aarch64(include_purecap=True):
+            files_to_add.append("boot/kernel/kernel")
 
         for files_list in files_to_add:
             self.process_files_list(files_list)


### PR DESCRIPTION
I'm working on a change to boot the minimal arm64 images. Fix two issues I found while working on it:
 * Replace boot1.efi with one of the loader.efi variants. the former loads the latter, so follow FreeBSD and use the latter directly.
 * Include the kernel in the minimal image on arm64 so loader.efi can find it.