### PR TITLE
Try to cleanup the handling of cheribsd kernel configuration files

### DIFF
--- a/pycheribuild/config/chericonfig.py
+++ b/pycheribuild/config/chericonfig.py
@@ -386,6 +386,9 @@ class CheriConfig(ConfigBase):
             "build-morello-firmware-from-source", help_hidden=False,
             help="Build the firmware from source instead of downloading the latest release.")
 
+        self.list_kernels = loader.add_bool_option("list-kernels",
+                                                   help="List available kernel configs to run and exit")
+
         self.targets = None  # type: typing.Optional[typing.List[str]]
         self.__optional_properties = ["preferred_xtarget", "internet_connection_last_checked_at"]
 

--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -277,6 +277,23 @@ class FreeBSDTargetInfo(_ClangBasedTargetInfo):
         return target.cpu_architecture.value + common_suffix
 
     @property
+    def freebsd_target_cputype(self):
+        """
+        Return the name of the target CPU type, which is also the name of
+        the machine-dependent code directory in the source tree.
+        (e.g. <arch> in sys/<arch>)
+        """
+        mapping = {
+            CPUArchitecture.AARCH64: "arm64",
+            CPUArchitecture.ARM32: "arm",
+            CPUArchitecture.I386: "i386",
+            CPUArchitecture.MIPS64: "mips",
+            CPUArchitecture.RISCV64: "riscv",
+            CPUArchitecture.X86_64: "amd64",
+        }
+        return mapping[self.target.cpu_architecture]
+
+    @property
     def freebsd_target_arch(self):
         mapping = {
             CPUArchitecture.AARCH64: "aarch64",

--- a/pycheribuild/projects/cross/bbl.py
+++ b/pycheribuild/projects/cross/bbl.py
@@ -29,6 +29,7 @@
 #
 
 from .crosscompileproject import CompilationTargets, CrossCompileAutotoolsProject
+from .cheribsd import ConfigPlatform
 from ..build_qemu import BuildQEMU
 from ..project import (BuildType, CheriConfig, ComputedDefaultValue, CrossCompileTarget, DefaultInstallDir,
                        GitRepository, MakeCommandKind, Project)
@@ -96,7 +97,9 @@ class BuildBBLBase(CrossCompileAutotoolsProject):
         else:
             # Add the kernel as a payload:
             assert self.kernel_class is not None
-            kernel_path = self.kernel_class.get_installed_kernel_path(self, cross_target=self.crosscompile_target)
+            kernel_project = self.kernel_class.get_instance(self)
+            kernel_config = kernel_project.default_kernel_config(ConfigPlatform.QEMU)
+            kernel_path = kernel_project.get_kernel_install_path(kernel_config)
             self.configure_args.append("--with-payload=" + str(kernel_path))
 
     def compile(self, **kwargs):

--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -1526,36 +1526,7 @@ class BuildCHERIBSD(BuildFreeBSD):
         self.extra_kernels = []
         self.extra_kernels_with_mfs = []
 
-        xtarget = self.crosscompile_target
-        if xtarget.is_hybrid_or_purecap_cheri():
-            kernABI = KernelABI.HYBRID
-        else:
-            kernABI = KernelABI.NATIVE
-
-        configs = []
-        if self.build_purecap_kernels:
-            # The default config has already been added if the default is purecap
-            # XXX-AM: should be build the hybrid kernel when the default is purecap?
-            if self.default_kernel == KernelABI.HYBRID:
-                configs.append(CheriBSDConfigTable.get_unique(xtarget, ConfigGroup.DEFAULT,
-                                                              KernelABI.PURECAP, mfsroot=False))
-
-        if self.build_fpga_kernels:
-            configs += CheriBSDConfigTable.get_configs(xtarget, ConfigGroup.FPGA_DEFAULT, kernABI)
-            configs += CheriBSDConfigTable.get_configs(xtarget, ConfigGroup.FPGA, kernABI)
-            if self.build_purecap_kernels:
-                configs += CheriBSDConfigTable.get_configs(xtarget, ConfigGroup.FPGA_DEFAULT, KernelABI.PURECAP)
-                configs += CheriBSDConfigTable.get_configs(xtarget, ConfigGroup.FPGA, KernelABI.PURECAP)
-
-        if self.build_fett_kernels:
-            if self.compiling_for_riscv(include_purecap=True):
-                configs += CheriBSDConfigTable.get_configs(xtarget, ConfigGroup.FETT, kernABI,
-                                                           caprevoke=self.caprevoke_kernel)
-                if self.build_purecap_kernels:
-                    configs += CheriBSDConfigTable.get_configs(xtarget, ConfigGroup.FETT, KernelABI.PURECAP)
-            else:
-                self.warning("Unsupported architecture for FETT kernels")
-
+        configs = self.extra_kernel_configs()
         self.extra_kernels += [c.kernconf for c in configs if not c.mfsroot]
         self.extra_kernels_with_mfs += [c.kernconf for c in configs if c.mfsroot]
 

--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -994,6 +994,18 @@ class BuildFreeBSD(BuildFreeBSDBase):
         else:
             return self.async_clean_directory(builddir)
 
+    def _list_kernel_configs(self):
+        """Emit a list of valid kernel configurations that can be given as --kernel-config overrides"""
+        conf_dir = self.source_dir / "sys" / self.target_info.freebsd_target_cputype / "conf"
+        configs = conf_dir.glob("*")
+        blacklist = ["NOTES", "LINT", "DEFAULTS"]
+        self.info("Valid kernel configuration files for --freebsd/kernel-config:")
+        for conf in configs:
+            if (conf.name in blacklist or conf.name.startswith("std.") or conf.name.endswith(".hints") or
+                    conf.name.endswith("~")):
+                continue
+            self.info(conf.name)
+
     def _buildkernel(self, kernconf: str, mfs_root_image: Path = None, extra_make_args=None,
                      ignore_skip_kernel=False):
         # Check that --skip-kernel is respected. However, we ignore it for the cheribsd-mfs-root-kernel targets
@@ -1313,6 +1325,10 @@ class BuildFreeBSD(BuildFreeBSDBase):
         if not OSInfo.IS_FREEBSD:
             assert self.crossbuild
         _clear_dangerous_make_env_vars()
+
+        if self.config.list_kernels:
+            self._list_kernel_configs()
+            return
 
         if self.explicit_subdirs_only:
             # Allow building a single FreeBSD/CheriBSD directory using the BUILDENV_SHELL trick

--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -256,6 +256,7 @@ class RISCVKernelConfigFactory(KernelConfigFactory):
         # Generate QEMU kernels
         for kABI in KernelABI:
             configs.append(self.make_config(ConfigPlatform.QEMU, kABI, default=True))
+            configs.append(self.make_config(ConfigPlatform.QEMU, kABI, benchmark=True, default=True))
             configs.append(self.make_config(ConfigPlatform.QEMU, kABI, mfsroot=True, default=True))
             configs.append(self.make_config(ConfigPlatform.QEMU, kABI, mfsroot=True, benchmark=True, default=True))
         # Generate GFE-FPGA kernels

--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -646,8 +646,7 @@ class BuildFreeBSD(BuildFreeBSDBase):
         assert not xtarget.is_hybrid_or_purecap_cheri(), "Unexpected FreeBSD target"
         if platform is None:
             platform = self.get_default_kernel_platform()
-        config = CheriBSDConfigTable.get_default(xtarget, platform, KernelABI.NOCHERI,
-                                                 **filter_kwargs)
+        config = CheriBSDConfigTable.get_default(xtarget, platform, KernelABI.NOCHERI, **filter_kwargs)
         return config.kernconf
 
     def _stdout_filter(self, line: bytes):
@@ -1624,8 +1623,8 @@ class BuildCHERIBSD(BuildFreeBSD):
         if xtarget.is_riscv(include_purecap=True):
             filter_kwargs.setdefault("fett", self.build_fett_kernels)
         filter_kwargs.setdefault("caprevoke", self.caprevoke_kernel)
-        config = CheriBSDConfigTable.get_default(xtarget, platform, self.default_kernel,
-                                                 **filter_kwargs)
+        kABI = filter_kwargs.pop("kABI", self.default_kernel)
+        config = CheriBSDConfigTable.get_default(xtarget, platform, kABI, **filter_kwargs)
         return config.kernconf
 
     def extra_kernel_configs(self):
@@ -1793,11 +1792,11 @@ class BuildCheriBsdMfsKernel(BuildCHERIBSD):
     def default_kernel_config(self, platform: ConfigPlatform = None, **filter_kwargs) -> str:
         if platform is None:
             platform = self.get_default_kernel_platform()
+        kABI = filter_kwargs.pop("kABI", self.get_default_kernel_abi())
+        filter_kwargs["mfsroot"] = True
         if self.caprevoke_kernel:
             filter_kwargs["caprevoke"] = True
-        config = CheriBSDConfigTable.get_default(self.crosscompile_target, platform,
-                                                 self.get_default_kernel_abi(),
-                                                 mfsroot=True, **filter_kwargs)
+        config = CheriBSDConfigTable.get_default(self.crosscompile_target, platform, kABI, **filter_kwargs)
         return config.kernconf
 
     def get_kernel_configs(self, **filter_kwargs) -> "typing.Sequence[str]":

--- a/pycheribuild/projects/project.py
+++ b/pycheribuild/projects/project.py
@@ -508,6 +508,9 @@ class SimpleProject(FileSystemUtils, metaclass=ProjectSubclassDefinitionHook):
     def compiling_for_riscv(self, include_purecap: bool):
         return self.crosscompile_target.is_riscv(include_purecap=include_purecap)
 
+    def compiling_for_aarch64(self, include_purecap: bool):
+        return self.crosscompile_target.is_aarch64(include_purecap=include_purecap)
+
     def build_configuration_suffix(self, target: typing.Optional[CrossCompileTarget] = None) -> str:
         """
         :param target: the target to use

--- a/pycheribuild/projects/run_fpga.py
+++ b/pycheribuild/projects/run_fpga.py
@@ -121,11 +121,9 @@ class LaunchCheriBSDOnFGPA(LaunchFPGABase):
         if self.kernel_image:
             self.current_kernel = self.kernel_image
         else:
-            if self.benchmark_kernel:
-                kernel_config = mfs_kernel.fpga_kernconf + "_BENCHMARK"
-            else:
-                kernel_config = mfs_kernel.fpga_kernconf
-            self.current_kernel = mfs_kernel.installed_kernel_for_config(self, kernel_config)
+            self.current_kernel = mfs_kernel.get_kernel_install_path(
+                fpga=True, benchmark=self.benchmark_kernel)
+
         with tempfile.TemporaryDirectory() as kernel_image_tmpdir:
             # Strip to kernel image to save some time when copying it to the FPGA booting
             # TODO: move into beri-fpga-bsd-boot?

--- a/pycheribuild/projects/run_qemu.py
+++ b/pycheribuild/projects/run_qemu.py
@@ -99,6 +99,8 @@ class LaunchQEMUBase(SimpleProject):
                                                             help="The port on localhost to forward to the QEMU ssh "
                                                                  "port. You can then use `ssh root@localhost -p $PORT` "
                                                                  "to connect to the VM")
+        cls.ephemeral = cls.add_bool_option("ephemeral", show_help=True,
+                                           help="Run qemu in 'snapshot' mode, changes to the disk image are non-persistent")
 
         cls.extra_tcp_forwarding = cls.add_config_option("extra-tcp-forwarding", kind=list, default=(),
                                                          help="Additional TCP bridge ports beyond ssh/22; "
@@ -289,6 +291,9 @@ class LaunchQEMUBase(SimpleProject):
                 g = ':' + g
 
             user_network_options += ",hostfwd=tcp:" + h + "-" + g
+
+        if self.ephemeral:
+            self._after_disk_options += ["-snapshot"]
 
         # input("Press enter to continue")
         qemu_command = self.qemu_options.get_commandline(qemu_command=self.qemu_binary,

--- a/pycheribuild/projects/spike.py
+++ b/pycheribuild/projects/spike.py
@@ -30,7 +30,7 @@
 import sys
 
 from .cross.bbl import BuildBBLNoPayload
-from .cross.cheribsd import BuildCheriBsdMfsKernel
+from .cross.cheribsd import BuildCheriBsdMfsKernel, ConfigPlatform
 from .project import (AutotoolsProject, BuildType, CheriConfig, DefaultInstallDir, GitRepository, MakeCommandKind,
                       SimpleProject)
 from ..config.compilation_targets import CompilationTargets
@@ -77,7 +77,9 @@ class RunCheriSpikeBase(SimpleProject):
         return [cls._source_class.target, cls._bbl_class.target, BuildCheriSpike.target]
 
     def process(self):
-        kernel = self._source_class.get_installed_kernel_path(self)
+        kernel_project = self._source_class.get_instance(self)
+        kernel_config = kernel_project.default_kernel_config(ConfigPlatform.QEMU)
+        kernel = kernel_project.get_kernel_install_path(kernel_config)
         # We always want output even with --quiet
         self.run_cmd([BuildCheriSpike.get_simulator_binary(self), "+payload=" + str(kernel),
                       self._bbl_class.get_installed_kernel_path(self, cross_target=self._bbl_xtarget)],

--- a/tests/test_argument_parsing.py
+++ b/tests/test_argument_parsing.py
@@ -617,9 +617,38 @@ def test_disk_image_path(target, expected_name):
 
 
 @pytest.mark.parametrize("target,config_options,expected_name,extra_kernels", [
+    # RISCV kernconf tests
     pytest.param("cheribsd-riscv64-purecap", [], "CHERI-QEMU", []),
+    pytest.param("cheribsd-riscv64-purecap", ["--cheribsd/build-fpga-kernels"], "CHERI-QEMU", []),
+    pytest.param("cheribsd-riscv64-purecap", ["--cheribsd/build-alternate-abi-kernels"],
+                 "CHERI-QEMU", ["CHERI-PURECAP-QEMU"]),
+    pytest.param("cheribsd-riscv64-purecap",
+                 ["--cheribsd/build-alternate-abi-kernels",
+                  "--cheribsd/default-kernel-abi", "purecap"],
+                 "CHERI-PURECAP-QEMU", ["CHERI-QEMU"]),
+    pytest.param("cheribsd-riscv64-purecap", ["--cheribsd/build-fett-kernels"],
+                 "CHERI-QEMU-FETT", ["CHERI-QEMU"]),
+    pytest.param("cheribsd-riscv64-purecap",
+                 ["--cheribsd/build-fett-kernels",
+                  "--cheribsd/build-alternate-abi-kernels"],
+                 "CHERI-QEMU-FETT", ["CHERI-QEMU", "CHERI-PURECAP-QEMU"]),
+    pytest.param("cheribsd-riscv64-purecap", ["--cheribsd/build-bench-kernels"],
+                 "CHERI-QEMU", ["CHERI-QEMU-NODEBUG"]),
+    # MIPS kernconf tests
     pytest.param("cheribsd-mips64-purecap", ["--cheribsd/build-fpga-kernels"],
-                 "CHERI_MALTA64", ["CHERI_DE4_USBROOT", "CHERI_DE4_USBROOT_BENCHMARK", "CHERI_DE4_NFSROOT"]),
+                 "CHERI_MALTA64", ["CHERI_DE4_USBROOT", "CHERI_DE4_NFSROOT"]),
+    pytest.param("cheribsd-mips64-purecap", ["--cheribsd/build-fpga-kernels", "--cheribsd/build-bench-kernels"],
+                 "CHERI_MALTA64", ["CHERI_DE4_USBROOT_BENCHMARK", "CHERI_DE4_USBROOT", "CHERI_DE4_NFSROOT"]),
+    pytest.param("cheribsd-mips64-purecap", ["--cheribsd/build-alternate-abi-kernels"],
+                 "CHERI_MALTA64", ["CHERI_PURECAP_MALTA64"]),
+    pytest.param("cheribsd-mips64-purecap",
+                 ["--cheribsd/build-alternate-abi-kernels",
+                  "--cheribsd/default-kernel-abi", "purecap"],
+                 "CHERI_PURECAP_MALTA64", ["CHERI_MALTA64"]),
+    # Morello kernconf tests
+    pytest.param("cheribsd-morello-purecap", [], "GENERIC-MORELLO", []),
+    pytest.param("cheribsd-morello-purecap", ["--cheribsd/build-alternate-abi-kernels"],
+                 "GENERIC-MORELLO", ["GENERIC-MORELLO-PURECAP"]),
 ])
 def test_kernel_configs(target, config_options: "list[str]", expected_name, extra_kernels):
     config = _parse_arguments(config_options)


### PR DESCRIPTION
This attempts to have a separate class to fetch (and possibly generate) kernel configuration variants to build and run in cheribuild targets.