### PR TITLE
Require python 3.8

### DIFF
--- a/pycheribuild/config/chericonfig.py
+++ b/pycheribuild/config/chericonfig.py
@@ -36,6 +36,7 @@ import re
 import shutil
 import typing
 from enum import Enum
+from functools import cached_property
 from pathlib import Path
 from typing import Optional
 
@@ -45,7 +46,6 @@ from ..processutils import latest_system_clang_tool, run_command
 from ..utils import (
     ConfigBase,
     DoNotUseInIfStmt,
-    cached_property,
     fatal_error,
     have_working_internet_connection,
     status_update,

--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -36,6 +36,7 @@ import subprocess
 import sys
 import typing
 from abc import ABC, abstractmethod
+from functools import cached_property
 from pathlib import Path
 from typing import Optional
 
@@ -56,7 +57,7 @@ from .target_info import (
 )
 from ..processutils import extract_version, get_compiler_info, get_version_output
 from ..projects.simple_project import SimpleProject
-from ..utils import cached_property, is_jenkins_build, warning_message
+from ..utils import is_jenkins_build, warning_message
 
 
 class BuildLLVMInterface(SimpleProject if typing.TYPE_CHECKING else object):

--- a/pycheribuild/config/target_info.py
+++ b/pycheribuild/config/target_info.py
@@ -33,13 +33,14 @@ import re
 import typing
 from abc import ABC, abstractmethod
 from enum import Enum
+from functools import cached_property
 from pathlib import Path
 from typing import ClassVar, Optional
 
 from .chericonfig import AArch64FloatSimdOptions, CheriConfig, MipsFloatAbi
 from ..filesystemutils import FileSystemUtils
 from ..processutils import CompilerInfo, get_compiler_info
-from ..utils import OSInfo, cached_property, fatal_error, final, status_update, warning_message
+from ..utils import OSInfo, fatal_error, final, status_update, warning_message
 
 __all__ = [
     "AArch64FloatSimdOptions",

--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -37,6 +37,7 @@ import tempfile
 import typing
 from collections import OrderedDict
 from enum import Enum
+from functools import cached_property
 from pathlib import Path
 from typing import ClassVar, Optional, Union
 
@@ -59,7 +60,7 @@ from ...config.compilation_targets import CompilationTargets, FreeBSDTargetInfo
 from ...config.loader import ConfigOptionHandle
 from ...config.target_info import AutoVarInit, CompilerType, CrossCompileTarget
 from ...processutils import latest_system_clang_tool, print_command
-from ...utils import OSInfo, ThreadJoiner, cached_property, classproperty, is_jenkins_build
+from ...utils import OSInfo, ThreadJoiner, classproperty, is_jenkins_build
 
 
 def _arch_suffixed_custom_install_dir(prefix: str) -> "ComputedDefaultValue[Path]":

--- a/pycheribuild/projects/cross/llvm_test_suite.py
+++ b/pycheribuild/projects/cross/llvm_test_suite.py
@@ -28,6 +28,7 @@
 # SUCH DAMAGE.
 #
 import shutil
+from functools import cached_property
 from pathlib import Path
 
 from .benchmark_mixin import BenchmarkMixin
@@ -42,7 +43,7 @@ from .llvm import BuildCheriLLVM, BuildLLVMBase, BuildUpstreamLLVM
 from ..project import ReuseOtherProjectRepository
 from ..simple_project import BoolConfigOption
 from ...config.compilation_targets import FreeBSDTargetInfo
-from ...utils import cached_property, classproperty, is_jenkins_build
+from ...utils import classproperty, is_jenkins_build
 
 
 class BuildLLVMTestSuiteBase(BenchmarkMixin, CrossCompileCMakeProject):

--- a/pycheribuild/projects/disk_image.py
+++ b/pycheribuild/projects/disk_image.py
@@ -34,6 +34,7 @@ import shutil
 import sys
 import tempfile
 from enum import Enum
+from functools import cached_property
 from pathlib import Path
 from typing import Optional
 
@@ -53,7 +54,7 @@ from .project import (
 from .simple_project import SimpleProject
 from ..config.compilation_targets import CompilationTargets
 from ..mtree import MtreeFile
-from ..utils import AnsiColour, cached_property, classproperty, coloured, include_local_file
+from ..utils import AnsiColour, classproperty, coloured, include_local_file
 
 # Notes:
 # Mount the filesystem of a BSD VM: guestmount -a /foo/bar.qcow2 -m /dev/sda1:/:ufstype=ufs2:ufs --ro /mnt/foo

--- a/pycheribuild/projects/project.py
+++ b/pycheribuild/projects/project.py
@@ -40,6 +40,7 @@ import time
 import typing
 from collections import OrderedDict
 from enum import Enum
+from functools import cached_property
 from pathlib import Path
 from typing import Callable, Optional, Sequence, Union
 
@@ -77,7 +78,6 @@ from ..utils import (
     InstallInstructions,
     OSInfo,
     ThreadJoiner,
-    cached_property,
     classproperty,
     coloured,
     remove_duplicates,

--- a/pycheribuild/projects/run_fvp.py
+++ b/pycheribuild/projects/run_fvp.py
@@ -32,6 +32,7 @@ import signal
 import subprocess
 import tempfile
 import typing
+from functools import cached_property
 from pathlib import Path
 from subprocess import CompletedProcess
 from typing import Optional
@@ -47,7 +48,6 @@ from ..utils import (
     AnsiColour,
     OSInfo,
     SocketAndPort,
-    cached_property,
     classproperty,
     coloured,
     find_free_port,

--- a/pycheribuild/projects/testrig.py
+++ b/pycheribuild/projects/testrig.py
@@ -27,6 +27,7 @@ import subprocess
 import time
 import typing
 from abc import ABC, abstractmethod
+from functools import cached_property
 from pathlib import Path
 from typing import Optional
 
@@ -36,7 +37,7 @@ from .repository import GitRepository
 from .sail import BuildSailCheriRISCV
 from .simple_project import BoolConfigOption, IntConfigOption, OptionalIntConfigOption, SimpleProject
 from ..processutils import FakePopen, commandline_to_str, popen
-from ..utils import cached_property, find_free_port
+from ..utils import find_free_port
 
 
 # This repository contains various implementations and QuickCheckVEngine

--- a/pycheribuild/utils.py
+++ b/pycheribuild/utils.py
@@ -80,8 +80,8 @@ __all__ = [
     "warning_message",
 ]
 
-if sys.version_info < (3, 6, 0):
-    sys.exit("This script requires at least Python 3.6.0")
+if sys.version_info < (3, 8, 0):  # noqa: UP036
+    sys.exit("This script requires at least Python 3.8.0")
 
 Type_T = typing.TypeVar("Type_T")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [tool.ruff]
 # Ensure suggested fixes are compatible with our minimum supported version
-# XXX: Currently this is py36, but the minimum supported by ruff is py37.
-target-version = "py37"
+target-version = "py38"
 line-length = 120
 src = ["pycheribuild", "release-scripts", "test-scripts", "tests"]
 exclude = [
@@ -20,7 +19,6 @@ show-fixes = true
 select = ["E", "F", "I", "N", "W", "U", "COM", "RUF", "PLC", "PLE", "PLW"]
 ignore = [
     "UP037",  # Remove quotes from type annotation, not possible until we start using 3.7 as the minimum
-    "UP036", # 'Version block is outdated for minimum Python version' to be removed when we set the minimum to 3.8
     "PLW2901", # `for` loop variable `value` overwritten by assignment target
     "RUF012",  # Mutable class attributes should be annotated with `typing.ClassVar` (cannot be fixed due to bug)
     "COM812",  # Incompatible with `ruff format`
@@ -33,7 +31,7 @@ known-local-folder = ["pycheribuild"]
 
 [tool.black]
 line-length = 120
-target-version = ['py36']
+target-version = ['py38']
 # 'extend-exclude' excludes files or directories in addition to the defaults
 # Currently reformatting pycheribuild/ results in lots of weird formatting, so
 # let's restrict this to the other files for now.


### PR DESCRIPTION
All older versions are EOL and none of the distributions we support
should have such an old version.