### PR TITLE
Work around newlib compilation failure with clang-15 

### DIFF
--- a/pycheribuild/projects/cross/newlib.py
+++ b/pycheribuild/projects/cross/newlib.py
@@ -95,6 +95,7 @@ class BuildNewlib(CrossCompileAutotoolsProject):
         super().setup()
         # ensure that we don't fall back to system headers (but do use stddef.h from clang...)
         self.COMMON_FLAGS.extend(["--sysroot", "/this/path/does/not/exist"])
+        self.COMMON_FLAGS.extend(["-Wno-implicit-function-declaration"])
 
         target_cflags = self.commandline_to_str(self.essential_compiler_and_linker_flags + self.COMMON_FLAGS)
         bindir = self.sdk_bindir


### PR DESCRIPTION
The command `./cheribuild.py newlib-baremetal-riscv64-purecap -d` currently fails when using clang-15.

This issue has been reported multiple times on the Cheri Slack channel. 

As a workaround, this commit adds the `-Wno-implicit-function-declaration` option to suppress these errors. While this may not be a permanent fix, it should unblock users and help others facing the same problem.