### PR TITLE
Emulate a USB keyboard+mouse when starting QEMU

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,8 @@ usage: cheribuild.py [-h] [--config-file FILE] [--help-all] [--pretend] [--build
                      [--docker-container DOCKER-CONTAINER] [--docker-reuse-container | --no-docker-reuse-container]
                      [--compilation-db] [--wait-for-debugger | --no-wait-for-debugger]
                      [--debugger-in-tmux-pane | --no-debugger-in-tmux-pane] [--gdb-random-port | --no-gdb-random-port]
-                     [--run-under-gdb | --no-run-under-gdb] [--test-ssh-key TEST-SSH-KEY]
+                     [--run-under-gdb | --no-run-under-gdb]
+                     [--emulate-usb-input-devices | --no-emulate-usb-input-devices] [--test-ssh-key TEST-SSH-KEY]
                      [--use-minimal-benchmark-kernel | --no-use-minimal-benchmark-kernel] [--test-extra-args ARGS]
                      [--interact-after-tests] [--test-environment-only] [--test-ld-preload TEST-LD-PRELOAD]
                      [--benchmark-fpga-extra-args ARGS] [--benchmark-clean-boot | --no-benchmark-clean-boot]
@@ -647,6 +648,8 @@ Configuration for launching QEMU (and other simulators):
   --run-under-gdb, --no-run-under-gdb
                         Run tests/benchmarks under GDB. Note: currently most targets ignore this flag. (default:
                         'False')
+  --emulate-usb-input-devices, --no-emulate-usb-input-devices
+                        Emulate USB keyboard+mouse in QEMU (default: 'True')
 
 FreeBSD and CheriBSD build configuration:
   --skip-world, --no-skip-world, --skip-buildworld, --no-skip-buildworld

--- a/pycheribuild/boot_cheribsd/__init__.py
+++ b/pycheribuild/boot_cheribsd/__init__.py
@@ -771,7 +771,7 @@ def boot_cheribsd(qemu_options: QemuOptions, qemu_command: typing.Optional[Path]
     qemu_args = qemu_options.get_commandline(qemu_command=qemu_command, kernel_file=kernel_image, disk_image=disk_image,
                                              bios_args=bios_args, user_network_args=user_network_args,
                                              write_disk_image_changes=write_disk_image_changes,
-                                             add_network_device=True,
+                                             add_network_device=True, add_usb_input=True,
                                              trap_on_unrepresentable=trap_on_unrepresentable,  # For debugging
                                              add_virtio_rng=True  # faster entropy gathering
                                              )

--- a/pycheribuild/config/chericonfig.py
+++ b/pycheribuild/config/chericonfig.py
@@ -322,6 +322,8 @@ class CheriConfig(ConfigBase):
         self.run_under_gdb = loader.add_bool_option("run-under-gdb", group=loader.run_group,
                                                     help="Run tests/benchmarks under GDB. Note: currently most "
                                                          "targets ignore this flag.")
+        self.emulate_usb_input_devices = loader.add_bool_option("emulate-usb-input-devices", group=loader.run_group,
+                                                                default=True, help="Emulate USB keyboard+mouse in QEMU")
 
         # Test options:
         self.test_ssh_key = loader.add_path_option("test-ssh-key", default=None, group=loader.tests_group,

--- a/pycheribuild/projects/run_qemu.py
+++ b/pycheribuild/projects/run_qemu.py
@@ -308,7 +308,8 @@ class LaunchQEMUBase(SimpleProject):
                                                          user_network_args=user_network_options,
                                                          trap_on_unrepresentable=self.config.trap_on_unrepresentable,
                                                          debugger_on_cheri_trap=self.config.debugger_on_cheri_trap,
-                                                         add_virtio_rng=self._add_virtio_rng)
+                                                         add_virtio_rng=self._add_virtio_rng,
+                                                         add_usb_input=self.config.emulate_usb_input_devices)
         qemu_command += self._project_specific_options + self._after_disk_options + monitor_options
         qemu_command += logfile_options + self.extra_qemu_options + virtfs_args
         self.info("About to run QEMU with image", self.disk_image, "and loader/kernel", qemu_loader_or_kernel)

--- a/pycheribuild/qemu_utils.py
+++ b/pycheribuild/qemu_utils.py
@@ -154,7 +154,7 @@ class QemuOptions:
 
     def get_commandline(self, *, qemu_command=None, kernel_file: Path = None, disk_image: Path = None,
                         disk_image_format: str = "raw", user_network_args: str = "", add_network_device=True,
-                        bios_args: "typing.List[str]" = None, trap_on_unrepresentable=False,
+                        bios_args: "typing.List[str]" = None, trap_on_unrepresentable=False, add_usb_input: bool,
                         debugger_on_cheri_trap=False, add_virtio_rng=False, write_disk_image_changes=True,
                         gui_options: "typing.List[str]" = None) -> "typing.List[str]":
         if qemu_command is None:
@@ -185,6 +185,10 @@ class QemuOptions:
             result.extend(self.user_network_args(user_network_args))
         if add_virtio_rng:
             result.extend(["-device", "virtio-rng-pci"])
+        if add_usb_input:
+            # Add USB input devices instead of the default PS/2. This ensures that the USB kernel setup logic
+            # in CheriBSD is tested during CI runs.
+            result.extend(["-device", "qemu-xhci", "-device", "usb-mouse", "-device", "usb-kbd"])
         return result
 
 


### PR DESCRIPTION
This previously triggered a panic in the purecap kernel, so adding those
devices seems like a good idea for CI purposes.