### PR TITLE
Use FAT-32 for EFI filesystem images made via makefs.

### DIFF
--- a/pycheribuild/projects/disk_image.py
+++ b/pycheribuild/projects/disk_image.py
@@ -607,6 +607,7 @@ class BuildDiskImageBase(SimpleProject):
                               # "-d", "0x2fffffff",  # super verbose output
                               # "-d", "0x20000000",  # MSDOSFS debug output
                               "-B", "le",  # byte order little endian
+                              "-o", "fat_type=32",
                               "-N", self.user_group_db_dir,
                               str(efi_partition), str(tmp_mtree.name)], cwd=self.rootfs_dir)
             else:


### PR DESCRIPTION
makefs defaults to FAT-12.