### PR TITLE
utils: ignore blank lines and comments in os-release file

### DIFF
--- a/pycheribuild/utils.py
+++ b/pycheribuild/utils.py
@@ -414,7 +414,10 @@ class OSInfo(object):
         with Path("/etc/os-release").open(encoding="utf-8") as f:
             d = {}
             for line in f:
-                k, v = line.rstrip().split("=", maxsplit=1)
+                line = line.strip()
+                if line == '' or line[0] == '#':
+                    continue
+                k, v = line.split("=", maxsplit=1)
                 # .strip('"') will remove if there or else do nothing
                 d[k] = v.strip('"')
         return d


### PR DESCRIPTION
Here's an example of the os-release file for CentOS 7:
```
NAME="CentOS Linux"
VERSION="7 (Core)"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="7"
PRETTY_NAME="CentOS Linux 7 (Core)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:7"
HOME_URL="https://www.centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"

CENTOS_MANTISBT_PROJECT="CentOS-7"
CENTOS_MANTISBT_PROJECT_VERSION="7"
REDHAT_SUPPORT_PRODUCT="centos"
REDHAT_SUPPORT_PRODUCT_VERSION="7"
```

The blank line broke the previous parser.

The man page for os-release (`OS-RELEASE(5)`) specifies:

> Lines beginning with "#" are treated as comments. Blank lines are
> permitted and ignored.

This modified parser will still fail if a line doesn't contain '=', I beleive this is acceptable since OS-RELEASE(5) specifies that each line should be an assignment, so a line without '=' that isn't a comment or blank would be invalid.