### PR TITLE
GitHub Actions: Pin ruff to the same version as pre-commit

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -20,12 +20,7 @@ jobs:
                 run: |
                     # Run as a non-root user to avoid cheribuild errors
                     adduser --disabled-password --gecos "Not Root" notroot
-                    su -c "python -m pip install --user --upgrade pip" notroot
-                    su -c "pip install --user -r requirements.txt" notroot
-            -   name: Lint with flake8
-                run: |
-                    # stop the build if there are any flake8 warnings
-                    su -c "python -m flake8" notroot
+                    su -c "python -m pip install --user --upgrade pip pytest" notroot
             -   name: Run basic regression tests
                 run: su -c "tests/run_basic_tests.sh" notroot
     build-macos:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -21,8 +21,7 @@ jobs:
                     # Run as a non-root user to avoid cheribuild errors
                     adduser --disabled-password --gecos "Not Root" notroot
                     su -c "python -m pip install --user --upgrade pip" notroot
-                    su -c " pip install --user --upgrade flake8 pytest" notroot
-                    su -c "if [ -f requirements.txt ]; then pip install --user -r requirements.txt; fi" notroot
+                    su -c "pip install --user -r requirements.txt" notroot
             -   name: Lint with flake8
                 run: |
                     # stop the build if there are any flake8 warnings
@@ -38,8 +37,8 @@ jobs:
                     # Use the system-provided python3 instead of actions/setup-python@v4
                     python3 --version
                     python3 -m pip install --upgrade pip
-                    python3 -m pip install --upgrade flake8 pytest ruff pre-commit
-                    if [ -f requirements.txt ]; then python3 -m pip install -r requirements.txt; fi
+                    python3 -m pip install --upgrade pre-commit
+                    python3 -m pip install -r requirements.txt
             -   name: Lint with flake8
                 run: flake8
             -   name: Lint with ruff
@@ -60,7 +59,7 @@ jobs:
             -   name: Install dependencies
                 run: |
                     python -m pip install --upgrade pip
-                    pip install --upgrade flake8 ruff pre-commit
+                    pip install --upgrade pre-commit
                     if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
             -   name: Lint with flake8
                 run: flake8

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -9,6 +9,9 @@ on:
     pull_request:
         branches: [ main ]
 
+env:
+    RUFF_VERSION: 0.3.4
+
 jobs:
     build-baseline:
         runs-on: ubuntu-latest
@@ -32,7 +35,7 @@ jobs:
                     # Use the system-provided python3 instead of actions/setup-python@v4
                     python3 --version
                     python3 -m pip install --upgrade pip
-                    python3 -m pip install --upgrade pre-commit
+                    python3 -m pip install --upgrade pre-commit ruff==${{ env.RUFF_VERSION }}
                     python3 -m pip install -r requirements.txt
             -   name: Lint with flake8
                 run: flake8
@@ -54,7 +57,7 @@ jobs:
             -   name: Install dependencies
                 run: |
                     python -m pip install --upgrade pip
-                    pip install --upgrade pre-commit
+                    pip install --upgrade pre-commit ruff==${{ env.RUFF_VERSION }}
                     if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
             -   name: Lint with flake8
                 run: flake8

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,4 +5,3 @@ argcomplete>=2.0.0
 # Only needed for RISC-V FPGA boot -> not bundled
 pyserial>=3.5
 flake8
-ruff==0.3.4

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,3 +5,4 @@ argcomplete>=2.0.0
 # Only needed for RISC-V FPGA boot -> not bundled
 pyserial>=3.5
 flake8
+ruff==0.3.4

--- a/tests/run_basic_tests.sh
+++ b/tests/run_basic_tests.sh
@@ -12,9 +12,6 @@ try_run_verbose() {
     fi
 }
 
-# check for errors that would fail the GitHub CI:
-try_run_verbose python3 -m flake8
-
 # check that there are no obvious mistakes:
 sh "$SCRIPT_DIR/run_smoke_tests.sh"
 

--- a/tests/test_argument_parsing.py
+++ b/tests/test_argument_parsing.py
@@ -829,10 +829,7 @@ def test_disk_image_path(target, expected_name):
         pytest.param(
             "cheribsd-riscv64-purecap",
             [],
-            [
-                "CHERI-QEMU",
-                "CHERI-PURECAP-QEMU"
-            ],
+            ["CHERI-QEMU", "CHERI-PURECAP-QEMU"],
         ),
         pytest.param(
             "cheribsd-riscv64-purecap",
@@ -907,10 +904,7 @@ def test_disk_image_path(target, expected_name):
             ["CUSTOM-KERNEL-CONFIG"],
         ),
         # Morello kernconf tests
-        pytest.param(
-            "cheribsd-aarch64",
-            [],
-            ["GENERIC"]),
+        pytest.param("cheribsd-aarch64", [], ["GENERIC"]),
         pytest.param(
             "cheribsd-morello-purecap",
             ["--cheribsd/no-build-alternate-abi-kernels"],


### PR DESCRIPTION
Similar to https://github.com/CTSRD-CHERI/cheribuild/pull/395
but centralizing it in requirements.txt