### PR TITLE
Drop support for Ubuntu 16.04 and Python < 3.6

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,25 +7,7 @@ pipeline {
   stages {
   stage('Test') {
   parallel {
-    stage('Test Python 3.5.0') {
-      agent {
-        dockerfile {
-          filename 'src/tests/python-350.Dockerfile'
-        }
-      }
-      steps {
-        ansiColor(colorMapName: 'xterm') {
-          dir("tempsrc") { deleteDir() }
-          dir("tempsrc") { sh 'ls -la' }
-          // Avoid git chowning .git/index to root which will cause the next build to fail
-          // Work around old docker version in jenkins that can't change cwd:
-          sh 'cd tempsrc && ../src/tests/run_jenkins_tests.sh 3.5.0'
-          dir("tempsrc") { deleteDir() }
-        }
-        junit '3.5.0-results.xml'
-      }
-    }
-    stage('Test Python 3.6') {
+    stage('Test Python 3.6.0') {
       agent {
         dockerfile {
           filename 'src/tests/python-360.Dockerfile'
@@ -64,7 +46,7 @@ pipeline {
     stage('Test Python 3.8.0') {
       agent {
         dockerfile {
-          filename 'src/tests/python-370.Dockerfile'
+          filename 'src/tests/python-380.Dockerfile'
         }
       }
       steps {
@@ -77,6 +59,24 @@ pipeline {
           dir("tempsrc") { deleteDir() }
         }
         junit '3.8.0-results.xml'
+      }
+    }
+    stage('Test Python 3.9.0') {
+      agent {
+        dockerfile {
+          filename 'src/tests/python-390.Dockerfile'
+        }
+      }
+      steps {
+        ansiColor(colorMapName: 'xterm') {
+          dir("tempsrc") { deleteDir() }
+          dir("tempsrc") { sh 'ls -la' }
+          // Avoid git chowning .git/index to root which will cause the next build to fail
+          // Work around old docker version in jenkins that can't change cwd:
+          sh 'cd tempsrc && ../src/tests/run_jenkins_tests.sh 3.9.0'
+          dir("tempsrc") { deleteDir() }
+        }
+        junit '3.9.0-results.xml'
       }
     }
     stage('Test Python RC') {
@@ -97,7 +97,7 @@ pipeline {
         junit 'rc-results.xml'
       }
     }
-    stage('Test Ubuntu 16.04') {
+    stage('Test Ubuntu 18.04') {
       agent {
         dockerfile {
           filename 'src/tests/ubuntu.Dockerfile'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `cheribuild.py` - A script to build CHERI-related software (**requires Python 3.5.2+**)
+# `cheribuild.py` - A script to build CHERI-related software (**requires Python 3.6+**)
 
 This script automates all the steps required to build various [CHERI](http://www.chericpu.com)-related software.
 For example `cheribuild.py [options] sdk-riscv64-purecap` will create an SDK that can be
@@ -8,8 +8,8 @@ will start an instance of [CheriBSD](https://github.com/CTSRD-CHERI/cheribsd) bu
 `cheribuild.py` also allows building software for Arm's adaption of CHERI, [the Morello platform](https://developer.arm.com/architectures/cpu-architecture/a-profile/morello), however not all targets are supported yet.
 
 ## Supported operating systems
-`cheribuild.py` has been tested and should work on FreeBSD 11 and 12.
-On Linux, Ubuntu 16.04/18.04/20.04, Debian 10 and OpenSUSE Tumbleweed are supported. Ubuntu 14.04 may also work but is no longer tested.
+`cheribuild.py` has been tested and should work on FreeBSD 12 and 13.
+On Linux, Ubuntu 18.04/20.04, Debian 10 and OpenSUSE Tumbleweed are supported.
 macOS 10.14 and newer is also supported.
 
 # Pre-Build Setup

--- a/pycheribuild/utils.py
+++ b/pycheribuild/utils.py
@@ -51,8 +51,8 @@ __all__ = ["typing", "include_local_file", "Type_T", "init_global_config",  # no
            "classproperty", "find_free_port", "have_working_internet_connection",  # no-combine
            "is_case_sensitive_dir", "SocketAndPort", "replace_one", "cached_property", "remove_prefix"]  # no-combine
 
-if sys.version_info < (3, 5, 2):
-    sys.exit("This script requires at least Python 3.5.2")
+if sys.version_info < (3, 6, 0):
+    sys.exit("This script requires at least Python 3.6.0")
 
 Type_T = typing.TypeVar("Type_T")
 

--- a/tests/python-390.Dockerfile
+++ b/tests/python-390.Dockerfile
@@ -1,5 +1,4 @@
-FROM python:3.5.2
-
+FROM python:3.9.0
 LABEL maintainer="Alexander.Richardson@cl.cam.ac.uk"
 
 RUN pip install pytest

--- a/tests/run_jenkins_tests.sh
+++ b/tests/run_jenkins_tests.sh
@@ -4,7 +4,7 @@ pytest_binary="python3 -m pytest"
 
 
 case  $1  in
-  3.5.0|3.6.0|3.7.0|3.8.0|rc|ubuntu)
+  3.6.0|3.7.0|3.8.0|3.9.0|rc|ubuntu)
     test_prefix=$1
     ;;
   *)

--- a/tests/ubuntu.Dockerfile
+++ b/tests/ubuntu.Dockerfile
@@ -1,5 +1,5 @@
 #FROM ubuntu:16.04
-FROM ubuntu:xenial-20210114
+FROM ubuntu:bionic-20180426
 
 LABEL maintainer="Alexander.Richardson@cl.cam.ac.uk"
 
@@ -8,8 +8,4 @@ RUN apt-get update && apt-get install -y  --no-install-recommends \
   gcc \
   git \
   python3-minimal python3-pip python3-setuptools
-# Work around https://github.com/jaraco/zipp/issues/40 and
-# https://github.com/pypa/pip/issues/5599
-# We have to pin pytest to 6.1.2 since 6.2 dropped support for python 3.5
-# Same for packaging: 20.9 is the last python3.5 version
-RUN python3 -m pip install importlib-metadata==1.0.0 pytest==6.1.2 packaging==20.9
+RUN python3 -m pip install "pytest==6.2.4"


### PR DESCRIPTION
Ubuntu 16.04 has been EOL for a while and based on the python versions
available on most Linux distributions requiring 3.6 seems like a
reasonable baseline. While I would like to use 3.7 for dataclasses,
Ubuntu 18.04 ships 3.6 and that's probably the distribution that is most
commonly used when building CHERI projects.
Bumping the Python version to 3.6 allows using features such as f-strings
and type annotations on variables (https://docs.python.org/3/whatsnew/3.6.html).