### PR TITLE
Use -morello-bounded-memargs=caller-only as appropriate

### DIFF
--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -728,6 +728,9 @@ class CheriBSDMorelloTargetInfo(CheriBSDTargetInfo):
         if version is None or version >= 20220511:
             # Use new var-args ABI
             result.extend(["-Xclang", "-morello-vararg=new"])
+        if version is None or version >= 20230804:
+            # Use new function call ABI
+            result.extend(["-Xclang", "-morello-bounded-memargs=caller-only"])
         if xtarget.is_cheri_purecap([CPUArchitecture.AARCH64]) and version is not None and version < 20220511:
             # Use emulated TLS on older purecap
             result.append("-femulated-tls")


### PR DESCRIPTION
When CheriBSD uses the new function argument ABI, use it for building other things.


Addresses #370 