### PR TITLE
Deconflate minimal and MFS_ROOT images

### DIFF
--- a/pycheribuild/files/minimal-image/boot.files
+++ b/pycheribuild/files/minimal-image/boot.files
@@ -1,0 +1,2 @@
+# Only the default kernel; no debug symbols and no modules
+boot/kernel/kernel

--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -1353,8 +1353,8 @@ class BuildCheriBSDFett(BuildCHERIBSD):
 # FIXME: this should inherit from BuildCheriBSD to avoid subtle problems
 class BuildCheriBsdMfsKernel(SimpleProject):
     project_name = "cheribsd-mfs-root-kernel"
-    dependencies = ["disk-image-minimal"]
-    # TODO: also support building a non-CHERI kernel... But that needs a plain MIPS disk-image-minimal first...
+    dependencies = ["disk-image-mfs-root"]
+    # TODO: also support building a non-CHERI kernel... But that needs a plain MIPS disk-image-mfs-root first...
     _always_add_suffixed_targets = True
 
     @classproperty
@@ -1369,12 +1369,12 @@ class BuildCheriBsdMfsKernel(SimpleProject):
 
     def __init__(self, config: CheriConfig):
         super().__init__(config)
-        from ..disk_image import BuildMinimalCheriBSDDiskImage
-        self.minimal_image_instance = BuildMinimalCheriBSDDiskImage.get_instance(self)
+        from ..disk_image import BuildMfsRootCheriBSDDiskImage
+        self.mfs_root_image_instance = BuildMfsRootCheriBSDDiskImage.get_instance(self)
         # Re-use the same build directory as the CheriBSD target that was used for the disk image
         # This ensure that the kernel build tools can be found in the build directory
-        self.image = self.minimal_image_instance.disk_image_path
-        self.build_cheribsd_instance = self.minimal_image_instance.cheribsd_class.get_instance(self)
+        self.image = self.mfs_root_image_instance.disk_image_path
+        self.build_cheribsd_instance = self.mfs_root_image_instance.cheribsd_class.get_instance(self)
 
     def process(self):
         default_kernconf = self._get_kernconf_to_build(self.build_cheribsd_instance)

--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -1354,7 +1354,6 @@ class BuildCheriBSDFett(BuildCHERIBSD):
 class BuildCheriBsdMfsKernel(SimpleProject):
     project_name = "cheribsd-mfs-root-kernel"
     dependencies = ["disk-image-mfs-root"]
-    # TODO: also support building a non-CHERI kernel... But that needs a plain MIPS disk-image-mfs-root first...
     _always_add_suffixed_targets = True
 
     @classproperty

--- a/pycheribuild/projects/disk_image.py
+++ b/pycheribuild/projects/disk_image.py
@@ -824,6 +824,7 @@ class BuildMinimalCheriBSDDiskImage(BuildDiskImageBase):
     project_name = "disk-image-minimal"
     _source_class = BuildCHERIBSD
     disk_image_prefix = "cheribsd-minimal"
+    include_boot = True
 
     class _MinimalFileTemplates(_AdditionalFileTemplates):
         def get_rc_conf_template(self):
@@ -884,6 +885,8 @@ class BuildMinimalCheriBSDDiskImage(BuildDiskImageBase):
                         include_local_file("files/minimal-image/etc.files")]
         if self._have_cplusplus_support(["lib", "usr/lib"]):
             files_to_add.append(include_local_file("files/minimal-image/need-cplusplus.files"))
+        if self.include_boot:
+            files_to_add.append(include_local_file("files/minimal-image/boot.files"))
 
         for files_list in files_to_add:
             self.process_files_list(files_list)
@@ -1030,6 +1033,12 @@ class BuildMinimalCheriBSDDiskImage(BuildDiskImageBase):
             self.run_cmd("du", "-ah", self.tmpdir)
             self.run_cmd("sh", "-c", "du -ah '{}' | sort -h".format(self.tmpdir))
         super().make_rootfs_image(rootfs_img)
+
+
+class BuildMfsRootCheriBSDDiskImage(BuildMinimalCheriBSDDiskImage):
+    project_name = "disk-image-mfs-root"
+    disk_image_prefix = "cheribsd-mfs-root"
+    include_boot = False
 
     @property
     def cheribsd_class(self):

--- a/pycheribuild/projects/run_fvp.py
+++ b/pycheribuild/projects/run_fvp.py
@@ -34,7 +34,7 @@ import typing
 from pathlib import Path
 from subprocess import CompletedProcess
 
-from .disk_image import BuildCheriBSDDiskImage, BuildFreeBSDImage, BuildMultiArchDiskImage
+from .disk_image import BuildCheriBSDDiskImage, BuildDiskImageBase, BuildFreeBSDImage
 from .fvp_firmware import BuildMorelloFlashImages, BuildMorelloScpFirmware, BuildMorelloUEFI
 from .project import SimpleProject
 from ..config.chericonfig import CheriConfig
