### PR TITLE
Speed up pytype by removing imports

### DIFF
--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -86,7 +86,7 @@ def _linker_supports_riscv_relaxations(linker: Path, config: CheriConfig) -> boo
         return True
     if linker_version.startswith(b"LLD "):
         version = extract_version(linker_version, program_name=b"LLD", regex=re.compile(b"(\\d+)\\.(\\d+)\\.?(\\d+)?"))
-        return version >= (15, 0, 0)   # Linker relaxations are not supported with clang+lld < 15
+        return version >= (15, 0, 0)  # Linker relaxations are not supported with clang+lld < 15
     return False
 
 

--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -522,9 +522,10 @@ class FreeBSDTargetInfo(_ClangBasedTargetInfo):
             ), "All other architectures can boot directly"
             if disk_image_path is None and not has_test_extra_arg_override("--disk-image"):
                 assert self.is_cheribsd(), "Not supported for FreeBSD yet"
-                from ..projects.disk_image import BuildMinimalCheriBSDDiskImage
-
-                instance = BuildMinimalCheriBSDDiskImage.get_instance(self.project, cross_target=rootfs_xtarget)
+                instance = self.project.get_instance_for_target_name(
+                    "disk-image-minimal", cross_target=rootfs_xtarget, config=self.config, caller=self.project,
+                )
+                # noinspection PyUnresolvedReferences
                 disk_image_path = instance.disk_image_path
                 if not disk_image_path.exists():
                     self.project.dependency_error(

--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -449,9 +449,7 @@ class FreeBSDTargetInfo(_ClangBasedTargetInfo):
         return BuildUpstreamLLVM
 
     def _get_rootfs_class(self, xtarget: "CrossCompileTarget") -> "type[Project]":
-        from ..projects.cross.cheribsd import BuildFreeBSD
-
-        return BuildFreeBSD.get_class_for_target(xtarget)
+        return Project.get_class_for_target_name("freebsd", xtarget)
 
     def _get_mfs_root_kernel(self, platform, use_benchmark_kernel: bool) -> Path:
         raise NotImplementedError("Only implemented for CheriBSD")
@@ -693,9 +691,7 @@ class CheriBSDTargetInfo(FreeBSDTargetInfo):
         ]
 
     def _get_rootfs_class(self, xtarget: "CrossCompileTarget") -> "type[Project]":
-        from ..projects.cross.cheribsd import BuildCHERIBSD
-
-        return BuildCHERIBSD.get_class_for_target(xtarget)
+        return Project.get_class_for_target_name("cheribsd", xtarget)
 
     def cheribsd_version(self) -> "Optional[int]":
         pattern = re.compile(r"#define\s+__CheriBSD_version\s+([0-9]+)")
@@ -938,9 +934,7 @@ class NewlibBaremetalTargetInfo(BaremetalClangTargetInfo):
         return True
 
     def _get_rootfs_class(self, xtarget: CrossCompileTarget) -> "type[Project]":
-        from ..projects.cross.newlib import BuildNewlib
-
-        return BuildNewlib.get_class_for_target(xtarget)
+        return Project.get_class_for_target_name("newlib", xtarget)
 
 
 class PicolibcBaremetalTargetInfo(BaremetalClangTargetInfo):
@@ -1014,9 +1008,7 @@ set(CMAKE_DL_LIBS "")
         return []
 
     def _get_rootfs_class(self, xtarget: CrossCompileTarget) -> "type[Project]":
-        from ..projects.cross.picolibc import BuildPicoLibc
-
-        return BuildPicoLibc.get_class_for_target(xtarget)
+        return Project.get_class_for_target_name("picolibc", xtarget)
 
 
 class BaremetalFreestandingTargetInfo(BaremetalClangTargetInfo):

--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -1013,10 +1013,10 @@ set(CMAKE_DL_LIBS "")
             return super().additional_executable_link_flags + self.semihosting_ldflags()
         return []
 
