### PR TITLE
Remove support for the BESSPIN evaluation tool

### DIFF
--- a/pycheribuild/files/cheribsd/rc.conf.in
+++ b/pycheribuild/files/cheribsd/rc.conf.in
@@ -16,6 +16,3 @@ nfs_client_enable="YES"
 fsck_y_enable="YES"
 fsck_y_flags="-T ffs:-R -T ufs:-R"
 crashinfo_enable=NO	# gdb runs for 5+ minutes on F1 if present...
-if [ -e /besspin ]; then
-	ifconfig_xae0="inet 10.88.88.2/24"
-fi

--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -1846,16 +1846,6 @@ class BuildCheriBsdMfsImageAndKernels(TargetAliasWithDependencies):
         return BuildCheriBsdMfsKernel.supported_architectures
 
 
-class BuildBesspinCheriBsdMfsKernel(BuildCheriBsdMfsKernel):
-    target: str = "besspin-cheribsd-mfs-root-kernel"
-    hide_options_from_help: bool = True
-
-    @classproperty
-    def mfs_root_image_class(self):
-        from ..disk_image import BuildBesspinMfsRootCheriBSDDiskImage
-        return BuildBesspinMfsRootCheriBSDDiskImage
-
-
 if typing.TYPE_CHECKING:
     ReleaseMixinBase = BuildFreeBSD
 else:


### PR DESCRIPTION
We're unlikely to need to run this again so remove the clutter.