### PR TITLE
Lib64c

### DIFF
--- a/pycheribuild/boot_cheribsd/__init__.py
+++ b/pycheribuild/boot_cheribsd/__init__.py
@@ -440,7 +440,7 @@ def prepend_ld_library_path(qemu: CheriBSDInstance, path: str):
 
 def set_ld_library_path_with_sysroot(qemu: CheriBSDInstance):
     non_cheri_libdir = "lib64"
-    cheri_libdir = "libcheri"
+    cheri_libdir = "lib64c"
     if not qemu.xtarget.is_hybrid_or_purecap_cheri():
         local_dir = "usr/local"
         if qemu.xtarget.target_info_cls.is_cheribsd():

--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -1331,7 +1331,7 @@ class BuildFreeBSD(BuildFreeBSDBase):
         if self.crosscompile_target.is_cheri_purecap():
             return "lib64"
         elif self.crosscompile_target.is_cheri_hybrid():
-            return "libcheri"
+            return "lib64c"
         self.warning("Unknown libcompat for target", self.target)
         self.info("Will use default buildenv target")
         return ""
@@ -2153,9 +2153,9 @@ class BuildCheriBsdSysrootArchive(SimpleProject):
             self.copy_sysroot_from_remote_machine()
         else:
             self.create_sysroot()
-        if (self.cross_sysroot_path / "usr/libcheri/").is_dir():
+        if (self.cross_sysroot_path / "usr/lib64c/").is_dir():
             # clang++ expects libgcc_eh to exist:
-            libgcc_eh = self.cross_sysroot_path / "usr/libcheri/libgcc_eh.a"
+            libgcc_eh = self.cross_sysroot_path / "usr/lib64c/libgcc_eh.a"
             if not libgcc_eh.is_file():
                 self.warning("CHERI libgcc_eh missing! You should probably update CheriBSD")
                 self.run_cmd("ar", "rc", libgcc_eh)

--- a/pycheribuild/projects/cross/libcxx.py
+++ b/pycheribuild/projects/cross/libcxx.py
@@ -60,7 +60,7 @@ class BuildLibunwind(_CxxRuntimeCMakeProject):
 
     def __init__(self, config: CheriConfig):
         super().__init__(config)
-        # self.add_cmake_options(LIBUNWIND_HAS_DL_LIB=False)  # Adding -ldl won't work: no libdl in /usr/libcheri
+        # self.add_cmake_options(LIBUNWIND_HAS_DL_LIB=False)  # Adding -ldl won't work: no libdl in /usr/lib64c
 
     def configure(self, **kwargs):
         # TODO: should share some code with libcxx
@@ -168,7 +168,7 @@ class BuildLibCXXRT(_CxxRuntimeCMakeProject):
         self.install_file(self.build_dir / "lib/libcxxrt.a", self.install_dir / "lib" / "libcxxrt.a", force=True)
         self.install_file(self.build_dir / "lib/libcxxrt.so", self.install_dir / "lib" / "libcxxrt.soa", force=True)
         # self.install_file(self.build_dir / "lib/libcxxrt.a", libdir / "libcxxrt.so", force=True)
-        # self.install_file(self.build_dir / "lib/libcxxrt.so", self.install_dir / "usr/libcheri/libcxxrt.so",
+        # self.install_file(self.build_dir / "lib/libcxxrt.so", self.install_dir / "usr/lib64c/libcxxrt.so",
         # force=True)
 
     def run_tests(self):


### PR DESCRIPTION
The first commit is probably a prerequisite for merging the CheriBSD lib64c change.  The second commit probably needs to wait a while until we deprecate the libcheri name and assume lib64c is present everywhere instead.