### PR TITLE
split on only the first `=` when parsing build options

### DIFF
--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -474,7 +474,7 @@ class BuildFreeBSDBase(Project):
                              " -- consider setting separate", self.get_config_option_name("extra_make_args"),
                              "in the config file.")
             if "=" in option:
-                key, value = option.split("=")
+                key, value = option.split("=", 1)
                 args = {key: value}
                 self.make_args.set(**args)
             else:


### PR DESCRIPTION
If you have a build option such as `OPTION=\"-DFOO=BAR\"` then the parsing of the config file fails. This just splits the string on the first `=` so the full value (with the second `=`) remains unchanged