### PR TITLE
Add build for B-lang-org/bsc-contrib repo as 'bluespec-libraries' target, also add 'bluespec' alias

### DIFF
--- a/pycheribuild/projects/bluespec_compiler.py
+++ b/pycheribuild/projects/bluespec_compiler.py
@@ -28,7 +28,6 @@
 # SUCH DAMAGE.
 #
 from .project import DefaultInstallDir, GitRepository, MakeCommandKind, Project
-from .project import ExternallyManagedSourceRepository
 from .simple_project import TargetAliasWithDependencies
 from ..utils import OSInfo
 

--- a/pycheribuild/projects/bluespec_compiler.py
+++ b/pycheribuild/projects/bluespec_compiler.py
@@ -28,6 +28,8 @@
 # SUCH DAMAGE.
 #
 from .project import DefaultInstallDir, GitRepository, MakeCommandKind, Project
+from .project import ExternallyManagedSourceRepository
+from .simple_project import TargetAliasWithDependencies
 from ..utils import OSInfo
 
 
@@ -86,3 +88,26 @@ class BuildBluespecCompiler(Project):
 
     def run_tests(self) -> None:
         self.run_cmd("check-smoke")
+
+
+class BuildBluespecLibraries(Project):
+    target = "bluespec-libraries"
+    dependencies = ("bluespec-compiler",)
+    default_directory_basename = "bsc-contrib"
+    repository = GitRepository("https://github.com/B-Lang-org/bsc-contrib.git")
+    native_install_dir = DefaultInstallDir.BOOTSTRAP_TOOLS
+    build_in_source_dir = True
+    make_kind = MakeCommandKind.GnuMake
+
+    def compile(self, **kwargs):
+        self.make_args.set(PREFIX=self.install_dir)
+        self.run_make("all")
+
+    def clean(self):
+        self.make_args.set(PREFIX=self.install_dir)
+        self.run_make("full_clean", cwd=self.source_dir)
+
+
+class BuildBluespec(TargetAliasWithDependencies):
+    target = "bluespec"
+    dependencies = ("bluespec-libraries",)


### PR DESCRIPTION
'bluespec-libraries' builds and installs the B-lang-org/bsc-contrib repo into the local install.

'bluespec' is a dummy target which depends on 'bluespec-libraries' which depends on 'bluespec-compiler', so building 'bluespec' with dependencies builds both.

Upstream bluespec-compiler's makefile tends to rebuild all its BSV files even if nothing changed, so building 'bluespec-libraries' also causes the BSV inside bluespec-compiler to get rebuilt.  Not sure if there's an easy solution for this.