### PR TITLE
Use --modversion instead of --exists to check library is installed

### DIFF
--- a/pycheribuild/projects/simple_project.py
+++ b/pycheribuild/projects/simple_project.py
@@ -821,7 +821,7 @@ class SimpleProject(AbstractProject, metaclass=ABCMeta if typing.TYPE_CHECKING e
             return  # already checked
         self._validate_cheribuild_target_for_system_deps(instructions.cheribuild_target)
         try:
-            self.run_cmd(["pkg-config", "--exists", package])
+            self.run_cmd(["pkg-config", "--modversion", package], capture_output=True)
         except subprocess.CalledProcessError as e:
             self.dependency_error("Required library", package, "is missing:", e, install_instructions=instructions,
                                   cheribuild_target=instructions.cheribuild_target,


### PR DESCRIPTION
pkg-config --exists also checks dependencies are present on macOS, and due to some packaging issues with upstream libarchive this is breaking the build for cheribsd and freebsd.

Closes #340.

See https://github.com/Homebrew/homebrew-core/issues/120526 for tracking of this issue as it relates to macOS.