### PR TITLE
Perform python version check earlier

### DIFF
--- a/cheribuild.py
+++ b/cheribuild.py
@@ -37,6 +37,7 @@ import sys
 module_dir = Path(__file__).resolve().parent
 sys.path.append(str(module_dir))
 # noinspection PyPep8
+import pycheribuild.check_version  # noqa
 from pycheribuild.__main__ import main  # "__main__" case  # noqa: E402
 
 main()

--- a/combine-files.py
+++ b/combine-files.py
@@ -121,6 +121,7 @@ def check_all_files_used(directory: Path):
 
 
 # append all the individual files in the right order
+add_filtered_file(script_dir / "check_version.py")
 add_filtered_file(script_dir / "colour.py")
 add_filtered_file(script_dir / "utils.py")
 add_filtered_file(script_dir / "mtree.py")

--- a/jenkins-cheri-build.py
+++ b/jenkins-cheri-build.py
@@ -38,5 +38,6 @@ import sys
 if __name__ == "__main__":
     module_dir = Path(__file__).resolve().parent
     sys.path.append(str(module_dir))
+    import pycheribuild.check_version  # noqa: E402
     import pycheribuild.jenkins
     pycheribuild.jenkins.jenkins_main()

--- a/pycheribuild/check_version.py
+++ b/pycheribuild/check_version.py
@@ -1,0 +1,32 @@
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2022 Lawrence Esswood
+#
+# This work was supported by Innovate UK project 105694, "Digital Security
+# by Design (DSbD) Technology Platform Prototype".
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+import sys
+
+if sys.version_info < (3, 6, 0):
+    sys.exit("This script requires at least Python 3.6.0")

--- a/release-scripts/create_morello_release_tarball.py
+++ b/release-scripts/create_morello_release_tarball.py
@@ -34,6 +34,7 @@ from pathlib import Path
 module_dir = Path(__file__).resolve().parent.parent
 sys.path.append(str(module_dir))
 # noinspection PyProtectedMember
+import pycheribuild.check_version  # noqa
 from pycheribuild.utils import default_make_jobs_count, GlobalConfig, warning_message  # noqa: E402
 from pycheribuild.processutils import run_command  # noqa: E402
 

--- a/tests/test_metalog.py
+++ b/tests/test_metalog.py
@@ -12,6 +12,7 @@ except ImportError:
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).parent.parent))
+import pycheribuild.check_version  # noqa
 from pycheribuild.mtree import MtreeFile  # noqa: E402
 
 HAVE_LCHMOD = True


### PR DESCRIPTION
Thought it would be nice to just have a single file where we bump the version to the maximum of all the requirements we have (that can safely be included first), for at least a couple of the top-level scripts. I left a more permissive noqa rather than noqa: E402 on some of the imports because nothing is actually imported and this would fail another flake8 check.