### PR TITLE
Add --with-build-python to Python cross-compilation configuration

### DIFF
--- a/pycheribuild/projects/cross/python.py
+++ b/pycheribuild/projects/cross/python.py
@@ -93,6 +93,7 @@ class BuildPython(CrossCompileAutotoolsProject):
                 ac_cv_file__dev_ptmx="no",  # no /dev/ptmx file on cheribsd
                 ac_cv_file__dev_ptc="no",  # no /dev/ptc file on cheribsd
             )
+            self.configure_args.append(f"--with-build-python={native_python}")
             # self.configure_environment["ac_cv_file__dev_ptmx+set"] = "set"
             # self.configure_environment["ac_cv_file__dev_ptc+set"] = "set"
             # TODO: do I need to set? ac_sys_release=13.0


### PR DESCRIPTION
Single line change that fixes cross-compilation of Python.