### PR TITLE
Add --presume-connectivity option

### DIFF
--- a/pycheribuild/config/defaultconfig.py
+++ b/pycheribuild/config/defaultconfig.py
@@ -103,6 +103,11 @@ class DefaultCheriConfig(CheriConfig):
             "confirm-clone", help="Ask for confirmation before cloning repositories.")
         self.force_update = loader.add_bool_option("force-update", help="Always update (with autostash) even if there "
                                                                         "are uncommitted changes")
+
+        self.presume_connectivity = loader.add_bool_option(
+            "presume-connectivity",
+            help="Do not probe for network connectivity and just assume that we are suitably connected")
+
         # TODO: should replace this group with a tristate value
         configure_group = loader.add_mutually_exclusive_group()
         self.skip_configure = loader.add_bool_option("skip-configure", help="Skip the configure step",

--- a/pycheribuild/utils.py
+++ b/pycheribuild/utils.py
@@ -90,6 +90,7 @@ class ConfigBase:
         self.verbose = verbose
         self.pretend = pretend
         self.force = force
+        self.presume_connectivity = False
         self.internet_connection_last_checked_at: typing.Optional[float] = None
         self.internet_connection_last_check_result = False
 
@@ -291,7 +292,7 @@ def include_local_file(path: str) -> str:
 
 
 def have_working_internet_connection(config: ConfigBase) -> bool:
-    if config.TEST_MODE:
+    if config.TEST_MODE or config.presume_connectivity:
         return True
     current_check_time = time.time()
     if config.internet_connection_last_checked_at:


### PR DESCRIPTION
If we're heavily firewalled, the attempt to check whether we're online doesn't really indicate whether or not we'll be able to reach, for example, github.com .  Operating in such an environment, I have historically just stubbed out the test locally, but rather than continuing to do that, having an option could be nice.