### PR TITLE
Add more CHERI-relevant tests from Juliet test suite

### DIFF
--- a/pycheribuild/projects/cross/juliet_test_suite.py
+++ b/pycheribuild/projects/cross/juliet_test_suite.py
@@ -111,10 +111,58 @@ class BuildJulietCWE121(BuildJulietCWESubdir):
                                              subdirectory="testcases/CWE121_Stack_Based_Buffer_Overflow")
 
 
+class BuildJulietCWE122(BuildJulietCWESubdir):
+    target = "juliet-cwe-122"
+    cwe_number = 122
+    repository = ReuseOtherProjectRepository(BuildJulietTestSuite,
+                                             subdirectory="testcases/CWE122_Heap_Based_Buffer_Overflow")
+
+
+class BuildJulietCWE124(BuildJulietCWESubdir):
+    target = "juliet-cwe-124"
+    cwe_number = 124
+    repository = ReuseOtherProjectRepository(BuildJulietTestSuite,
+                                             subdirectory="testcases/CWE124_Buffer_Underwrite")
+
+
 class BuildJulietCWE126(BuildJulietCWESubdir):
     target = "juliet-cwe-126"
     cwe_number = 126
-    repository = ReuseOtherProjectRepository(BuildJulietTestSuite, subdirectory="testcases/CWE126_Buffer_Overread")
+    repository = ReuseOtherProjectRepository(BuildJulietTestSuite,
+                                             subdirectory="testcases/CWE126_Buffer_Overread")
+    cwe_setup_commands = [
+                "echo 500 > /tmp/in.txt"
+            ]
+
+
+class BuildJulietCWE127(BuildJulietCWESubdir):
+    target = "juliet-cwe-127"
+    cwe_number = 127
+    repository = ReuseOtherProjectRepository(BuildJulietTestSuite,
+                                             subdirectory="testcases/CWE127_Buffer_Underread")
+    cwe_setup_commands = [
+                "echo -500 > /tmp/in.txt"
+            ]
+
+
+class BuildJulietCWE134(BuildJulietCWESubdir):
+    target = "juliet-cwe-134"
+    cwe_number = 134
+    repository = ReuseOtherProjectRepository(BuildJulietTestSuite,
+                                             subdirectory="testcases/CWE134_Uncontrolled_Format_String")
+    cwe_warning_flags = ["-Wno-error=format-security"]
+
+
+class BuildJulietCWE188(BuildJulietCWESubdir):
+    target = "juliet-cwe-188"
+    cwe_number = 188
+    repository = ReuseOtherProjectRepository(BuildJulietTestSuite,
+                                             subdirectory="testcases/CWE188_Reliance_on_Data_Memory_Layout")
+
+    def setup(self):
+        super().setup()
+        if self.compiling_for_cheri():
+            self.CFLAGS.append("-cheri-bounds=subobject-safe")
 
 
 class BuildJulietCWE415(BuildJulietCWESubdir):
@@ -127,3 +175,40 @@ class BuildJulietCWE416(BuildJulietCWESubdir):
     target = "juliet-cwe-416"
     cwe_number = 416
     repository = ReuseOtherProjectRepository(BuildJulietTestSuite, subdirectory="testcases/CWE416_Use_After_Free")
+
+
+class BuildJulietCWE587(BuildJulietCWESubdir):
+    target = "juliet-cwe-587"
+    cwe_number = 587
+    repository = ReuseOtherProjectRepository(BuildJulietTestSuite,
+                                             subdirectory="testcases/CWE587_Assignment_of_Fixed_Address_to_Pointer")
+
+
+class BuildJulietCWE588(BuildJulietCWESubdir):
+    target = "juliet-cwe-588"
+    cwe_number = 588
+    repository = ReuseOtherProjectRepository(
+            BuildJulietTestSuite,
+            subdirectory="testcases/CWE588_Attempt_to_Access_Child_of_Non_Structure_Pointer")
+
+
+class BuildJulietCWE680(BuildJulietCWESubdir):
+    target = "juliet-cwe-680"
+    cwe_number = 680
+    repository = ReuseOtherProjectRepository(BuildJulietTestSuite,
+                                             subdirectory="testcases/CWE680_Integer_Overflow_to_Buffer_Overflow")
+
+
+class BuildJulietCWE685(BuildJulietCWESubdir):
+    target = "juliet-cwe-685"
+    cwe_number = 685
+    repository = ReuseOtherProjectRepository(
+            BuildJulietTestSuite,
+            subdirectory="testcases/CWE685_Function_Call_With_Incorrect_Number_of_Arguments")
+    cwe_warning_flags = ["-Wno-error=format-insufficient-args"]
+
+
+class BuildJulietCWE843(BuildJulietCWESubdir):
+    target = "juliet-cwe-843"
+    cwe_number = 843
+    repository = ReuseOtherProjectRepository(BuildJulietTestSuite, subdirectory="testcases/CWE843_Type_Confusion")

--- a/pycheribuild/projects/cross/juliet_test_suite.py
+++ b/pycheribuild/projects/cross/juliet_test_suite.py
@@ -66,12 +66,18 @@ class BuildJulietCWESubdir(CrossCompileCMakeProject):
     do_not_add_to_targets = True
     cwe_number = None
     default_install_dir = DefaultInstallDir.DO_NOT_INSTALL
+    cwe_warning_flags = []
 
     @classmethod
     def setup_config_options(cls, **kwargs):
         super().setup_config_options(**kwargs)
         cls.testcase_timeout = cls.add_config_option("testcase-timeout", kind=str)
         cls.ld_preload_path = cls.add_config_option("ld-preload-path", kind=str)
