### PR TITLE
cheribsd: use llvm-link from the SDK

### DIFF
--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -1044,6 +1044,7 @@ class BuildFreeBSD(BuildFreeBSDBase):
                 XSTRINGS=cross_bindir / "llvm-strings",
                 XOBJCOPY=cross_bindir / "llvm-objcopy",
                 XRANLIB=cross_bindir / "llvm-ranlib",
+                XLLVM_LINK=cross_bindir / "llvm-link",
             )
         if xccinfo.is_clang and xccinfo.version < (10, 0):
             # llvm-ranlib didn't support -D flag (see https://bugs.llvm.org/show_bug.cgi?id=41707)


### PR DESCRIPTION
llvm-link is used by the kernel-c18n branch to generate an IR file of the kernel.

A corresponding change making use of this is in https://github.com/CTSRD-CHERI/cheribsd/commit/ae7327c781363ae6885e9716971c3052716197a6.