### PR TITLE
Add the ability to filter the built dependencies with regexes

### DIFF
--- a/pycheribuild/config/chericonfig.py
+++ b/pycheribuild/config/chericonfig.py
@@ -457,8 +457,7 @@ class CheriConfig(ConfigBase):
 
         # Check that the skip_dependency_filters arguments are all valid regular expressions (do it now since otherwise
         # the validation is delayed until the first time the object is used.
-        for pattern in self.skip_dependency_filters:
-            assert(isinstance(pattern, re.Pattern))
+        assert isinstance(self.skip_dependency_filters, list)
 
     @cached_property
     def _other_tools_path_prefix(self) -> str:

--- a/pycheribuild/projects/project.py
+++ b/pycheribuild/projects/project.py
@@ -391,6 +391,9 @@ class SimpleProject(FileSystemUtils, metaclass=ProjectSubclassDefinitionHook):
         for target in cls._direct_dependencies(config, include_toolchain_dependencies=include_toolchain_dependencies,
                                                include_sdk_dependencies=include_sdk_dependencies,
                                                explicit_dependencies_only=cls.direct_dependencies_only):
+            if config.should_skip_dependency(target.name, cls.target):
+                continue
+
             if target not in result:
                 result.append(target)
             if cls.direct_dependencies_only:


### PR DESCRIPTION
When building e.g. KDE programs, I want to build the KDE framework
dependencies but skip targets that take a long time to build such as QtBase
and all the underlying dependencies. This patch lets me do the following:

`cheribuild.py <target> -d --skip-sdk "--skip-dependency-filter=qt.*" "--skip-dependency-filter=libx.*"`

This avoids lots of build time (especially when combined with --clean or
--reconfigure since we also need to build a native qtbase+qtdeclarative
for the bootstrap tools in KConfig and other frameworks.