### PR TITLE
cheribsd-release: allow to use custom configs

### DIFF
--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -2209,7 +2209,7 @@ class BuildFreeBSDReleaseMixin(ReleaseMixinBase):
 
         # release/Makefile needs to install both world and kernel to create
         # images, so start with the arguments for the combination of the two.
-        kernconfs = self.get_kernel_configs(None)
+        kernconfs = self.kernconf_list()
         release_args = self.installworld_args.copy()
         release_args.update(self.kernel_make_args_for_config(kernconfs, None).copy())
 


### PR DESCRIPTION
Use the same routines to get a list of kernel configurations to include in release files as is used when building a CheriBSD rootfs.

This can be either --kernel-config or --cheribsd-release-*/kernel-config.