-    def _get_rootfs_project(self, xtarget: CrossCompileTarget) -> "Project":
+    def _get_rootfs_class(self, xtarget: CrossCompileTarget) -> "type[Project]":
         from ..projects.cross.picolibc import BuildPicoLibc
 
-        return BuildPicoLibc.get_instance(self.project, cross_target=xtarget)
+        return BuildPicoLibc.get_class_for_target(xtarget)
 
 
 class BaremetalFreestandingTargetInfo(BaremetalClangTargetInfo):

--- a/pycheribuild/config/loader.py
+++ b/pycheribuild/config/loader.py
@@ -256,7 +256,7 @@ class CommandLineConfigOption(ConfigOptionBase[T]):
             if action_kind is None:
                 kwargs["action"] = StoreActionWithPossibleAliases
             else:
-                assert action_kind == "append", "Unhandled action " + action_kind
+                assert action_kind == "append", f"Unhandled action {action_kind}"
         # TODO: instantiate the actions and call parser_obj._add_action() to skip some slow argparse code
         # TODO: but need to investigate if that API is stable across versions
         if shortname:

--- a/pycheribuild/processutils.py
+++ b/pycheribuild/processutils.py
@@ -502,7 +502,7 @@ class CompilerInfo:
         return self._resource_dir
 
     def get_include_dirs(self, basic_flags: "list[str]") -> "list[Path]":
-        include_dirs = self._include_dirs.get(tuple(basic_flags), None)
+        include_dirs = self._include_dirs.get(tuple(*basic_flags), None)
         if include_dirs is None:
             if not self.path.exists():
                 return [Path("/unknown/include/dir")]  # avoid failing in jenkins
@@ -525,7 +525,7 @@ class CompilerInfo:
                 warning_message("Could not determine include dirs for", self.path, basic_flags)
             if self.config.verbose:
                 print("Include paths for", self.path, basic_flags, "are", include_dirs)
-            self._include_dirs[tuple(basic_flags)] = include_dirs
+            self._include_dirs[tuple(*basic_flags)] = include_dirs
         return list(include_dirs)
 
     def _supports_flag(self, flag: str, other_args: "list[str]") -> bool:
@@ -540,12 +540,12 @@ class CompilerInfo:
         return result.returncode == 0
 
     def supports_sanitizer_flag(self, sanitzer_flag: str, arch_flags: "list[str]"):
-        result = self._supported_sanitizer_flags.get((sanitzer_flag, tuple(arch_flags)))
+        result = self._supported_sanitizer_flags.get((sanitzer_flag, tuple(*arch_flags)))
         if result is None:
             assert sanitzer_flag.startswith("-fsanitize")
             result = self._supports_flag(sanitzer_flag,
                                          [*arch_flags, "-c", "-xc", "/dev/null", "-Werror", "-o", "/dev/null"])
-            self._supported_sanitizer_flags[(sanitzer_flag, tuple(arch_flags))] = result
+            self._supported_sanitizer_flags[(sanitzer_flag, tuple(*arch_flags))] = result
         return result
 
     def supports_warning_flag(self, flag: str) -> bool:

--- a/pycheribuild/projects/cross/benchmark_mixin.py
+++ b/pycheribuild/projects/cross/benchmark_mixin.py
@@ -36,6 +36,7 @@ from typing import Optional
 from .crosscompileproject import CompilationTargets
 from ..project import Project
 from ...config.chericonfig import BuildType
+from ...config.compilation_targets import CheriBSDTargetInfo
 from ...processutils import commandline_to_str
 from ...utils import SocketAndPort, find_free_port
 
@@ -116,9 +117,12 @@ class BenchmarkMixin(_BenchmarkMixinBase):
         from ...projects.cross.cheribsd import BuildCheriBsdMfsKernel, ConfigPlatform
         if self.config.benchmark_with_qemu:
             # When benchmarking with QEMU we always spawn a new instance
+            target = self.target_info
+            assert isinstance(target, CheriBSDTargetInfo)
             # noinspection PyProtectedMember
