### PR TITLE
Added missing macOS dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ macOS 10.14 and newer is also supported.
 When building on macOS the following commands will install the packages required for
 the most commonly used cheribuild targets:
 ```shell
-brew install cmake ninja libarchive git glib gnu-sed automake autoconf coreutils llvm make wget pixman pkg-config xz
+brew install cmake ninja libarchive git glib gnu-sed automake autoconf coreutils llvm make wget pixman pkg-config xz texinfo mercurial
 # Install samba for shared mounts between host and CheriBSD on QEMU
 brew install samba
 # If you intend to run the morello FVP model you will also need the following:


### PR DESCRIPTION
I added "texinfo" and "mercurial" to the packages that need to be installed on macOS with Homebrew. I needed to install these in addition to packages that are already listed in the readme file to build the "run-riscv64-purecap" target.