### PR TITLE
rsync: don't build in source directory

### DIFF
--- a/pycheribuild/projects/cross/rsync.py
+++ b/pycheribuild/projects/cross/rsync.py
@@ -35,7 +35,6 @@ class BuildRsync(CrossCompileAutotoolsProject):
     repository = GitRepository("https://github.com/CTSRD-CHERI/rsync.git")
     native_install_dir = DefaultInstallDir.BOOTSTRAP_TOOLS
     cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
-    build_in_source_dir = True  # Cannot build out-of-source
 
     def configure(self, **kwargs):
         # The rsync check for gettimeofday timzeone argument fails because the prototype for exit is missing (-Werror)


### PR DESCRIPTION
This seems to work fine; tested locally with `rsync-morello-purecap`, `rsync-riscv64-purecap`, and `rsync-native`.