-            kernel_image = self.target_info._get_mfs_root_kernel(ConfigPlatform.QEMU,
-                                                                 not self.config.benchmark_with_debug_kernel)
+            kernel_image = target._get_run_project(xtarget.get_rootfs_target(), self).get_qemu_mfs_root_kernel(
+                not self.config.benchmark_with_debug_kernel,
+            )
             basic_args.append("--kernel-img=" + str(kernel_image))
         elif self.config.benchmark_clean_boot:
             # use a bitfile from jenkins. TODO: add option for overriding

--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -1782,8 +1782,8 @@ class BuildCheriBsdMfsKernel(BuildCHERIBSD):
 
     @cached_property
     def image(self) -> Path:
-        image_project = self.get_instance_for_target_name("disk-image-minimal", self.crosscompile_target, self)
-        return image_project.disk_image_path
+        from ..disk_image import BuildMfsRootCheriBSDDiskImage
+        return BuildMfsRootCheriBSDDiskImage.get_instance(self).disk_image_path
 
     @classmethod
     def setup_config_options(cls, **kwargs) -> None:

--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -1774,11 +1774,6 @@ class BuildCheriBsdMfsKernel(BuildCHERIBSD):
     # We want the CheriBSD config options as well, so that defaults (e.g. build-alternate-abi-kernels) are inherited.
     _config_inherits_from: "type[BuildCHERIBSD]" = BuildCHERIBSD
 
-    @classproperty
-    def mfs_root_image_class(self) -> "type[SimpleProject]":
-        from ..disk_image import BuildMfsRootCheriBSDDiskImage
-        return BuildMfsRootCheriBSDDiskImage
-
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         # No need to rebuild kernel-toolchain, the full toolchain must have
@@ -1787,7 +1782,8 @@ class BuildCheriBsdMfsKernel(BuildCHERIBSD):
 
     @cached_property
     def image(self) -> Path:
-        return self.mfs_root_image_class.get_instance(self).disk_image_path
+        image_project = self.get_instance_for_target_name("disk-image-minimal", self.crosscompile_target, self)
+        return image_project.disk_image_path
 
     @classmethod
     def setup_config_options(cls, **kwargs) -> None:

--- a/pycheribuild/projects/cross/llvm.py
+++ b/pycheribuild/projects/cross/llvm.py
@@ -37,6 +37,7 @@ from ..project import BuildType, ComputedDefaultValue, DefaultInstallDir, GitRep
 from ..simple_project import SimpleProject
 from ...config.chericonfig import CheriConfig
 from ...config.compilation_targets import (
+    BuildLLVMInterface,
     CheriBSDMorelloTargetInfo,
     CheriBSDTargetInfo,
     CompilationTargets,
@@ -556,7 +557,7 @@ exec {lld} "$@"
         self.run_cmd("du", "-sh", self.install_dir)
 
 
-class BuildLLVMMonoRepoBase(BuildLLVMBase):
+class BuildLLVMMonoRepoBase(BuildLLVMBase, BuildLLVMInterface):
     do_not_add_to_targets = True
     root_cmakelists_subdirectory = Path("llvm")
 
@@ -625,12 +626,6 @@ class BuildLLVMMonoRepoBase(BuildLLVMBase):
                     fatal_when_pretending=True,
                 )
         return super().process()
-
-    @classmethod
-    def get_native_install_path(cls, config: CheriConfig):
-        # This returns the path where the installed compiler is expected to be
-        # Note: When building LLVM in Jenkins this will not match the install_directory
-        raise NotImplementedError()
 
 
 class BuildCheriLLVM(BuildLLVMMonoRepoBase):

--- a/pycheribuild/projects/meson_project.py
+++ b/pycheribuild/projects/meson_project.py
@@ -126,7 +126,8 @@ class MesonProject(_CMakeAndMesonSharedLogic):
         # See https://github.com/mesonbuild/meson/issues/6220, https://github.com/mesonbuild/meson/issues/6541, etc.
         if not self.compiling_for_host():
             extra_libdirs = [s / self.target_info.default_libdir for s in self.dependency_install_prefixes]
