### PR TITLE
Support RISCV CheriOS

### DIFF
--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -1081,6 +1081,7 @@ class CompilationTargets(BasicCompilationTargets):
     CHERIBSD_X86_64 = CrossCompileTarget("amd64", CPUArchitecture.X86_64, CheriBSDTargetInfo)
 
     CHERIOS_MIPS_PURECAP = CrossCompileTarget("mips", CPUArchitecture.MIPS64, CheriOSTargetInfo, is_cheri_purecap=True)
+    CHERIOS_RISCV_PURECAP = CrossCompileTarget("riscv64", CPUArchitecture.RISCV64, CheriOSTargetInfo, is_cheri_purecap=True)
 
     # Baremetal targets
     BAREMETAL_NEWLIB_MIPS64 = CrossCompileTarget("mips64", CPUArchitecture.MIPS64, NewlibBaremetalTargetInfo)

--- a/pycheribuild/projects/build_qemu.py
+++ b/pycheribuild/projects/build_qemu.py
@@ -342,22 +342,3 @@ class BuildMorelloQEMU(BuildQEMU):
             raise ValueError("Invalid xtarget" + str(xtarget))
         return caller.config.morello_qemu_bindir / os.getenv("QEMU_MORELLO_PATH", binary_name)
 
-
-class BuildCheriOSQEMU(BuildQEMU):
-    repository = GitRepository("https://github.com/CTSRD-CHERI/qemu.git", default_branch="qemu-cheri",
-                               force_branch=True)
-    default_targets = "cheri128-softmmu"
-    target = "cherios-qemu"
-    _default_install_dir_fn = ComputedDefaultValue(
-        function=lambda config, project: config.output_root / "cherios-sdk",
-        as_string="$INSTALL_ROOT/cherios-sdk")
-    hide_options_from_help = True
-
-    def __init__(self, config: CheriConfig):
-        super().__init__(config)
-
-    @classmethod
-    def qemu_binary(cls, caller: SimpleProject, _=None):
-        binary_name = "qemu-system-cheri" + caller.config.mips_cheri_bits_str
-        return cls.get_instance(caller, caller.config,
-                                cross_target=CompilationTargets.NATIVE).install_dir / "bin" / binary_name

--- a/pycheribuild/projects/cherios.py
+++ b/pycheribuild/projects/cherios.py
@@ -38,17 +38,16 @@ class BuildCheriOS(CMakeProject):
     default_build_type = BuildType.DEBUG
     repository = GitRepository("https://github.com/CTSRD-CHERI/cherios.git", default_branch="master")
     _default_install_dir_fn = ComputedDefaultValue(
-        function=lambda config, cls: config.output_root / ("cherios" + config.mips_cheri_bits_str),
+        function=lambda config, cls: config.output_root / ("cherios" + cls._xtarget.build_suffix(config,include_os=False)),
         as_string="<OUTPUT_ROOT>/cherios128")
     needs_sysroot = False
-    supported_architectures = [CompilationTargets.CHERIOS_MIPS_PURECAP]
+    supported_architectures = [CompilationTargets.CHERIOS_MIPS_PURECAP, CompilationTargets.CHERIOS_RISCV_PURECAP]
 
     @classmethod
     def setup_config_options(cls, **kwargs):
         super().setup_config_options(**kwargs)
         cls.smp_cores = cls.add_config_option("smp-cores", default=1, kind=int)
         cls.build_net = cls.add_bool_option("build-net", default=False)
-
     def __init__(self, config: CheriConfig):
         super().__init__(config)
         self.add_cmake_options(CHERI_SDK_DIR=self.target_info.sdk_root_dir)
@@ -57,6 +56,6 @@ class BuildCheriOS(CMakeProject):
         self.add_cmake_options(SMP_CORES=self.smp_cores)
         self.add_cmake_options(CMAKE_AR=self.sdk_bindir / "llvm-ar")
         self.add_cmake_options(CMAKE_RANLIB=self.sdk_bindir / "llvm-ranlib")
-
+        self.add_cmake_options(PLATFORM=self._xtarget.base_target_suffix)
     def install(self, **kwargs):
         pass  # nothing to install yet

--- a/pycheribuild/projects/cross/llvm.py
+++ b/pycheribuild/projects/cross/llvm.py
@@ -589,7 +589,7 @@ class BuildCheriOSLLVM(BuildLLVMMonoRepoBase):
     hide_options_from_help = True
 
     def configure(self, **kwargs):
-        self.add_cmake_options(LLVM_TARGETS_TO_BUILD="Mips;host")
+        self.add_cmake_options(LLVM_TARGETS_TO_BUILD="RISCV;Mips;host")
         super().configure(**kwargs)
 
     @classmethod

--- a/pycheribuild/projects/run_qemu.py
+++ b/pycheribuild/projects/run_qemu.py
@@ -35,7 +35,7 @@ import sys
 import typing
 from pathlib import Path
 
-from .build_qemu import BuildCheriOSQEMU, BuildMorelloQEMU, BuildQEMU
+from .build_qemu import BuildMorelloQEMU, BuildQEMU
 from .cherios import BuildCheriOS
 from .cross.cheribsd import BuildCHERIBSD, BuildCheriBsdMfsKernel, BuildFreeBSD, ConfigPlatform, KernelABI
 from .cross.freertos import BuildFreeRTOS
@@ -587,8 +587,8 @@ class LaunchCheriBSD(_RunMultiArchFreeBSDImage):
 
 class LaunchCheriOSQEMU(LaunchQEMUBase):
     target = "run-cherios"
-    dependencies = ["cherios-qemu", "cherios"]
-    supported_architectures = [CompilationTargets.CHERIOS_MIPS_PURECAP]
+    dependencies = ["qemu", "cherios"]
+    supported_architectures = [CompilationTargets.CHERIOS_MIPS_PURECAP, CompilationTargets.CHERIOS_RISCV_PURECAP]
     forward_ssh_port = False
     qemu_user_networking = False
     hide_options_from_help = True
@@ -621,7 +621,7 @@ class LaunchCheriOSQEMU(LaunchQEMUBase):
 
     def setup(self):
         super().setup()
-        self.qemu_binary = BuildCheriOSQEMU.qemu_binary(self)
+        self.qemu_binary = BuildQEMU.qemu_cheri_binary(self)
 
     def process(self):
         if not self.disk_image.exists():


### PR DESCRIPTION
Add a CheriOS RISCV target cross compile target and have it be supported for cherios and run-cherios targets. I also deleted the CheriOS qemu target because it is no longer needed.