### PR TITLE
Fix --test causing cheribuild to be suspended

### DIFF
--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -435,7 +435,7 @@ class CheriBSDTargetInfo(FreeBSDTargetInfo):
         cmd += list(script_args)
         if self.config.test_extra_args:
             cmd.extend(map(str, self.config.test_extra_args))
-        self.project.run_cmd(cmd)
+        self.project.run_cmd(cmd, give_tty_control=True)
 
     def run_fpga_benchmark(self, benchmarks_dir: Path, *, output_file: str = None, benchmark_script: str = None,
                            benchmark_script_args: list = None, extra_runbench_args: list = None):
@@ -534,9 +534,11 @@ exec {cheribuild_path}/beri-fpga-bsd-boot.py {basic_args} -vvvvv runbench {runbe
                 qemu_ssh_socket.socket.close()
             # noinspection PyTypeChecker
             self.project.run_cmd(
-                [cheribuild_path / "beri-fpga-bsd-boot.py"] + basic_args + ["-vvvvv", "runbench"] + runbench_args)
+                [cheribuild_path / "beri-fpga-bsd-boot.py"] + basic_args + ["-vvvvv", "runbench"] + runbench_args,
+                give_tty_control=True)
         else:
-            self.project.run_shell_script(beri_fpga_bsd_boot_script, shell="bash")  # the setup script needs bash not sh
+            # the setup script needs bash not sh
+            self.project.run_shell_script(beri_fpga_bsd_boot_script, shell="bash", give_tty_control=True)
 
     @classmethod
     def triple_for_target(cls, target: "CrossCompileTarget", config, *, include_version):

--- a/pycheribuild/projects/project.py
+++ b/pycheribuild/projects/project.py
@@ -582,11 +582,11 @@ class SimpleProject(FileSystemUtils, metaclass=ProjectSubclassDefinitionHook):
     # noinspection PyShadowingBuiltins
     def run_cmd(self, *args, capture_output=False, capture_error=False, input: typing.Union[str, bytes] = None,
                 timeout=None, print_verbose_only=False, run_in_pretend_mode=False, raise_in_pretend_mode=False,
-                no_print=False, replace_env=False, **kwargs):
+                no_print=False, replace_env=False, give_tty_control=False, **kwargs):
         return run_command(*args, capture_output=capture_output, capture_error=capture_error, input=input,
                            timeout=timeout, config=self.config, print_verbose_only=print_verbose_only,
                            run_in_pretend_mode=run_in_pretend_mode, raise_in_pretend_mode=raise_in_pretend_mode,
-                           no_print=no_print, replace_env=replace_env, **kwargs)
+                           no_print=no_print, replace_env=replace_env, give_tty_control=give_tty_control, **kwargs)
 
     def set_env(self, *, print_verbose_only=True, **environ):
         return set_env(print_verbose_only=print_verbose_only, config=self.config, **environ)


### PR DESCRIPTION
Without this change I get the following after killing QEMU inside the
test script:

[1]+  Stopped                 cheribuild.py cmake-riscv64 --test --interact-after-tests
alex@Alexs-MBP-10:~/devel/cheribuild(master * u=)> fg
cheribuild.py cmake-riscv64 --test --interact-after-tests
Warning: '/Users/alex/devel/cheribuild/test-scripts/run_simple_tests.py --ssh-key /Users/alex/.ssh/id_ed25519.pub --architecture riscv64 --kernel /Users/alex/cheri/output/kernel-riscv64.QEMU-MFS-ROOT --qemu-cmd /Users/alex/cheri/output/sdk/bin/qemu-system-riscv64cheri --build-dir /Users/alex/cheri/build/cmake-crosscompiled-riscv64-build --source-dir /Users/alex/cheri/cmake --sysroot-dir /Users/alex/cheri/output/rootfs-riscv64 --interact --test-command 'cd /build/bin && ./ctest --help' --test-timeout 7200' error while draining: (4, 'Interrupted system call')
Fatal error: Command `/Users/alex/devel/cheribuild/test-scripts/run_simple_tests.py --ssh-key /Users/alex/.ssh/id_ed25519.pub --architecture riscv64 --kernel /Users/alex/cheri/output/kernel-riscv64.QEMU-MFS-ROOT --qemu-cmd /Users/alex/cheri/output/sdk/bin/qemu-system-riscv64cheri --build-dir /Users/alex/cheri/build/cmake-crosscompiled-riscv64-build --source-dir /Users/alex/cheri/cmake --sysroot-dir /Users/alex/cheri/output/rootfs-riscv64 --interact --test-command 'cd /build/bin && ./ctest --help' --test-timeout 7200` failed with non-zero exit code 2. Working directory was /Users/alex/devel/cheribuild