-            with contextlib.suppress(LookupError):  # If there isn't a rootfs, we use the absolute paths instead.
+            # If there isn't a rootfs, we use the absolute paths instead.
+            with contextlib.suppress(LookupError, ValueError):
                 # If we are installing into a rootfs, remove the rootfs prefix from the RPATH
                 extra_libdirs = ["/" + str(s.relative_to(self.rootfs_dir)) for s in extra_libdirs]
             rpath_dirs = remove_duplicates(self.target_info.additional_rpath_directories + extra_libdirs)

--- a/pycheribuild/projects/repository.py
+++ b/pycheribuild/projects/repository.py
@@ -190,9 +190,9 @@ class GitRepository(SourceRepository):
                     break  # end of metadata information
                 key, value = line[1:].decode("utf-8").split(None, maxsplit=1)
                 headers[key] = value
-            upstream = headers.get("branch.upstream", None)
+            upstream = headers.get("branch.upstream", "")
             remote_name, remote_branch = upstream.split("/", maxsplit=1) if upstream else (None, None)
-            return GitBranchInfo(local_branch=headers.get("branch.head", None),
+            return GitBranchInfo(local_branch=headers.get("branch.head", ""),
                                  remote_name=remote_name, upstream_branch=remote_branch)
         except subprocess.CalledProcessError as e:
             if isinstance(e.__cause__, FileNotFoundError):

--- a/pycheribuild/projects/run_qemu.py
+++ b/pycheribuild/projects/run_qemu.py
@@ -50,7 +50,7 @@ from .disk_image import (
 )
 from .project import CheriConfig, ComputedDefaultValue, CPUArchitecture, Project
 from .simple_project import BoolConfigOption, SimpleProject, TargetAliasWithDependencies
-from ..config.compilation_targets import CompilationTargets
+from ..config.compilation_targets import CompilationTargets, LaunchFreeBSDInterface
 from ..config.target_info import CrossCompileTarget
 from ..qemu_utils import QemuOptions, qemu_supports_9pfs, riscv_bios_arguments
 from ..utils import AnsiColour, OSInfo, classproperty, coloured, fatal_error, find_free_port, is_jenkins_build
@@ -588,7 +588,7 @@ class LaunchQEMUBase(SimpleProject):
             return False
 
 
-class AbstractLaunchFreeBSD(LaunchQEMUBase):
+class AbstractLaunchFreeBSD(LaunchQEMUBase, LaunchFreeBSDInterface):
     do_not_add_to_targets = True
     kernel_project: Optional[BuildFreeBSD]
     disk_image_project: Optional[BuildDiskImageBase]

--- a/pycheribuild/projects/run_qemu.py
+++ b/pycheribuild/projects/run_qemu.py
@@ -770,6 +770,15 @@ class LaunchCheriBSD(_RunMultiArchFreeBSDImage):
             result += ("bbl-baremetal-riscv64-purecap",)
         return result
 
+    def get_qemu_mfs_root_kernel(self, use_benchmark_kernel: bool) -> Path:
+        xtarget = self.crosscompile_target.get_rootfs_target()
+        if xtarget not in BuildCheriBsdMfsKernel.supported_architectures:
+            self.fatal("No MFS kernel for target", xtarget)
+            raise ValueError()
+        mfs_kernel = BuildCheriBsdMfsKernel.get_instance_for_cross_target(xtarget, self.config, caller=self)
+        kernconf = mfs_kernel.default_kernel_config(ConfigPlatform.QEMU, benchmark=use_benchmark_kernel)
+        return mfs_kernel.get_kernel_install_path(kernconf)
+
 
 class LaunchDmQEMU(LaunchCheriBSD):
     target = "run-dm"


### PR DESCRIPTION
Avoid cyclic (deferred) imports and use a string target name lookup instead of ProjectCls.get_instance().

The main benefit here is that it allows pytype to run more checks in parallel. It may also result in a very minor speedup.

PR for CI checks.