### PR TITLE
Rather awful approach to add a $ORIGIN RUNPATH to X11 libs

### DIFF
--- a/pycheribuild/processutils.py
+++ b/pycheribuild/processutils.py
@@ -438,8 +438,20 @@ def run_command(*args, capture_output=False, capture_error=False, input: "typing
             return CompletedProcess(process.args, retcode, stdout, stderr)
 
 
+class DoNoQuoteStr:
+    def __init__(self, s):
+        self.s = s
+
+    def __str__(self):
+        return self.s
+
+
+def _quote(s):
+    return str(s) if isinstance(s, DoNoQuoteStr) else shlex.quote(str(s))
+
+
 def commandline_to_str(args: "typing.Iterable[typing.Union[str,Path]]") -> str:
-    return " ".join((shlex.quote(str(s)) for s in args))
+    return " ".join((_quote(s) for s in args))
 
 
 class CompilerInfo(object):

--- a/pycheribuild/projects/cross/x11.py
+++ b/pycheribuild/projects/cross/x11.py
@@ -33,7 +33,7 @@ from .freetype import BuildFreeType2
 from ..project import DefaultInstallDir, GitRepository
 from ...config.chericonfig import BuildType
 from ...config.compilation_targets import CompilationTargets
-from ...processutils import set_env
+from ...processutils import DoNoQuoteStr, set_env
 from ...utils import OSInfo
 
 
@@ -78,6 +78,13 @@ class X11AutotoolsProject(X11AutotoolsProjectBase):
             self.configure_args.append("--with-sysroot=" + str(self.sdk_sysroot))
             # Needed for many of the projects but not all of them:
             self.configure_args.append("--enable-malloc0returnsnull")
+
+    @property
+    def default_ldflags(self):
+        result = super().default_ldflags
+        if not self.compiling_for_host():
+            result.append(DoNoQuoteStr("-Wl,--enable-new-dtags,-rpath,'$$ORIGIN/../lib'"))
+        return result
 
 
 class BuildXCBProto(X11AutotoolsProject):


### PR DESCRIPTION
Some binaries (e.g. xkbcomp) can't find the required libraries otherwise.
Dealing with the multiple levels of quoting in autotools projects is
rather awkward and it took me a while to find something that works:
`'$$ORIGIN/../lib'` (in single quotes).