### PR TITLE
Revert "Default to purecap kernels for CheriBSD"

### DIFF
--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -1865,7 +1865,7 @@ class BuildCHERIBSD(BuildFreeBSD):
             _allow_unknown_targets=True,
             only_add_for_targets=cls.purecap_kernel_targets,
             kind=KernelABI,
-            default=KernelABI.PURECAP,
+            default=KernelABI.HYBRID,
             enum_choices=[KernelABI.HYBRID, KernelABI.PURECAP],
             help="Select default kernel to build",
         )

--- a/tests/test_argument_parsing.py
+++ b/tests/test_argument_parsing.py
@@ -528,7 +528,7 @@ def test_kernconf():
     freebsd_native = _get_target_instance("freebsd-amd64", config, BuildFreeBSD)
     assert config.freebsd_kernconf is None
     assert freebsd_riscv.kernel_config == "QEMU"
-    assert cheribsd_riscv_hybrid.kernel_config == "CHERI-PURECAP-QEMU"
+    assert cheribsd_riscv_hybrid.kernel_config == "CHERI-QEMU"
     assert freebsd_native.kernel_config == "GENERIC"
 
     # Check that --kernconf is used as the fallback
@@ -816,23 +816,20 @@ def test_disk_image_path(target, expected_name):
         pytest.param(
             "cheribsd-riscv64-purecap",
             ["--cheribsd/no-build-alternate-abi-kernels"],
-            ["CHERI-PURECAP-QEMU"],
+            ["CHERI-QEMU"],
         ),
         pytest.param(
             "cheribsd-riscv64-purecap",
             ["--cheribsd/build-fpga-kernels"],
             [
-                "CHERI-PURECAP-QEMU",
                 "CHERI-QEMU",
+                "CHERI-PURECAP-QEMU",
             ],
         ),
         pytest.param(
             "cheribsd-riscv64-purecap",
             [],
-            [
-                "CHERI-PURECAP-QEMU",
-                "CHERI-QEMU",
-            ],
+            ["CHERI-QEMU", "CHERI-PURECAP-QEMU"],
         ),
         pytest.param(
             "cheribsd-riscv64-purecap",
@@ -846,34 +843,35 @@ def test_disk_image_path(target, expected_name):
             "cheribsd-riscv64-purecap",
             ["--cheribsd/build-fett-kernels", "--cheribsd/no-build-alternate-abi-kernels"],
             [
-                "CHERI-PURECAP-QEMU",
-            ],
-        ),
-        pytest.param(
-            "cheribsd-riscv64-purecap",
-            ["--cheribsd/build-fett-kernels"],
-            [
-                "CHERI-PURECAP-QEMU",
                 "CHERI-QEMU",
                 "CHERI-QEMU-FETT",
             ],
         ),
         pytest.param(
             "cheribsd-riscv64-purecap",
+            ["--cheribsd/build-fett-kernels"],
+            [
+                "CHERI-QEMU",
+                "CHERI-QEMU-FETT",
+                "CHERI-PURECAP-QEMU",
+            ],
+        ),
+        pytest.param(
+            "cheribsd-riscv64-purecap",
             ["--cheribsd/build-bench-kernels", "--cheribsd/no-build-alternate-abi-kernels"],
             [
-                "CHERI-PURECAP-QEMU",
-                "CHERI-PURECAP-QEMU-NODEBUG",
+                "CHERI-QEMU",
+                "CHERI-QEMU-NODEBUG",
             ],
         ),
         pytest.param(
             "cheribsd-riscv64-purecap",
             ["--cheribsd/build-bench-kernels"],
             [
-                "CHERI-PURECAP-QEMU",
-                "CHERI-PURECAP-QEMU-NODEBUG",
                 "CHERI-QEMU",
                 "CHERI-QEMU-NODEBUG",
+                "CHERI-PURECAP-QEMU",
+                "CHERI-PURECAP-QEMU-NODEBUG",
             ],
         ),
         pytest.param(
@@ -884,19 +882,20 @@ def test_disk_image_path(target, expected_name):
                 "--cheribsd/no-build-alternate-abi-kernels",
             ],
             [
-                "CHERI-PURECAP-QEMU",
-                "CHERI-PURECAP-FETT",
+                "CHERI-QEMU",
+                "CHERI-QEMU-FETT",
+                "CHERI-FETT",
             ],
         ),
         pytest.param(
             "cheribsd-riscv64-purecap",
             ["--cheribsd/build-fett-kernels", "--cheribsd/build-fpga-kernels"],
             [
-                "CHERI-PURECAP-QEMU",
                 "CHERI-QEMU",
                 "CHERI-QEMU-FETT",
-                "CHERI-PURECAP-FETT",
+                "CHERI-PURECAP-QEMU",
                 "CHERI-FETT",
+                "CHERI-PURECAP-FETT",
             ],
         ),
         pytest.param(
@@ -907,14 +906,16 @@ def test_disk_image_path(target, expected_name):
         # Morello kernconf tests
         pytest.param("cheribsd-aarch64", [], ["GENERIC"]),
         pytest.param(
-            "cheribsd-morello-purecap", ["--cheribsd/no-build-alternate-abi-kernels"], ["GENERIC-MORELLO-PURECAP"]
+            "cheribsd-morello-purecap",
+            ["--cheribsd/no-build-alternate-abi-kernels"],
+            ["GENERIC-MORELLO"],
         ),
         pytest.param(
             "cheribsd-morello-purecap",
             [],
             [
-                "GENERIC-MORELLO-PURECAP",
                 "GENERIC-MORELLO",
+                "GENERIC-MORELLO-PURECAP",
             ],
         ),
         pytest.param(
@@ -957,16 +958,19 @@ def test_kernel_configs(target, config_options: "list[str]", expected_kernels: "
                 "--cheribsd-mfs-root-kernel-riscv64-purecap/build-fpga-kernels",
                 "--cheribsd-mfs-root-kernel-riscv64-purecap/no-build-alternate-abi-kernels",
             ],
-            ["CHERI-PURECAP-QEMU-MFS-ROOT", "CHERI-PURECAP-GFE"],
+            [
+                "CHERI-QEMU-MFS-ROOT",
+                "CHERI-GFE",
+            ],
         ),
         pytest.param(
             "cheribsd-mfs-root-kernel-riscv64-purecap",
             ["--cheribsd-mfs-root-kernel-riscv64-purecap/build-fpga-kernels"],
             [
-                "CHERI-PURECAP-QEMU-MFS-ROOT",
                 "CHERI-QEMU-MFS-ROOT",
-                "CHERI-PURECAP-GFE",
+                "CHERI-PURECAP-QEMU-MFS-ROOT",
                 "CHERI-GFE",
+                "CHERI-PURECAP-GFE",
             ],
         ),
         pytest.param(
@@ -992,10 +996,10 @@ def test_kernel_configs(target, config_options: "list[str]", expected_kernels: "
             "cheribsd-mfs-root-kernel-riscv64-purecap",
             ["--cheribsd/build-nocaprevoke-kernel"],
             [
-                "CHERI-PURECAP-QEMU-MFS-ROOT",
-                "CHERI-PURECAP-NOCAPREVOKE-QEMU-MFS-ROOT",
                 "CHERI-QEMU-MFS-ROOT",
                 "CHERI-NOCAPREVOKE-QEMU-MFS-ROOT",
+                "CHERI-PURECAP-QEMU-MFS-ROOT",
+                "CHERI-PURECAP-NOCAPREVOKE-QEMU-MFS-ROOT",
             ],
         ),
     ],
@@ -1327,7 +1331,7 @@ def test_mfs_root_kernel_inherits_defaults_from_cheribsd():
         ],
     )
     assert cheribsd_riscv64_purecap.kernel_config == "BASE_CONFIG_RISCV64"
-    assert cheribsd_riscv64_hybrid.kernel_config == "CHERI-PURECAP-QEMU"
+    assert cheribsd_riscv64_hybrid.kernel_config == "CHERI-QEMU"
     assert mfs_riscv64.kernel_config is None
     assert mfs_riscv64_hybrid.kernel_config == "MFS_CONFIG_RISCV64_HYBRID"
     _parse_arguments(


### PR DESCRIPTION
This reverts commit de423d149a976a5118d88d879a4a64ae0487400d.