### PR TITLE
Update to latest Ubuntu and tools.  Add a docker build template.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,8 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 LABEL maintainer="Alexander.Richardson@cl.cam.ac.uk"
+
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \
   make ninja-build \
@@ -9,7 +11,9 @@ RUN apt-get update && apt-get install -y \
   python3-minimal \
   lsb-release \
   wget \
-  samba
+  samba \
+  texlive-base \
+  texinfo
 
 # RUN git config --global http.sslVerify false
 # RUN cd /tmp && git clone https://github.com/arichardson/bmake && cd bmake \
@@ -20,17 +24,12 @@ COPY cheribuild.json /root/.config/cheribuild.json
 
 # deps to build QEMU+elftoolchain:
 RUN apt-get update && apt-get install -y \
-  libtool pkg-config python-minimal autotools-dev automake autoconf libglib2.0-dev libpixman-1-dev \
+  libtool pkg-config python2-minimal autotools-dev automake autoconf libglib2.0-dev libpixman-1-dev \
   bison groff-base libarchive-dev flex
 
-# INSTALL clang 8.0
-RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main" > /etc/apt/sources.list.d/llvm.list
-# RUN echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu trusty main" > /etc/apt/sources.list.d/r-toolchain.list
-# RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1E9377A2BA9EF27F
-RUN apt-get update && apt-get install -y clang-8 lld-8
-
 RUN apt-get update && apt-get install -y cmake
+
+RUN addgroup --gid 12345 cheri && adduser --uid 12345 --ingroup cheri cheri
 
 VOLUME ["/cheribuild", "/source", "/build", "/output"]
 ENV PATH /cheribuild:$PATH

--- a/docker/Dockerfile.useradd
+++ b/docker/Dockerfile.useradd
@@ -1,0 +1,7 @@
+FROM cheribuild-test
+
+# NOTE: Change USER to your username, GROUPID and USERID to the output
+# of the id(1) command.
+ 
+RUN addgroup --gid GROUPID  USER && adduser --uid USERID --ingroup USER USER
+

--- a/docker/docker-cheribuild.json
+++ b/docker/docker-cheribuild.json
@@ -1,0 +1,7 @@
+# NOTE: Change the paths below to match the locations for your
+# sources, build and output directories.
+{
+  "source-root": "/home/USER/MYDIR/sources",
+  "build-root": "/home/USER/MYDIR/build",
+  "output-root": "/home/USER/MYDIR/output"
+}


### PR DESCRIPTION
A more narrow update just for docker related files.  This includes a simple Dockerfile that can be used by Linux users to layer on more users once the base image is installed.