### PR TITLE
cheribsd-release: include all built kernels

### DIFF
--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -1942,6 +1942,9 @@ class BuildFreeBSDReleaseMixin(ReleaseMixinBase):
         release_args.set_env(PATH=":".join(map(str, extra_path_entries)) + ":" +
                                   release_args.env_vars.get("PATH", os.getenv("PATH")))
 
+        # Also include all the other kernels in the distribution.
+        release_args.set(NO_INSTALLEXTRAKERNELS="no")
+
         # DESTDIR for install target is where to install the media, as you'd
         # expect, unlike the release target where it leaks into installworld
         # etc recursive makes. Otherwise everything is the same, though many


### PR DESCRIPTION
We already do this as part of installing the cheribsd-$ARCH targets, in BuildFreeBSD::_installkernel (called by BuildFreeBSD::install from BuildFreeBSD::process via delegation to its superclass Project::process), but BuildFreeBSDReleaseMixin overrides its process() method and does not delegate to this existing installation machinery.

Note that CheriBSD itself sets this NO_INSTALLEXTRAKERNELS control to "no" on aarch64c if it isn't already set, presumably so that self-hosted Morello builds do the right thing.