### PR TITLE
Support ZFS images for CheriBSD

### DIFF
--- a/pycheribuild/files/cheribsd/fstab.in
+++ b/pycheribuild/files/cheribsd/fstab.in
@@ -1,6 +1,4 @@
-/dev/ufs/root / ufs rw,noatime 1 1
 tmpfs /tmp tmpfs rw,failok 0 0
-/dev/gpt/swap none swap sw,failok 0 0
 
 # Uncomment to automount the default QEMU smbfs
 # //10.0.2.4/qemu /mnt smbfs rw,-I=10.0.2.4,-N 0 0


### PR DESCRIPTION
Add support for simple ZFS images.  The images contain a single 5GiB pool (zroot) mounted at /.  They can be created with the disk-image-zfs target and can be booted in qemu with the run-zfs target.

This has been tested on morello-purecap and amd64. The results should work on any platform that uses the FreeBSD loader as kernels don't typically contain the ZFS module. This means it will not work on RISC-V unless the kernel configuration is altered to build ZFS in.

This depends on https://github.com/CTSRD-CHERI/cheribsd/pull/1620