### PR TITLE
Use the LLVM runtimes build for llvm-libs

### DIFF
--- a/pycheribuild/projects/cross/libcxx.py
+++ b/pycheribuild/projects/cross/libcxx.py
@@ -40,7 +40,7 @@ from ..cmake_project import CMakeProject
 from ..project import ReuseOtherProjectDefaultTargetRepository
 from ..run_qemu import LaunchCheriBSD
 from ...config.chericonfig import BuildType
-from ...utils import OSInfo, replace_one
+from ...utils import OSInfo
 
 
 # A base class to set the default installation directory
@@ -435,8 +435,7 @@ class BuildLlvmLibs(CMakeProject):
             # Without setting LC_ALL lit attempts to encode some things as ASCII and fails.
             # This only happens on FreeBSD, but we might as well set it everywhere
             with self.set_env(LC_ALL="en_US.UTF-8", FILECHECK_DUMP_INPUT_ON_FAILURE=1):
-                targets = ["check-" + replace_one(tgt,  "lib", "") for tgt in self.enabled_runtimes]
-                self.run_cmd("cmake", "--build", self.build_dir, "--target", *targets)
+                self.run_cmd("cmake", "--build", self.build_dir, "--target", "check-runtimes")
                 return
         # We can't use check-all since that will (currently) also build and test LLVM and using the
         # individual check-* targets will overwrite the XML output.

--- a/pycheribuild/projects/cross/libcxx.py
+++ b/pycheribuild/projects/cross/libcxx.py
@@ -397,9 +397,6 @@ class BuildLlvmLibs(CMakeProject):
             external_cxxabi = "libcxxrt"
             if self.llvm_project is BuildUpstreamLLVM:
                 self.enabled_runtimes.remove("libunwind")  # CHERI fixes have not been upstreamed.
-            # Skip experimental for now since it crashes the compiler...
-            self.add_cmake_options(LIBCXX_TEST_PARAMS="enable_experimental=False")
-            self.add_cmake_options(LIBCXXABI_TEST_PARAMS="enable_experimental=False")
 
         if external_cxxabi is not None:
             self.add_cmake_options(LIBCXX_CXX_ABI=external_cxxabi)


### PR DESCRIPTION
This currently requires changes cherry-picked to the dev branch of llvm, so can only be merged once those land in master.