### PR TITLE
Add a recipe for Neomutt command line email client

### DIFF
--- a/pycheribuild/projects/cross/neomutt.py
+++ b/pycheribuild/projects/cross/neomutt.py
@@ -24,10 +24,8 @@
 #
 
 from .crosscompileproject import CrossCompileAutotoolsProject
-from .crosscompileproject import CheriConfig, CompilationTargets, CrossCompileProject
+from .crosscompileproject import CheriConfig, CompilationTargets
 from ..project import GitRepository
-from ...config.compilation_targets import CompilationTargets
-
 
 class BuildNeomutt(CrossCompileAutotoolsProject):
     repository = GitRepository("https://github.com/neomutt/neomutt.git")
@@ -44,4 +42,4 @@ class BuildNeomutt(CrossCompileAutotoolsProject):
 
         # enable OpenSSL (in base system), disable internationalisation libs we don't have
         self.configure_args.extend(['--disable-nls', '--disable-idn',
-          '--disable-doc', '--ssl'])
+            '--disable-doc', '--ssl'])

--- a/pycheribuild/projects/cross/neomutt.py
+++ b/pycheribuild/projects/cross/neomutt.py
@@ -30,11 +30,10 @@ from ..project import GitRepository
 
 class BuildNeomutt(CrossCompileAutotoolsProject):
     repository = GitRepository("https://github.com/neomutt/neomutt.git")
-    supported_architectures = CompilationTargets.ALL_FREEBSD_AND_CHERIBSD_TARGETS + [CompilationTargets.NATIVE]
     dependencies = ['libxml2']
 
-    def __init__(self, config: CheriConfig):
-        super().__init__(config)
+    def setup(self):
+        super().setup()
 
         # neomutt's build system doesn't use autotools, it justs pretends to look the same
         # - but it doesn't implement the --target option, so we strip it

--- a/pycheribuild/projects/cross/neomutt.py
+++ b/pycheribuild/projects/cross/neomutt.py
@@ -37,8 +37,7 @@ class BuildNeomutt(CrossCompileAutotoolsProject):
 
         # neomutt's build system doesn't use autotools, it justs pretends to look the same
         # - but it doesn't implement the --target option, so we strip it
-        indices = [i for i, s in enumerate(self.configure_args) if '--target=' in s]
-        self.configure_args.pop(indices[0])
+        self.configure_args[:] = [arg for arg in self.configure_args if not arg.startswith('--target=')]
 
         # enable OpenSSL (in base system), disable internationalisation libs we don't have
         self.configure_args.extend(['--disable-nls', '--disable-idn',

--- a/pycheribuild/projects/cross/neomutt.py
+++ b/pycheribuild/projects/cross/neomutt.py
@@ -24,7 +24,6 @@
 #
 
 from .crosscompileproject import CrossCompileAutotoolsProject
-from .crosscompileproject import CompilationTargets
 from ..project import GitRepository
 
 

--- a/pycheribuild/projects/cross/neomutt.py
+++ b/pycheribuild/projects/cross/neomutt.py
@@ -24,7 +24,7 @@
 #
 
 from .crosscompileproject import CrossCompileAutotoolsProject
-from .crosscompileproject import CheriConfig, CompilationTargets
+from .crosscompileproject import CompilationTargets
 from ..project import GitRepository
 
 

--- a/pycheribuild/projects/cross/neomutt.py
+++ b/pycheribuild/projects/cross/neomutt.py
@@ -27,6 +27,7 @@ from .crosscompileproject import CrossCompileAutotoolsProject
 from .crosscompileproject import CheriConfig, CompilationTargets
 from ..project import GitRepository
 
+
 class BuildNeomutt(CrossCompileAutotoolsProject):
     repository = GitRepository("https://github.com/neomutt/neomutt.git")
     supported_architectures = CompilationTargets.ALL_FREEBSD_AND_CHERIBSD_TARGETS + [CompilationTargets.NATIVE]
@@ -42,4 +43,4 @@ class BuildNeomutt(CrossCompileAutotoolsProject):
 
         # enable OpenSSL (in base system), disable internationalisation libs we don't have
         self.configure_args.extend(['--disable-nls', '--disable-idn',
-            '--disable-doc', '--ssl'])
+                                    '--disable-doc', '--ssl'])

--- a/pycheribuild/projects/cross/neomutt.py
+++ b/pycheribuild/projects/cross/neomutt.py
@@ -31,7 +31,7 @@ from ..project import GitRepository
 class BuildNeomutt(CrossCompileAutotoolsProject):
     repository = GitRepository("https://github.com/neomutt/neomutt.git")
     supported_architectures = CompilationTargets.ALL_FREEBSD_AND_CHERIBSD_TARGETS + [CompilationTargets.NATIVE]
-    dependencies = ['gettext', 'libxml2']
+    dependencies = ['libxml2']
 
     def __init__(self, config: CheriConfig):
         super().__init__(config)

--- a/pycheribuild/projects/cross/neomutt.py
+++ b/pycheribuild/projects/cross/neomutt.py
@@ -1,0 +1,47 @@
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2021 A. Theodore Markettos
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+from .crosscompileproject import CrossCompileAutotoolsProject
+from .crosscompileproject import CheriConfig, CompilationTargets, CrossCompileProject
+from ..project import GitRepository
+from ...config.compilation_targets import CompilationTargets
+
+
+class BuildNeomutt(CrossCompileAutotoolsProject):
+    repository = GitRepository("https://github.com/neomutt/neomutt.git")
+    supported_architectures = CompilationTargets.ALL_FREEBSD_AND_CHERIBSD_TARGETS + [CompilationTargets.NATIVE]
+    dependencies = ['gettext', 'libxml2']
+
+    def __init__(self, config: CheriConfig):
+        super().__init__(config)
+
+        # neomutt's build system doesn't use autotools, it justs pretends to look the same
+        # - but it doesn't implement the --target option, so we strip it
+        indices = [i for i, s in enumerate(self.configure_args) if '--target=' in s]
+        self.configure_args.pop(indices[0])
+
+        # enable OpenSSL (in base system), disable internationalisation libs we don't have
+        self.configure_args.extend(['--disable-nls', '--disable-idn',
+          '--disable-doc', '--ssl'])


### PR DESCRIPTION
This adds basic support for building the Neomutt email client.  Some nice-to-have functionality is not enabled (header caches, SASL, NLS, international domain names) but as-is it's basically usable for talking to IMAP/SMTP servers.

Tested with Fastmail with the following config flags to avoid SASL:
```
set smtp_authenticators="login"
set ssl_starttls = yes
set ssl_force_tls = yes
```