### PR TITLE
openssh: Pass DESTDIR as an argument

### DIFF
--- a/pycheribuild/projects/cross/openssh.py
+++ b/pycheribuild/projects/cross/openssh.py
@@ -46,7 +46,7 @@ class BuildOpenSSH(CrossCompileAutotoolsProject):
 
     def configure(self, **kwargs):
         self.add_configure_env_arg("AR", self.target_info.ar)
-        self.add_configure_env_arg("DESTDIR", self.destdir)
         self.add_configure_env_arg("ac_cv_have_control_in_msghdr", "yes")
         self.run_cmd("autoreconf", str(self.source_dir), cwd=self.build_dir)
+        self.make_args.set(DESTDIR=str(self.destdir))
         super().configure(**kwargs)


### PR DESCRIPTION
With older openssh versions (e.g., the one used in FETT) DESTDIR
could be passed in the environment.  In the current openssh-portable
build system, it must be passed as an argument to override it being
set to the empty string in Makefile.