### PR TITLE
Introduce a freestanding target info

### DIFF
--- a/pycheribuild/projects/build_qemu.py
+++ b/pycheribuild/projects/build_qemu.py
@@ -47,7 +47,7 @@ from .project import (
     Project,
 )
 from .simple_project import SimpleProject, _cached_get_homebrew_prefix
-from ..config.compilation_targets import CompilationTargets, NewlibBaremetalTargetInfo
+from ..config.compilation_targets import BaremetalFreestandingTargetInfo, CompilationTargets
 
 
 class BuildQEMUBase(AutotoolsProject):
@@ -289,9 +289,10 @@ class RunMorelloQEMUTests(Project):
     def run_tests(self) -> None:
         # TODO: suggest installing pytest-xdist
         qemu = BuildQEMU.get_instance(self)
+        qemu_binary = qemu.qemu_binary_for_target(CompilationTargets.FREESTANDING_MORELLO_PURECAP, self.config)
         self.run_cmd(sys.executable, "-m", "pytest", qemu.source_dir / "tests/morello",
                      f"--morello-tests-dir={self.source_dir}",
-                     f"--qemu={qemu.qemu_binary_for_target(CompilationTargets.MORELLO_BAREMETAL_PURECAP, self.config)}",
+                     f"--qemu={qemu_binary}",
                      f"--junit-xml={self.build_dir}/morello-generated-tests-result.xml",
                      cwd=qemu.source_dir / "tests/morello")
 
@@ -388,9 +389,9 @@ class BuildQEMU(BuildQEMUBase):
             fake_project.warning = self.warning
             fake_project.target = "qemu-tcg-tests"
             # noinspection PyTypeChecker
-            tgt_info_mips = NewlibBaremetalTargetInfo(CompilationTargets.BAREMETAL_NEWLIB_MIPS64, fake_project)
+            tgt_info_mips = BaremetalFreestandingTargetInfo(CompilationTargets.FREESTANDING_MIPS64, fake_project)
             # noinspection PyTypeChecker
