### PR TITLE
sail: catch up with upstream

### DIFF
--- a/pycheribuild/projects/sail.py
+++ b/pycheribuild/projects/sail.py
@@ -411,9 +411,7 @@ class BuildSailFromSource(OcamlProject):
         pass
 
     def install(self, **kwargs):
-        # Use ./opam to just build sail, not coq-sail.  Using '.' will try to
-        # build both and we probably don't need all of coq installed just now
-        self.run_in_ocaml_env("opam install -y ./opam")
+        self.run_in_ocaml_env("opam install -y ./*.opam")
 
     def process(self):
         lemdir = BuildLem.get_source_dir(self)


### PR DESCRIPTION
Ever since the patch series of
https://github.com/rems-project/sail/commit/09e69c98c60b6b8467e39ed17fd5dff01011cb88
through
https://github.com/rems-project/sail/commit/6ba9f1d726bf8e1ed826a1886eaa8e8d79c93135
landed, sail has, from the looks of it, had a dune-based build system with opam
backwards compatibility.  Rather than teach cheribuild about dune, take
advantage of the latter.