### PR TITLE
Add time to fedora package list

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you are building CHERI on a RHEL/Fedora-based machine, the following command 
 the most commonly used cheribuild targets:
 
 ```shell
-dnf install libtool clang-devel bison cmake mercurial ninja-build samba flex texinfo glib2-devel pixman-devel libarchive-devel bsdtar bzip2-devel libattr-devel libcap-ng-devel expat-devel
+dnf install libtool clang-devel bison cmake mercurial ninja-build samba flex texinfo glib2-devel pixman-devel libarchive-devel bsdtar bzip2-devel libattr-devel libcap-ng-devel expat-devel time
 ```
 
 #### FreeBSD


### PR DESCRIPTION
I found on Fedora 40 (qubes) that the only time executable was the shell builtin, which caused a rather cryptic error for cheribuild, complaining "MAKEOBJDIRPREFIX" is not set, cannot continue! "  Installing the package fixed it and the build worked without a hitch.