-            tgt_info_riscv64 = NewlibBaremetalTargetInfo(CompilationTargets.BAREMETAL_NEWLIB_RISCV64, fake_project)
+            tgt_info_riscv64 = BaremetalFreestandingTargetInfo(CompilationTargets.FREESTANDING_RISCV64, fake_project)
             self.configure_args.extend([
                 "--cross-cc-mips=" + str(tgt_info_mips.c_compiler),
                 "--cross-cc-cflags-mips=" + self.commandline_to_str(

--- a/pycheribuild/projects/cross/bbl.py
+++ b/pycheribuild/projects/cross/bbl.py
@@ -142,8 +142,7 @@ class BuildBBLTestPayload(BuildBBLBase):
     default_directory_basename = "bbl"  # reuse same source dir
     build_dir_suffix = "-test-payload"  # but not the build dir
     cross_install_dir = DefaultInstallDir.DO_NOT_INSTALL
-    supported_architectures = [CompilationTargets.BAREMETAL_NEWLIB_RISCV64_PURECAP,
-                               CompilationTargets.BAREMETAL_NEWLIB_RISCV64]
+    supported_architectures = [CompilationTargets.FREESTANDING_RISCV64_PURECAP, CompilationTargets.FREESTANDING_RISCV64]
     custom_payload = "dummy_payload"
 
     def setup(self):
@@ -165,9 +164,7 @@ class BuildBBLNoPayload(BuildBBLBase):
     default_directory_basename = "bbl"
     without_payload = True
     cross_install_dir = DefaultInstallDir.CUSTOM_INSTALL_DIR
-    supported_architectures = [CompilationTargets.BAREMETAL_NEWLIB_RISCV64_PURECAP,
-                               CompilationTargets.BAREMETAL_NEWLIB_RISCV64]
-
+    supported_architectures = [CompilationTargets.FREESTANDING_RISCV64_PURECAP, CompilationTargets.FREESTANDING_RISCV64]
     _default_install_dir_fn = ComputedDefaultValue(function=_bbl_install_dir,
                                                    as_string="$SDK_ROOT/bbl/riscv{32,64}{,-purecap}")
 

--- a/pycheribuild/projects/cross/compiler_rt.py
+++ b/pycheribuild/projects/cross/compiler_rt.py
@@ -46,8 +46,7 @@ class BuildCompilerRt(CrossCompileCMakeProject):
     cross_install_dir = DefaultInstallDir.IN_BUILD_DIRECTORY
     _check_install_dir_conflict = False
     supported_architectures = \
-        CompilationTargets.ALL_SUPPORTED_CHERIBSD_AND_HOST_TARGETS + \
-        CompilationTargets.ALL_SUPPORTED_BAREMETAL_TARGETS + \
+        CompilationTargets.ALL_SUPPORTED_CHERIBSD_AND_BAREMETAL_AND_HOST_TARGETS + \
         CompilationTargets.ALL_SUPPORTED_RTEMS_TARGETS
 
     def setup(self):
@@ -129,6 +128,7 @@ class BuildCompilerRtBuiltins(CrossCompileCMakeProject):
     needs_sysroot = False  # We don't need a complete sysroot
     supported_architectures = (CompilationTargets.ALL_SUPPORTED_BAREMETAL_TARGETS +
                                CompilationTargets.ALL_SUPPORTED_RTEMS_TARGETS +
+                               CompilationTargets.ALL_FREESTANDING_TARGETS +
                                CompilationTargets.ALL_NATIVE)
 
     # Note: needs to be @classproperty since it is called before __init__

--- a/pycheribuild/projects/cross/device_model.py
+++ b/pycheribuild/projects/cross/device_model.py
@@ -39,7 +39,7 @@ class BuildDeviceModel(CrossCompileAutotoolsProject):
     target = "device-model"
     is_sdk_target = True
     needs_sysroot = False  # We don't need a complete sysroot
-    supported_architectures = [CompilationTargets.BAREMETAL_NEWLIB_RISCV64_PURECAP]
+    supported_architectures = [CompilationTargets.FREESTANDING_RISCV64_PURECAP]
     default_install_dir = DefaultInstallDir.ROOTFS_LOCALBASE
     build_in_source_dir = True  # Cannot build out-of-source
 

--- a/pycheribuild/projects/cross/opensbi.py
+++ b/pycheribuild/projects/cross/opensbi.py
@@ -58,9 +58,9 @@ class BuildOpenSBI(Project):
     default_install_dir = DefaultInstallDir.CUSTOM_INSTALL_DIR
     default_build_type = BuildType.RELWITHDEBINFO
     supported_architectures = [
-        CompilationTargets.BAREMETAL_NEWLIB_RISCV64_HYBRID,
-        CompilationTargets.BAREMETAL_NEWLIB_RISCV64,
-        # Won't compile yet: CompilationTargets.BAREMETAL_NEWLIB_RISCV64_PURECAP
+        CompilationTargets.FREESTANDING_RISCV64_HYBRID,
+        CompilationTargets.FREESTANDING_RISCV64,
+        # Won't compile yet: CompilationTargets.FREESTANDING_RISCV64_PURECAP
         ]
     make_kind = MakeCommandKind.GnuMake
     _always_add_suffixed_targets = True
@@ -147,12 +147,12 @@ class BuildOpenSBI(Project):
     @classmethod
     def get_nocap_instance(cls, caller, cpu_arch=CPUArchitecture.RISCV64) -> "BuildOpenSBI":
         assert cpu_arch == CPUArchitecture.RISCV64, "RISCV32 not supported yet"
-        return cls.get_instance(caller, cross_target=CompilationTargets.BAREMETAL_NEWLIB_RISCV64)
+        return cls.get_instance(caller, cross_target=CompilationTargets.FREESTANDING_RISCV64)
 
     @classmethod
     def get_hybrid_instance(cls, caller, cpu_arch=CPUArchitecture.RISCV64) -> "BuildOpenSBI":
         assert cpu_arch == CPUArchitecture.RISCV64, "RISCV32 not supported yet"
-        return cls.get_instance(caller, cross_target=CompilationTargets.BAREMETAL_NEWLIB_RISCV64_HYBRID)
+        return cls.get_instance(caller, cross_target=CompilationTargets.FREESTANDING_RISCV64_HYBRID)
 
     @classmethod
     def get_nocap_bios(cls, caller) -> Path:
@@ -179,7 +179,7 @@ class BuildUpstreamOpenSBI(BuildOpenSBI):
         function=lambda config, p: config.cheri_sdk_dir / "upstream-opensbi/riscv64",
         as_string="$SDK_ROOT/upstream-opensbi/riscv64")
     repository = GitRepository("https://github.com/riscv-software-src/opensbi.git")
-    supported_architectures = [CompilationTargets.BAREMETAL_NEWLIB_RISCV64]
+    supported_architectures = [CompilationTargets.FREESTANDING_RISCV64]
 
     def run_tests(self):
         options = QemuOptions(self.crosscompile_target)

--- a/pycheribuild/projects/cross/u_boot.py
+++ b/pycheribuild/projects/cross/u_boot.py
@@ -58,10 +58,10 @@ class BuildUBoot(Project):
     default_install_dir = DefaultInstallDir.CUSTOM_INSTALL_DIR
     default_build_type = BuildType.RELWITHDEBINFO
     supported_architectures = [
-        CompilationTargets.BAREMETAL_NEWLIB_RISCV64_HYBRID,
-        CompilationTargets.BAREMETAL_NEWLIB_RISCV64,
-        # Won't compile yet: CompilationTargets.BAREMETAL_NEWLIB_RISCV64_PURECAP
-        ]
+        CompilationTargets.FREESTANDING_RISCV64_HYBRID,
+        CompilationTargets.FREESTANDING_RISCV64,
+        # Won't compile yet: CompilationTargets.FREESTANDING_RISCV64_PURECAP
+    ]
     make_kind = MakeCommandKind.GnuMake
     _always_add_suffixed_targets = True
     _default_install_dir_fn: ComputedDefaultValue[Path] = \

--- a/pycheribuild/projects/fvp_firmware.py
+++ b/pycheribuild/projects/fvp_firmware.py
@@ -88,7 +88,7 @@ class ArmNoneEabiToolchain(SimpleProject):
 
 class MorelloFirmwareBase(CrossCompileMakefileProject):
     do_not_add_to_targets = True
-    supported_architectures = [CompilationTargets.MORELLO_BAREMETAL_HYBRID]
+    supported_architectures = [CompilationTargets.FREESTANDING_MORELLO_HYBRID]
     cross_install_dir = DefaultInstallDir.CUSTOM_INSTALL_DIR  # TODO: install it
     needs_sysroot = False  # We don't need a complete sysroot
     default_build_type = BuildType.RELEASE
@@ -327,7 +327,7 @@ build -n {make_jobs} -a AARCH64 -t CLANG38 -p {platform_desc} \
 
     @classmethod
     def uefi_bin(cls, caller):
-        return cls.get_install_dir(caller, cross_target=CompilationTargets.MORELLO_BAREMETAL_HYBRID) / "uefi.bin"
+        return cls.get_install_dir(caller, cross_target=CompilationTargets.FREESTANDING_MORELLO_HYBRID) / "uefi.bin"
 
 
 class BuildMorelloFlashImages(Project):

--- a/pycheribuild/projects/run_qemu.py
+++ b/pycheribuild/projects/run_qemu.py
@@ -310,9 +310,9 @@ class LaunchQEMUBase(SimpleProject):
             uboot_xtarget = None
             if xtarget.cpu_architecture == CPUArchitecture.RISCV64:
                 if xtarget.is_hybrid_or_purecap_cheri():
-                    uboot_xtarget = CompilationTargets.BAREMETAL_NEWLIB_RISCV64_HYBRID
+                    uboot_xtarget = CompilationTargets.FREESTANDING_RISCV64_HYBRID
                 else:
-                    uboot_xtarget = CompilationTargets.BAREMETAL_NEWLIB_RISCV64
+                    uboot_xtarget = CompilationTargets.FREESTANDING_RISCV64
 
             if uboot_xtarget is not None:
                 qemu_loader_or_kernel = BuildUBoot.get_firmware_path(self, self.config, cross_target=uboot_xtarget)

--- a/pycheribuild/projects/spike.py
+++ b/pycheribuild/projects/spike.py
@@ -67,7 +67,7 @@ class BuildCheriSpike(AutotoolsProject):
 
 class RunCheriSpikeBase(SimpleProject):
     do_not_add_to_targets = True
-    _bbl_xtarget = CompilationTargets.BAREMETAL_NEWLIB_RISCV64_PURECAP
+    _bbl_xtarget = CompilationTargets.FREESTANDING_RISCV64_PURECAP
     _bbl_class = BuildBBLNoPayload.get_class_for_target(_bbl_xtarget)
     _source_class = None
 

--- a/tests/test_target_order.py
+++ b/tests/test_target_order.py
@@ -449,6 +449,8 @@ def test_no_dependencies_in_build_dir(config: CheriConfig, native_target: Target
     pytest.param(CompilationTargets.CHERIBSD_MORELLO_NO_CHERI, ["morello-llvm-native"]),
     pytest.param(CompilationTargets.BAREMETAL_NEWLIB_RISCV64_PURECAP, ["llvm-native"]),
     pytest.param(CompilationTargets.BAREMETAL_NEWLIB_RISCV64, ["llvm-native"]),
+    pytest.param(CompilationTargets.FREESTANDING_RISCV64_PURECAP, ["llvm-native"]),
+    pytest.param(CompilationTargets.FREESTANDING_MORELLO_NO_CHERI, ["morello-llvm-native"]),
     pytest.param(CompilationTargets.RTEMS_RISCV64_PURECAP, ["llvm-native"]),
     pytest.param(CompilationTargets.ARM_NONE_EABI, []),
     pytest.param(CompilationTargets.CHERIOS_RISCV_PURECAP, ["cherios-llvm"]),


### PR DESCRIPTION
Currently BBL and other freestanding baremetal targets use the newlib target info but that is not quite right - introduce a new one that does not include a libc. No functional change intended.