### PR TITLE
GDB: register dependency on texinfo

### DIFF
--- a/pycheribuild/projects/cross/gdb.py
+++ b/pycheribuild/projects/cross/gdb.py
@@ -71,6 +71,7 @@ class BuildGDBBase(CrossCompileAutotoolsProject):
 
     def check_system_dependencies(self) -> None:
         super().check_system_dependencies()
+        self.check_required_system_tool("makeinfo", default="texinfo")
         if self.compiling_for_host() and self.target_info.is_cheribsd():
             self.check_required_pkg_config("gmp", freebsd="gmp")
             self.check_required_pkg_config("expat", freebsd="expat")

--- a/pycheribuild/projects/cross/gmp.py
+++ b/pycheribuild/projects/cross/gmp.py
@@ -39,7 +39,7 @@ class BuildGmp(CrossCompileAutotoolsProject):
         super().check_system_dependencies()
         # It would be nice if we could just disable building documentation, but until we can do so, missing makeinfo
         # results in failing build
-        self.check_required_system_tool("makeinfo", freebsd="texinfo")
+        self.check_required_system_tool("makeinfo", default="texinfo")
 
     def setup(self):
         super().setup()


### PR DESCRIPTION
On a fresh installation of FreeBSD, the GDB build will fail in configure when it can't find makeinfo.  This is part of the texinfo package.