### PR TITLE
Pass -bios none for CheriOS QEMU

### DIFF
--- a/pycheribuild/projects/run_qemu.py
+++ b/pycheribuild/projects/run_qemu.py
@@ -771,6 +771,10 @@ class LaunchCheriOSQEMU(LaunchQEMUBase):
                 self.run_cmd("dd", "if=/dev/zero", "of=" + str(self.disk_image), size_flag, "count=1")
         super().process()
 
+    def get_riscv_bios_args(self) -> typing.List[str]:
+        # CheriOS bundles its kernel with its own bootloader
+        return ["-bios", "none"]
+
 
 class LaunchRtemsQEMU(LaunchQEMUBase):
     target = "run-rtems"


### PR DESCRIPTION
The eventual plan is combine the CheriOS nanokernel with any firmware
required for a particular platform. As it stands, CheriOS will only run
with this flag.