### PR TITLE
cheribsd: Ensure that the kernel-config override only builds one kernel.

### DIFF
--- a/pycheribuild/config/config_loader_base.py
+++ b/pycheribuild/config/config_loader_base.py
@@ -151,6 +151,7 @@ class ConfigLoaderBase(ABC):
     def reset(self) -> None:
         for option in self.options.values():
             option._cached = None
+            option._is_default_value = False
 
     def debug_msg(self, *args, sep=" ", **kwargs) -> None:
         pass

--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -27,6 +27,7 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 #
+import inspect
 import itertools
 import os
 import shutil
@@ -55,6 +56,7 @@ from ..project import (
 )
 from ..simple_project import SimpleProject, TargetAliasWithDependencies, _clear_line_sequence, flush_stdio
 from ...config.compilation_targets import CompilationTargets, FreeBSDTargetInfo
+from ...config.loader import ConfigOptionBase
 from ...config.target_info import AutoVarInit, CrossCompileTarget
 from ...config.target_info import CompilerType as FreeBSDToolchainKind
 from ...processutils import latest_system_clang_tool, print_command
@@ -1678,6 +1680,10 @@ class BuildCHERIBSD(BuildFreeBSD):
 
     def extra_kernel_configs(self) -> "list[CheriBSDConfig]":
         # Everything that is not the default kernconf
+        option = inspect.getattr_static(self, "kernel_config")
+        assert isinstance(option, ConfigOptionBase)
+        if self.has_default_buildkernel_kernel_config and not option.is_default_value:
+            return []
         configs = self._get_all_kernel_configs()
         default_kernconf = self.default_kernel_config()
         return [c for c in configs if c.kernconf != default_kernconf]

--- a/tests/test_argument_parsing.py
+++ b/tests/test_argument_parsing.py
@@ -699,6 +699,11 @@ def test_disk_image_path(target, expected_name):
                   "CHERI-PURECAP-QEMU",
                   "CHERI-FETT",
                   "CHERI-PURECAP-FETT"]),
+    pytest.param("cheribsd-riscv64-purecap",
+                 ["--cheribsd-riscv64-purecap/kernel-config",
+                  "CUSTOM-KERNEL-CONFIG"],
+                 "CUSTOM-KERNEL-CONFIG",
+                 []),
     # Morello kernconf tests
     pytest.param("cheribsd-aarch64",
                  [],
@@ -712,6 +717,11 @@ def test_disk_image_path(target, expected_name):
                  [],
                  "GENERIC-MORELLO",
                  ["GENERIC-MORELLO-PURECAP"]),
+    pytest.param("cheribsd-morello-purecap",
+                 ["--cheribsd-morello-purecap/kernel-config",
+                  "CUSTOM-KERNEL-CONFIG"],
+                 "CUSTOM-KERNEL-CONFIG",
+                 []),
     # FreeBSD kernel configs
     pytest.param("freebsd-i386", [], "GENERIC", []),
     pytest.param("freebsd-aarch64", [], "GENERIC", []),


### PR DESCRIPTION
When the kernel-config is specified explicitly, extra kernels should not be built.