+
+    def setup(self):
+        super().setup()
+        for flag in self.cwe_warning_flags:
+            self.cross_warning_flags.append(flag)
 
     def configure(self, **kwargs):
         self.add_cmake_options(PLACE_OUTPUT_IN_TOPLEVEL_DIR=False)

--- a/pycheribuild/projects/cross/juliet_test_suite.py
+++ b/pycheribuild/projects/cross/juliet_test_suite.py
@@ -67,6 +67,7 @@ class BuildJulietCWESubdir(CrossCompileCMakeProject):
     cwe_number = None
     default_install_dir = DefaultInstallDir.DO_NOT_INSTALL
     cwe_warning_flags = []
+    cwe_setup_commands = []
 
     @classmethod
     def setup_config_options(cls, **kwargs):
@@ -100,6 +101,12 @@ class BuildJulietCWESubdir(CrossCompileCMakeProject):
             args.append("--ld-preload-path")
             args.append(self.ld_preload_path)
 
+        for cmd in self.cwe_setup_commands:
+            args.append("--test-setup-command=" + cmd)
+
+        # For stdin redirection
+        args.append("--test-setup-command=touch /tmp/in.txt")
+
         self.target_info.run_cheribsd_test_script("run_juliet_tests.py", *args, mount_sourcedir=True,
                                                   mount_sysroot=True, mount_builddir=True)
 
@@ -109,6 +116,9 @@ class BuildJulietCWE121(BuildJulietCWESubdir):
     cwe_number = 121
     repository = ReuseOtherProjectRepository(BuildJulietTestSuite,
                                              subdirectory="testcases/CWE121_Stack_Based_Buffer_Overflow")
+    cwe_setup_commands = [
+                "echo 500 > /tmp/in.txt"
+            ]
 
 
 class BuildJulietCWE122(BuildJulietCWESubdir):
@@ -116,6 +126,9 @@ class BuildJulietCWE122(BuildJulietCWESubdir):
     cwe_number = 122
     repository = ReuseOtherProjectRepository(BuildJulietTestSuite,
                                              subdirectory="testcases/CWE122_Heap_Based_Buffer_Overflow")
+    cwe_setup_commands = [
+                "echo 500 > /tmp/in.txt"
+            ]
 
 
 class BuildJulietCWE124(BuildJulietCWESubdir):
@@ -123,6 +136,9 @@ class BuildJulietCWE124(BuildJulietCWESubdir):
     cwe_number = 124
     repository = ReuseOtherProjectRepository(BuildJulietTestSuite,
                                              subdirectory="testcases/CWE124_Buffer_Underwrite")
+    cwe_setup_commands = [
+                "echo -500 > /tmp/in.txt"
+            ]
 
 
 class BuildJulietCWE126(BuildJulietCWESubdir):
@@ -151,6 +167,11 @@ class BuildJulietCWE134(BuildJulietCWESubdir):
     repository = ReuseOtherProjectRepository(BuildJulietTestSuite,
                                              subdirectory="testcases/CWE134_Uncontrolled_Format_String")
     cwe_warning_flags = ["-Wno-error=format-security"]
+    cwe_setup_commands = [
+                "export ADD=%s%d%s",
+                "echo Format string: %s %d %s > /tmp/file.txt",
+                "echo Format string: %s %d %s > /tmp/in.txt"
+            ]
 
 
 class BuildJulietCWE188(BuildJulietCWESubdir):

--- a/test-scripts/run_juliet_tests.py
+++ b/test-scripts/run_juliet_tests.py
@@ -67,10 +67,15 @@ def output_to_junit_suite(xml, output_path, suite_name, good=True):
 def add_args(parser: argparse.ArgumentParser):
     parser.add_argument("--testcase-timeout", required=False, default="1s")
     parser.add_argument("--ld-preload-path", required=False, default=None)
+    parser.add_argument("--test-setup-command", action="append", dest="test_setup_commands", metavar="COMMAND",
+                        help="Run COMMAND as an additional test setup step before running the tests")
 
 
-def setup_juliet_test_environment(qemu: boot_cheribsd.CheriBSDInstance, _: argparse.Namespace):
+def setup_juliet_test_environment(qemu: boot_cheribsd.CheriBSDInstance, args: argparse.Namespace):
     boot_cheribsd.set_ld_library_path_with_sysroot(qemu)
+    if args.test_setup_commands:
+        for command in args.test_setup_commands:
+            qemu.checked_run(command)
 
 
 def run_juliet_tests(qemu: boot_cheribsd.CheriBSDInstance, args: argparse.Namespace) -> bool:


### PR DESCRIPTION
- Add the following CWE entries in addition to already present in `juliet_test_suite` project of `cheribuild`
  - 122 Heap-based Buffer Overflow
  - 124 Buffer Underwrite ('Buffer Underflow')
  - 127 Buffer Under-read
  - 134 Uncontrolled Format String
  - 188 Reliance on Data/Memory Layout
  - 587 Assignment of a Fixed Address to a Pointer
  - 588 Attempt to Access Child of a Non-structure Pointer
  - 685 Function Call With Incorrect Number of Arguments
  - 843 Access of Resource Using Incompatible Type ('Type
Confusion')

- Treat compiler detected bugs as warnings, not errors, for relevant CWE entries.
- Provide user input from stdtin, files and environment that triggers illegal memory access.