@@ -413,7 +413,7 @@ VOLUME /diskimg
 
 class LaunchFVPBase(SimpleProject):
     do_not_add_to_targets = True
-    _source_class = None  # type: BuildMultiArchDiskImage
+    _source_class = None  # type: BuildDiskImageBase
 
     @classmethod
     def dependencies(cls, _: CheriConfig):

--- a/tests/test_argument_parsing.py
+++ b/tests/test_argument_parsing.py
@@ -18,7 +18,7 @@ from pycheribuild.projects.cross import *  # noqa: F401, F403
 from pycheribuild.projects.cross.cheribsd import BuildCHERIBSD, BuildFreeBSD, FreeBSDToolchainKind
 from pycheribuild.projects.cross.qt5 import BuildQtBase
 # noinspection PyProtectedMember
-from pycheribuild.projects.disk_image import _BuildDiskImageBase, BuildCheriBSDDiskImage
+from pycheribuild.projects.disk_image import BuildDiskImageBase, BuildCheriBSDDiskImage
 # Override the default config loader:
 from pycheribuild.projects.project import SimpleProject
 from pycheribuild.projects.run_qemu import LaunchCheriBSD
@@ -612,7 +612,7 @@ def test_freebsd_toolchains(target, expected_path, kind: FreeBSDToolchainKind, e
     ])
 def test_disk_image_path(target, expected_name):
     config = _parse_arguments([])
-    project = _get_target_instance(target, config, _BuildDiskImageBase)
+    project = _get_target_instance(target, config, BuildDiskImageBase)
     assert str(project.disk_image_path) == str(config.output_root / expected_name)
 
 

--- a/tests/test_target_order.py
+++ b/tests/test_target_order.py
@@ -161,17 +161,17 @@ def test_remove_duplicates():
     assert _sort_targets(["binutils", "llvm"], add_dependencies=True) == ["llvm-native"]
 
 
-def test_minimal_run():
+def test_mfs_root_run():
     # Check that we build the mfs root first
     assert _sort_targets(["disk-image-minimal-mips64-hybrid",
                           "cheribsd-mfs-root-kernel-mips64-hybrid",
-                          "run-minimal-mips64-hybrid"]) == ["disk-image-minimal-mips64-hybrid",
-                                                            "cheribsd-mfs-root-kernel-mips64-hybrid",
-                                                            "run-minimal-mips64-hybrid"]
+                          "run-mfs-root-mips64-hybrid"]) == ["disk-image-minimal-mips64-hybrid",
+                                                             "cheribsd-mfs-root-kernel-mips64-hybrid",
+                                                             "run-mfs-root-mips64-hybrid"]
     assert _sort_targets(["cheribsd-mfs-root-kernel-mips64-hybrid", "disk-image-minimal-mips64-hybrid",
-                          "run-minimal-mips64-hybrid"]) == ["disk-image-minimal-mips64-hybrid",
-                                                            "cheribsd-mfs-root-kernel-mips64-hybrid",
-                                                            "run-minimal-mips64-hybrid"]
+                          "run-mfs-root-mips64-hybrid"]) == ["disk-image-minimal-mips64-hybrid",
+                                                             "cheribsd-mfs-root-kernel-mips64-hybrid",
+                                                             "run-mfs-root-mips64-hybrid"]
 
 
 def _check_deps_not_cached(classes):

--- a/tests/test_target_order.py
+++ b/tests/test_target_order.py
@@ -163,13 +163,13 @@ def test_remove_duplicates():
 
 def test_mfs_root_run():
     # Check that we build the mfs root first
-    assert _sort_targets(["disk-image-minimal-mips64-hybrid",
+    assert _sort_targets(["disk-image-mfs-root-mips64-hybrid",
                           "cheribsd-mfs-root-kernel-mips64-hybrid",
-                          "run-mfs-root-mips64-hybrid"]) == ["disk-image-minimal-mips64-hybrid",
+                          "run-mfs-root-mips64-hybrid"]) == ["disk-image-mfs-root-mips64-hybrid",
                                                              "cheribsd-mfs-root-kernel-mips64-hybrid",
                                                              "run-mfs-root-mips64-hybrid"]
-    assert _sort_targets(["cheribsd-mfs-root-kernel-mips64-hybrid", "disk-image-minimal-mips64-hybrid",
-                          "run-mfs-root-mips64-hybrid"]) == ["disk-image-minimal-mips64-hybrid",
+    assert _sort_targets(["cheribsd-mfs-root-kernel-mips64-hybrid", "disk-image-mfs-root-mips64-hybrid",
+                          "run-mfs-root-mips64-hybrid"]) == ["disk-image-mfs-root-mips64-hybrid",
                                                              "cheribsd-mfs-root-kernel-mips64-hybrid",
                                                              "run-mfs-root-mips64-hybrid"]
 


### PR DESCRIPTION
Currently we regard minimal images as being the images embedded MFS_ROOT kernels, but they have another use case as just being a much smaller disk image. This separates things out everywhere so both exist, with minimal images now being bootable, and MFS_ROOT images only being a rootfs.
