### PR TITLE
remove --enable-slirp=git option from build.

### DIFF
--- a/pycheribuild/projects/build_qemu.py
+++ b/pycheribuild/projects/build_qemu.py
@@ -183,7 +183,6 @@ class BuildQEMUBase(AutotoolsProject):
 
         self.configureArgs.extend([
             "--target-list=" + self.qemu_targets,
-            "--enable-slirp=git",
             "--disable-linux-user",
             "--disable-bsd-user",
             "--disable-xen",


### PR DESCRIPTION
No longer valid option; slirp enabled by default?
(note that cheri/cherios-qemu/configure defaults to slirp=”yes”)

Encountered when attempting to build run-cherios target clean.