### PR TITLE
Pass compiler/linker flags to CMake for -native-hybrid

### DIFF
--- a/pycheribuild/config/target_info.py
+++ b/pycheribuild/config/target_info.py
@@ -860,6 +860,9 @@ class CrossCompileTarget:
         assert self.target_info_cls is not None
         return self.target_info_cls.is_native()
 
+    def is_native_hybrid(self) -> bool:
+        return self.is_native() and self._is_cheri_hybrid
+
     def _check_arch(self, arch: CPUArchitecture, include_purecap: "Optional[bool]") -> bool:
         if self.cpu_architecture is not arch:
             return False

--- a/pycheribuild/projects/cmake_project.py
+++ b/pycheribuild/projects/cmake_project.py
@@ -198,7 +198,7 @@ class CMakeProject(_CMakeAndMesonSharedLogic):
             CMAKE_CXX_COMPILER=self.CXX,
             CMAKE_ASM_COMPILER=self.CC,  # Compile assembly files with the default compiler
         )
-        if not self.compiling_for_host():
+        if not self.compiling_for_host() or self.compiling_for_host_hybrid():
             # Add compiler/linker flags (for cross-compilation these are defined in the toolchain file).
             # Note: All of these should be commandlines not CMake lists.
             self.add_cmake_options(

--- a/pycheribuild/projects/simple_project.py
+++ b/pycheribuild/projects/simple_project.py
@@ -658,6 +658,9 @@ class SimpleProject(AbstractProject, metaclass=ABCMeta if typing.TYPE_CHECKING e
     def compiling_for_host(self) -> bool:
         return self.crosscompile_target.is_native()
 
+    def compiling_for_host_hybrid(self) -> bool:
+        return self.crosscompile_target.is_native_hybrid()
+
     def compiling_for_riscv(self, include_purecap: bool) -> bool:
         return self.crosscompile_target.is_riscv(include_purecap=include_purecap)
 


### PR DESCRIPTION
morello-llvm-native on CheriBSD/Morello requires -mabi=aapcs in CFLAGS. Otherwise, it would be compiled with -mabi=purecap that cc uses by default on CheriBSD with purecap world.