### PR TITLE
Add telnet to the docker image for the FVP

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y \
   lsb-release \
   wget \
   samba \
+  telnet \
   texlive-base \
   texinfo
 


### PR DESCRIPTION
Works for me when built locally with: `docker build -t ctsrd/cheribuild-docker:latest cheri/cheribuild/docker`