### PR TITLE
Automatically start xvnc if it's installed

### DIFF
--- a/pycheribuild/files/cheribsd/rc.conf.in
+++ b/pycheribuild/files/cheribsd/rc.conf.in
@@ -16,6 +16,7 @@ nfs_client_enable="YES"
 fsck_y_enable="YES"
 fsck_y_flags="-T ffs:-R -T ufs:-R"
 crashinfo_enable=NO	# gdb runs for 5+ minutes on F1 if present...
+xvnc_enable="YES"
 if [ -e /fett ]; then
 	fett_bvrs_enable="YES"
 	fett_nginx_enable="YES"

--- a/pycheribuild/projects/cross/x11.py
+++ b/pycheribuild/projects/cross/x11.py
@@ -443,6 +443,24 @@ class BuildXVncServer(X11AutotoolsProject):
         # TODO: should we install a service that we can start with `service xvnc start`?
         self.write_file(self.install_dir / "bin/startxvnc", overwrite=True, mode=0o755,
                         contents="#!/bin/sh\nXvnc -geometry 1024x768 -SecurityTypes=None \"$@\"\n")
+        self.write_file(self.install_dir / "etc/rc.d/xvnc", overwrite=True, mode=0o755, contents=f"""#!/bin/sh
+# PROVIDE: xvnc
+# REQUIRE: DAEMON
+# BEFORE:  LOGIN
+# KEYWORD: nojail shutdown
+. /etc/rc.subr
+
+name=xvnc
+rcvar=xvnc_enable
+: "${{xvnc_args="-geometry 1024x768 -SecurityTypes=None"}}"
+
+pidfile="/var/run/${{name}}.pid"
+command=/usr/sbin/daemon
+command_args="-p ${{pidfile}} -S -T ${{name}} {self.install_prefix / "bin/Xvnc"} ${{xvnc_args}}"
+
+load_rc_config $name
+run_rc_command "$1"
+""")
 
     def update(self):
         super().update()


### PR DESCRIPTION
This commit installs a etc/rc.d/xvnc as part of xvnc-server-<arch> and
modifies the rc.conf template installed by disk-image to enable the
service by default.