### PR TITLE
gmake: bootstrap to fetch gnulib before configuring

### DIFF
--- a/pycheribuild/projects/cross/gmake.py
+++ b/pycheribuild/projects/cross/gmake.py
@@ -54,3 +54,7 @@ class BuildGmake(CrossCompileAutotoolsProject):
             # when the locale is something like en_GB.UTF-8. C.UTF-8 seems to
             # work fine, not just C, so use that for the build.
             self.make_args.set_env(LC_ALL="C.UTF-8")
+
+    def configure(self, **kwargs):
+        self.run_cmd(self.source_dir / "bootstrap", cwd=self.source_dir)
+        super().configure(**kwargs)


### PR DESCRIPTION
Without this, the build dies with

```
cd /cheri/source/mainline/gmake && /cheri/source/mainline/gmake/autogen.sh
/cheri/source/mainline/gmake/autogen.sh: 1088: cannot open gnulib/gnulib-tool: No such file
Fatal error (in target gmake-aarch64): Command `/cheri/source/mainline/gmake/autogen.sh` failed with non-zero exit code 2. Working directory was /cheri/source/mainline/gmake
```