### PR TITLE
Introduce bsd-user-qemu  and run-{shell,user}-riscv64-purecap targets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,9 @@ For the `cheribsd`, `disk-image` and `run` targets the hybrid vs purecap distinc
 #### Other targets
 - `freebsd-<architecture>` builds and installs [freebsd/freebsd](https://github.com/freebsd/freebsd).
 - `disk-image-freebsd-<architecture>` creates a FreeBSD disk-image.
-- `run-<architecture>-shell` launches a shell with the QEMU user mode in a CheriBSD sysroot.
 - `run-freebsd-<architecture>` launches QEMU with the FreeBSD disk image.
+- `run-shell-<architecture>` launches a shell with the QEMU user mode in a CheriBSD sysroot.
+- `run-user-<architecture>` launches a command with the QEMU user mode in a CheriBSD sysroot.
 - `cmake` builds and installs latest [CMake](https://github.com/Kitware/CMake)
 - `cherios` builds and installs [CTSRD-CHERI/cherios](https://github.com/CTSRD-CHERI/cherios)
 - `cheritrace` builds and installs [CTSRD-CHERI/cheritrace](https://github.com/CTSRD-CHERI/cheritrace)

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ For the `cheribsd`, `disk-image` and `run` targets the hybrid vs purecap distinc
 #### Other targets
 - `freebsd-<architecture>` builds and installs [freebsd/freebsd](https://github.com/freebsd/freebsd).
 - `disk-image-freebsd-<architecture>` creates a FreeBSD disk-image.
+- `run-<architecture>-shell` launches a shell with the QEMU user mode in a CheriBSD sysroot.
 - `run-freebsd-<architecture>` launches QEMU with the FreeBSD disk image.
 - `cmake` builds and installs latest [CMake](https://github.com/Kitware/CMake)
 - `cherios` builds and installs [CTSRD-CHERI/cherios](https://github.com/CTSRD-CHERI/cherios)

--- a/pycheribuild/boot_cheribsd/__init__.py
+++ b/pycheribuild/boot_cheribsd/__init__.py
@@ -768,7 +768,7 @@ def boot_cheribsd(qemu_options: QemuOptions, qemu_command: typing.Optional[Path]
         bios_args = riscv_bios_arguments(qemu_options.xtarget, None)
     else:
         bios_args = []
-    qemu_args = qemu_options.get_commandline(qemu_command=qemu_command, kernel_file=kernel_image, disk_image=disk_image,
+    qemu_args = qemu_options.get_system_commandline(qemu_command=qemu_command, kernel_file=kernel_image, disk_image=disk_image,
                                              bios_args=bios_args, user_network_args=user_network_args,
                                              write_disk_image_changes=write_disk_image_changes,
                                              add_network_device=True,

--- a/pycheribuild/config/chericonfig.py
+++ b/pycheribuild/config/chericonfig.py
@@ -289,6 +289,7 @@ class CheriConfig(ConfigBase):
         self.build_root = None  # type: Optional[Path]
         # Path to kernel/disk images (this is the same as output_root by default but different in Jenkins)
         self.cheribsd_image_root = None  # type: Optional[Path]
+        self.bsd_user_sdk_dir = None  # type: Optional[Path]
         self.cheri_sdk_dir = None  # type: Optional[Path]
         self.morello_sdk_dir = None  # type: Optional[Path]
         self.other_tools_dir = None  # type: Optional[Path]
@@ -490,12 +491,20 @@ class CheriConfig(ConfigBase):
         return str(self.mips_cheri_bits)
 
     @property
+    def default_bsd_user_sdk_directory_name(self) -> str:
+        return "bsd-user-sdk"
+
+    @property
     def default_cheri_sdk_directory_name(self) -> str:
         return "sdk"
 
     @property
     def default_morello_sdk_directory_name(self) -> str:
         return "morello-sdk"
+
+    @property
+    def bsd_user_sdk_bindir(self):
+        return self.bsd_user_sdk_dir / "bin"
 
     @property
     def cheri_sdk_bindir(self):
@@ -508,6 +517,10 @@ class CheriConfig(ConfigBase):
     @property
     def qemu_bindir(self):
         return self.cheri_sdk_bindir
+
+    @property
+    def bsd_user_qemu_bindir(self):
+        return self.bsd_user_sdk_bindir
 
     @property
     def morello_qemu_bindir(self):

--- a/pycheribuild/config/defaultconfig.py
+++ b/pycheribuild/config/defaultconfig.py
@@ -155,6 +155,7 @@ class DefaultCheriConfig(CheriConfig):
         self.preferred_xtarget = None
         # now set some generic derived config options
         self.cheri_sdk_dir = self.tools_root / self.default_cheri_sdk_directory_name
+        self.bsd_user_sdk_dir = self.tools_root / self.default_bsd_user_sdk_directory_name
         self.other_tools_dir = self.tools_root / "bootstrap"
         self.cheribsd_image_root = self.output_root  # TODO: allow this to be different?
 

--- a/pycheribuild/config/jenkinsconfig.py
+++ b/pycheribuild/config/jenkinsconfig.py
@@ -143,6 +143,9 @@ class JenkinsConfig(CheriConfig):
             help="Don't use the CHERI SDK -> only /usr (for native builds)")
         self.strip_elf_files = loader.add_commandline_only_bool_option(
             "strip-elf-files", help="Strip ELF files before creating the tarball", default=True, negatable=True)
+        self._bsd_user_sdk_dir_override = loader.add_commandline_only_option(
+            "bsd-user-sdk-path", default=None, type=Path,
+            help="Override the path to the BSD user mode SDK (default is $WORKSPACE/bsd-user-sdk)")  # type: Path
         self._cheri_sdk_dir_override = loader.add_commandline_only_option(
             "cheri-sdk-path", default=None, type=Path,
             help="Override the path to the CHERI SDK (default is $WORKSPACE/cherisdk)")  # type: Path
@@ -209,6 +212,23 @@ class JenkinsConfig(CheriConfig):
         return self.workspace / ("qemu-" + os_suffix) / "bin"
 
     @property
+    def bsd_user_qemu_bindir(self):
+        for i in self.bsd_user_sdk_bindir.glob("qemu-*"):
+            if self.verbose:
+                print("Found QEMU binary", i, "in BSD user-mode SDK dir -> using that for BSD user-mode QEMU binaries")
+            # If one qemu-foo exists in the bsd_user_sdk_bindir use that instead of $WORKSPACE/qemu-<OS>
+            return self.bsd_user_sdk_bindir
+        if OSInfo.IS_LINUX:
+            os_suffix = "linux"
+        elif OSInfo.IS_FREEBSD:
+            os_suffix = "freebsd"
+        elif OSInfo.IS_MAC:
+            os_suffix = "mac"
+        else:
+            os_suffix = "unknown-os"
+        return self.workspace / ("qemu-" + os_suffix) / "bin"
+
+    @property
     def morello_qemu_bindir(self):
         for i in self.morello_sdk_bindir.glob("qemu-system-*"):
             if self.verbose:
@@ -247,6 +267,11 @@ class JenkinsConfig(CheriConfig):
         self.cheribsd_image_root = self.workspace
 
         self.other_tools_dir = self.workspace / "bootstrap"
+
+        if self._bsd_user_sdk_dir_override is not None:
+            self.bsd_user_sdk_dir = self._bsd_user_sdk_dir_override
+        else:
+            self.bsd_user_sdk_dir = self.workspace / self.default_bsd_user_sdk_directory_name
 
         if self._cheri_sdk_dir_override is not None:
             self.cheri_sdk_dir = self._cheri_sdk_dir_override
@@ -298,6 +323,8 @@ class JenkinsConfig(CheriConfig):
                 self.clang_plusplus_path = compiler_dir_override / "clang++"
                 self.clang_cpp_path = compiler_dir_override / "clang-cpp"
 
+        if self._bsd_user_sdk_dir_override is not None:
+            assert self.bsd_user_sdk_bindir == self._bsd_user_sdk_dir_override / "bin"
         if self._cheri_sdk_dir_override is not None:
             assert self.cheri_sdk_bindir == self._cheri_sdk_dir_override / "bin"
         if self._morello_sdk_dir_override is not None:

--- a/pycheribuild/projects/build_qemu.py
+++ b/pycheribuild/projects/build_qemu.py
@@ -326,14 +326,17 @@ class BuildBsdUserQEMU(BuildQEMU):
     hide_options_from_help = True
 
     @classmethod
-    def qemu_cheri_binary(cls, caller: SimpleProject, xtarget: CrossCompileTarget = None):
+    def qemu_cheri_binary(cls, caller: SimpleProject, xtarget: CrossCompileTarget = None, absolute_path=True):
         if xtarget is None:
             xtarget = caller.get_crosscompile_target(caller.config)
         if xtarget.is_riscv(include_purecap=True):
             binary_name = "qemu-riscv64cheri"
         else:
             raise ValueError("Invalid xtarget" + str(xtarget))
-        return caller.config.bsd_user_qemu_bindir / os.getenv("QEMU_BSD_USER_PATH", binary_name)
+        if absolute_path:
+            return caller.config.bsd_user_qemu_bindir / os.getenv("QEMU_BSD_USER_PATH", binary_name)
+        else:
+            return binary_name
 
     def setup(self):
         super().setup()

--- a/pycheribuild/projects/build_qemu.py
+++ b/pycheribuild/projects/build_qemu.py
@@ -50,6 +50,7 @@ class BuildQEMUBase(AutotoolsProject):
     can_build_with_asan = True
     default_targets = "some-invalid-target"
     default_build_type = BuildType.RELEASE
+    default_use_smbd = True
     lto_by_default = True
 
     @classmethod
@@ -65,7 +66,7 @@ class BuildQEMUBase(AutotoolsProject):
     @classmethod
     def setup_config_options(cls, **kwargs):
         super().setup_config_options(**kwargs)
-        cls.use_smbd = cls.add_bool_option("use-smbd", show_help=False, default=True,
+        cls.use_smbd = cls.add_bool_option("use-smbd", show_help=False, default=cls.default_use_smbd,
                                            help="Don't require SMB support when building QEMU (warning: most --test "
                                                 "targets will fail without smbd support)")
 
@@ -312,6 +313,36 @@ class BuildQEMU(BuildQEMUBase):
                 "--cross-cc-cflags-riscv64=" + self.commandline_to_str(
                     tgt_info_riscv64.get_essential_compiler_and_linker_flags()).replace("=", " ")
             ])
+
+
+class BuildBsdUserQEMU(BuildQEMU):
+    repository = GitRepository("https://github.com/CTSRD-CHERI/qemu.git",
+                               default_branch="qemu-cheri-bsd-user",
+                               force_branch=True)
+    native_install_dir = DefaultInstallDir.BSD_USER_SDK
+    default_targets = "riscv64cheri-bsd-user"
+    default_use_smbd = False
+    target = "bsd-user-qemu"
+    hide_options_from_help = True
+
+    @classmethod
+    def qemu_cheri_binary(cls, caller: SimpleProject, xtarget: CrossCompileTarget = None):
+        if xtarget is None:
+            xtarget = caller.get_crosscompile_target(caller.config)
+        if xtarget.is_riscv(include_purecap=True):
+            binary_name = "qemu-riscv64cheri"
+        else:
+            raise ValueError("Invalid xtarget" + str(xtarget))
+        return caller.config.bsd_user_qemu_bindir / os.getenv("QEMU_BSD_USER_PATH", binary_name)
+
+    def setup(self):
+        super().setup()
+        # Disable RVFI-DDI unsupported in the user mode.
+        self.configure_args.append("--disable-rvfi-dii")
+        # Enable to build BSD user mode targets.
+        self.configure_args.append("--enable-bsd-user")
+        # Build a static binary that can be easily included in a guest jail.
+        self.configure_args.append("--static")
 
 
 class BuildMorelloQEMU(BuildQEMU):

--- a/pycheribuild/projects/project.py
+++ b/pycheribuild/projects/project.py
@@ -2043,6 +2043,7 @@ class DefaultInstallDir(Enum):
     KDE_PREFIX = "The sysroot for this target (<rootfs>/opt/<arch>/kde by default)"
     COMPILER_RESOURCE_DIR = "The compiler resource directory"
     CHERI_SDK = "The CHERI SDK directory"
+    BSD_USER_SDK = "The QEMU BSD user mode SDK directory"
     MORELLO_SDK = "The Morello SDK directory"
     BOOTSTRAP_TOOLS = "The bootstap tools directory"
     CUSTOM_INSTALL_DIR = "Custom install directory"
@@ -2087,6 +2088,10 @@ def _default_install_dir_handler(config: CheriConfig, project: "Project") -> Pat
         assert not project.compiling_for_host(), "ROOTFS_LOCALBASE is only a valid install dir for cross-builds, " \
                                                  "use BOOTSTRAP_TOOLS/CUSTOM_INSTALL_DIR/IN_BUILD_DIRECTORY for native"
         return project.sdk_sysroot
+    elif install_dir == DefaultInstallDir.BSD_USER_SDK:
+        assert project.compiling_for_host(), "BSD_USER_SDK is only a valid install dir for native, " \
+                                             "use ROOTFS_LOCALBASE/ROOTFS_OPTBASE for cross"
+        return config.bsd_user_sdk_dir
     elif install_dir == DefaultInstallDir.CHERI_SDK:
         assert project.compiling_for_host(), "CHERI_SDK is only a valid install dir for native, " \
                                              "use ROOTFS_LOCALBASE/ROOTFS_OPTBASE for cross"

--- a/pycheribuild/projects/run_qemu.py
+++ b/pycheribuild/projects/run_qemu.py
@@ -35,7 +35,7 @@ import sys
 import typing
 from pathlib import Path
 
-from .build_qemu import BuildMorelloQEMU, BuildQEMU
+from .build_qemu import BuildBsdUserQEMU, BuildMorelloQEMU, BuildQEMU
 from .cherios import BuildCheriOS
 from .cross.cheribsd import BuildCHERIBSD, BuildCheriBsdMfsKernel, BuildFreeBSD, ConfigPlatform, KernelABI
 from .cross.freertos import BuildFreeRTOS
@@ -45,7 +45,7 @@ from .cross.u_boot import BuildUBoot
 from .disk_image import (BuildCheriBSDDiskImage, BuildDiskImageBase, BuildFreeBSDImage,
                          BuildFreeBSDWithDefaultOptionsDiskImage, BuildMinimalCheriBSDDiskImage)
 from .project import CheriConfig, CPUArchitecture, SimpleProject, TargetAliasWithDependencies
-from ..config.compilation_targets import CompilationTargets
+from ..config.compilation_targets import CompilationTargets, CrossCompileTarget
 from ..config.loader import ComputedDefaultValue
 from ..qemu_utils import qemu_supports_9pfs, QemuOptions, riscv_bios_arguments
 from ..targets import target_manager
@@ -299,7 +299,7 @@ class LaunchQEMUBase(SimpleProject):
             self._after_disk_options += ["-snapshot"]
 
         # input("Press enter to continue")
-        qemu_command = self.qemu_options.get_commandline(qemu_command=self.qemu_binary,
+        qemu_command = self.qemu_options.get_system_commandline(qemu_command=self.qemu_binary,
                                                          kernel_file=qemu_loader_or_kernel,
                                                          disk_image=self.disk_image,
                                                          disk_image_format=self.disk_image_format,
@@ -426,6 +426,41 @@ class LaunchQEMUBase(SimpleProject):
                 return True
         except OSError:
             return False
+
+
+class LaunchBsdUserQEMUBase(SimpleProject):
+    do_not_add_to_targets = True
+
+    @classmethod
+    def setup_config_options(cls, default_ssh_port: int = None, **kwargs):
+        super().setup_config_options(**kwargs)
+
+    def __init__(self, config: CheriConfig):
+        super().__init__(config)
+        self.qemu_binary = None  # type: typing.Optional[Path]
+        self.qemu_options = QemuOptions(self.crosscompile_target, is_system_mode=False)
+        self.rootfs_path = None  # type:typing.Optional[Path]
+
+    def setup(self):
+        super().setup()
+        xtarget = self.crosscompile_target
+        if xtarget.is_riscv(include_purecap=True):
+            self.qemu_binary = BuildBsdUserQEMU.qemu_cheri_binary(self)
+        else:
+            assert False, "Unknown target " + str(xtarget)
+
+    def process(self):
+        assert self.qemu_binary is not None
+        if not self.qemu_binary.exists():
+            self.dependency_error("QEMU is missing:", self.qemu_binary, cheribuild_target="qemu")
+
+        program = "{}{}".format(self.rootfs_path, "/bin/sh")
+        qemu_command = self.qemu_options.get_user_commandline(qemu_command=self.qemu_binary,
+                rootfs_path=self.rootfs_path, program=program)
+
+        self.info("About to run '{}' with the QEMU user mode".format(program))
+
+        self.run_cmd(qemu_command, stdout=sys.stdout, stderr=sys.stderr, give_tty_control=True)
 
 
 class AbstractLaunchFreeBSD(LaunchQEMUBase):
@@ -582,6 +617,28 @@ class LaunchCheriBSD(_RunMultiArchFreeBSDImage):
         xtarget = cls.get_crosscompile_target(config)
         if xtarget.is_hybrid_or_purecap_cheri([CPUArchitecture.RISCV64]):
             result.append("bbl-baremetal-riscv64-purecap")
+        return result
+
+
+class LaunchCheriBSDShell(LaunchBsdUserQEMUBase):
+    target = "run"
+    _source_class = BuildCHERIBSD
+    _freebsd_class = BuildCHERIBSD
+    _always_add_suffixed_targets = True
+    supported_architectures = [CompilationTargets.CHERIBSD_RISCV_PURECAP]
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.rootfs_path = self._source_class.get_rootfs_dir(self, config=config)
+
+    @staticmethod
+    def custom_target_name(base_target: str, xtarget: CrossCompileTarget) -> str:
+        return base_target + '-' + xtarget.generic_target_suffix + '-shell'
+
+    @classmethod
+    def dependencies(cls: "typing.Type[_RunMultiArchFreeBSDImage]", config: CheriConfig) -> "list[str]":
+        xtarget = cls.get_crosscompile_target(config)
+        result = ["bsd-user-qemu", cls._source_class.get_class_for_target(xtarget).target]
         return result
 
 

--- a/pycheribuild/projects/run_qemu.py
+++ b/pycheribuild/projects/run_qemu.py
@@ -443,24 +443,45 @@ class LaunchBsdUserQEMUBase(SimpleProject):
 
     def setup(self):
         super().setup()
+        absolute_path = not self.chroot and not self.jail
         xtarget = self.crosscompile_target
         if xtarget.is_riscv(include_purecap=True):
-            self.qemu_binary = BuildBsdUserQEMU.qemu_cheri_binary(self)
+            self.qemu_binary = BuildBsdUserQEMU.qemu_cheri_binary(self, absolute_path=absolute_path)
         else:
             assert False, "Unknown target " + str(xtarget)
 
     def process(self):
         assert self.qemu_binary is not None
-        if not self.qemu_binary.exists():
-            self.dependency_error("QEMU is missing:", self.qemu_binary, cheribuild_target="qemu")
+        assert self.rootfs_path is not None
 
-        program = "{}{}".format(self.rootfs_path, "/bin/sh")
-        qemu_command = self.qemu_options.get_user_commandline(qemu_command=self.qemu_binary,
-                rootfs_path=self.rootfs_path, program=program)
+        if self.chroot and self.jail:
+            self.fatal("Chroot and jail options are mutually exclusive.")
+        elif self.chroot:
+            command = ["chroot", self.rootfs_path]
+            qemu_command = self.qemu_binary
+            rootfs_path = None
+        elif self.jail:
+            command = ["jail", "-c", "path={}".format(self.rootfs_path)]
+            qemu_command = "command={}".format(self.qemu_binary)
+            rootfs_path = None
+        else:
+            command = []
+            qemu_command = self.qemu_binary
+            rootfs_path = self.rootfs_path
 
-        self.info("About to run '{}' with the QEMU user mode".format(program))
+        if self.command:
+            user_command = self.command
+        elif rootfs_path:
+            user_command = ["{}{}".format(rootfs_path, "/bin/sh")]
+        else:
+            user_command = ["sh"]
 
-        self.run_cmd(qemu_command, stdout=sys.stdout, stderr=sys.stderr, give_tty_control=True)
+        command.extend(self.qemu_options.get_user_commandline(qemu_command=qemu_command,
+                rootfs_path=rootfs_path, user_command=user_command))
+
+        self.info("About to run '{}' with the QEMU user mode".format(" ".join(user_command)))
+
+        self.run_cmd(command, stdout=sys.stdout, stderr=sys.stderr, give_tty_control=True)
 
 
 class AbstractLaunchFreeBSD(LaunchQEMUBase):
@@ -620,8 +641,8 @@ class LaunchCheriBSD(_RunMultiArchFreeBSDImage):
         return result
 
 
-class LaunchCheriBSDShell(LaunchBsdUserQEMUBase):
-    target = "run"
+class AbstractLaunchFreeBSDProgram(LaunchBsdUserQEMUBase):
+    do_not_add_to_targets = True
     _source_class = BuildCHERIBSD
     _freebsd_class = BuildCHERIBSD
     _always_add_suffixed_targets = True
@@ -631,9 +652,17 @@ class LaunchCheriBSDShell(LaunchBsdUserQEMUBase):
         super().__init__(config)
         self.rootfs_path = self._source_class.get_rootfs_dir(self, config=config)
 
+    @classmethod
+    def setup_config_options(cls, **kwargs):
+        super().setup_config_options(**kwargs)
+        cls.chroot = cls.add_bool_option("chroot", default=False, show_help=True,
+                                         help="Change the root directory to a sysroot before executing a command.")
+        cls.jail = cls.add_bool_option("jail", default=False, show_help=True,
+                                       help="Enter a jail with a sysroot before executing a command.")
+
     @staticmethod
     def custom_target_name(base_target: str, xtarget: CrossCompileTarget) -> str:
-        return base_target + '-' + xtarget.generic_target_suffix + '-shell'
+        return "run-{}-{}".format(xtarget.generic_target_suffix, base_target)
 
     @classmethod
     def dependencies(cls: "typing.Type[_RunMultiArchFreeBSDImage]", config: CheriConfig) -> "list[str]":
@@ -641,6 +670,23 @@ class LaunchCheriBSDShell(LaunchBsdUserQEMUBase):
         result = ["bsd-user-qemu", cls._source_class.get_class_for_target(xtarget).target]
         return result
 
+
+class LaunchCheriBSDShell(AbstractLaunchFreeBSDProgram):
+    target = "shell"
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.command = None
+
+
+class LaunchCheriBSDExec(AbstractLaunchFreeBSDProgram):
+    target = "exec"
+
+    @classmethod
+    def setup_config_options(cls, **kwargs):
+        super().setup_config_options(**kwargs)
+        cls.command = cls.add_config_option("command", metavar="COMMAND", show_help=True, kind=list,
+                                            help="Command to execute.")
 
 class LaunchCheriOSQEMU(LaunchQEMUBase):
     target = "run-cherios"

--- a/pycheribuild/projects/run_qemu.py
+++ b/pycheribuild/projects/run_qemu.py
@@ -660,10 +660,6 @@ class AbstractLaunchFreeBSDProgram(LaunchBsdUserQEMUBase):
         cls.jail = cls.add_bool_option("jail", default=False, show_help=True,
                                        help="Enter a jail with a sysroot before executing a command.")
 
-    @staticmethod
-    def custom_target_name(base_target: str, xtarget: CrossCompileTarget) -> str:
-        return "run-{}-{}".format(xtarget.generic_target_suffix, base_target)
-
     @classmethod
     def dependencies(cls: "typing.Type[_RunMultiArchFreeBSDImage]", config: CheriConfig) -> "list[str]":
         xtarget = cls.get_crosscompile_target(config)
@@ -672,7 +668,7 @@ class AbstractLaunchFreeBSDProgram(LaunchBsdUserQEMUBase):
 
 
 class LaunchCheriBSDShell(AbstractLaunchFreeBSDProgram):
-    target = "shell"
+    target = "run-shell"
 
     def __init__(self, config):
         super().__init__(config)
@@ -680,7 +676,7 @@ class LaunchCheriBSDShell(AbstractLaunchFreeBSDProgram):
 
 
 class LaunchCheriBSDExec(AbstractLaunchFreeBSDProgram):
-    target = "exec"
+    target = "run-user"
 
     @classmethod
     def setup_config_options(cls, **kwargs):

--- a/pycheribuild/projects/run_qemu.py
+++ b/pycheribuild/projects/run_qemu.py
@@ -462,6 +462,8 @@ class LaunchBsdUserQEMUBase(SimpleProject):
             rootfs_path = None
         elif self.jail:
             command = ["jail", "-c", "path={}".format(self.rootfs_path)]
+            if self.jail_extra_args:
+                command.extend(self.jail_extra_args)
             qemu_command = "command={}".format(self.qemu_binary)
             rootfs_path = None
         else:
@@ -659,6 +661,8 @@ class AbstractLaunchFreeBSDProgram(LaunchBsdUserQEMUBase):
                                          help="Change the root directory to a sysroot before executing a command.")
         cls.jail = cls.add_bool_option("jail", default=False, show_help=True,
                                        help="Enter a jail with a sysroot before executing a command.")
+        cls.jail_extra_args = cls.add_config_option("jail-extra-args", metavar="ARGS", kind=list, show_help=True,
+                                                    help="Extra jail parameters to pass to jail(8).")
 
     @classmethod
     def dependencies(cls: "typing.Type[_RunMultiArchFreeBSDImage]", config: CheriConfig) -> "list[str]":

--- a/pycheribuild/qemu_utils.py
+++ b/pycheribuild/qemu_utils.py
@@ -191,12 +191,12 @@ class QemuOptions:
             result.extend(["-device", "virtio-rng-pci"])
         return result
 
-    def get_user_commandline(self, *, qemu_command=None, rootfs_path: Path = None, program: Path =None):
+    def get_user_commandline(self, *, qemu_command=None, rootfs_path: Path = None, user_command: Path = None):
         result = self.get_common_commandline(qemu_command=qemu_command)
         if rootfs_path:
             result.extend(["-L", rootfs_path])
-        if program:
-            result.append(program)
+        if user_command:
+            result.extend(user_command)
         return result
 
 

--- a/pycheribuild/qemu_utils.py
+++ b/pycheribuild/qemu_utils.py
@@ -39,7 +39,8 @@ from .utils import OSInfo, warning_message
 
 
 class QemuOptions:
-    def __init__(self, xtarget: CrossCompileTarget, want_debugger=False):
+    def __init__(self, xtarget: CrossCompileTarget, want_debugger=False,
+            is_system_mode=True):
         self.xtarget = xtarget
         self.virtio_disk = True
         self.force_virtio_blk_device = False
@@ -152,14 +153,17 @@ class QemuOptions:
         found_in_path = shutil.which("qemu-system-" + self.qemu_arch_sufffix)
         return Path(found_in_path) if found_in_path is not None else None
 
-    def get_commandline(self, *, qemu_command=None, kernel_file: Path = None, disk_image: Path = None,
+    def get_common_commandline(self, *, qemu_command=None):
+        if qemu_command is None:
+            qemu_command = self.get_qemu_binary()
+        return [str(qemu_command)]
+
+    def get_system_commandline(self, *, qemu_command=None, kernel_file: Path = None, disk_image: Path = None,
                         disk_image_format: str = "raw", user_network_args: str = "", add_network_device=True,
                         bios_args: "typing.List[str]" = None, trap_on_unrepresentable=False,
                         debugger_on_cheri_trap=False, add_virtio_rng=False, write_disk_image_changes=True,
                         gui_options: "typing.List[str]" = None) -> "typing.List[str]":
-        if qemu_command is None:
-            qemu_command = self.get_qemu_binary()
-        result = [str(qemu_command)]
+        result = self.get_common_commandline()
         result.extend(self.machine_flags)
         result.extend(["-m", self.memory_size])
         if gui_options is None:
@@ -185,6 +189,14 @@ class QemuOptions:
             result.extend(self.user_network_args(user_network_args))
         if add_virtio_rng:
             result.extend(["-device", "virtio-rng-pci"])
+        return result
+
+    def get_user_commandline(self, *, qemu_command=None, rootfs_path: Path = None, program: Path =None):
+        result = self.get_common_commandline(qemu_command=qemu_command)
+        if rootfs_path:
+            result.extend(["-L", rootfs_path])
+        if program:
+            result.append(program)
         return result
 
 

--- a/tests/setup_mock_chericonfig.py
+++ b/tests/setup_mock_chericonfig.py
@@ -55,6 +55,7 @@ class MockConfig(CheriConfig):
         self.source_root = source_root
         self.build_root = source_root / "build"
         self.output_root = source_root / "output"
+        self.bsd_user_sdk_dir = self.output_root / "bsd-user-sdk"
         self.cheri_sdk_dir = self.output_root / "sdk"
         self.morello_sdk_dir = self.output_root / "morello-sdk"
         self.sysroot_output_root = self.output_root


### PR DESCRIPTION
The targets use QEMU code from the qemu-cheri-bsd-user branch.

Examples:
* Build the BSD user mode:
    ```
    ./cheribuild.py bsd-user-qemu
    ```
* Run a CheriABI CHERI-RISC-V command:
    ```
    ./cheribuild.py run-user-riscv64-purecap \
        --run-user/command  \
        '/zdata/cheri/output/rootfs-riscv64-purecap/bin/cheribsdtest-purecap-dynamic -a'
    ```
* Run a CheriABI CHERI-RISC-V command with the root directory changed to a sysroot:
    ```
    sudo ./cheribuild.py --allow-running-as-root run-user-riscv64-purecap \
        --run-user/chroot --run-user/command \
        'cheribsdtest-purecap-dynamic -a'
    ```
* Run a CheriABI CHERI-RISC-V shell in a jail with the root directory changed to a sysroot and devfs(8) mounted:
    ```
    sudo ./cheribuild.py --allow-running-as-root run-shell-riscv64-purecap \
        --run-shell/jail --run-shell/jail-extra-args mount.devfs
    ```