### PR TITLE
qemu: always build hybrid

### DIFF
--- a/pycheribuild/projects/build_qemu.py
+++ b/pycheribuild/projects/build_qemu.py
@@ -480,6 +480,8 @@ class BuildQEMU(BuildQEMUBase):
         show_help=True,
         help="Collect statistics on out-of-bounds capability creation.",
     )
+    supported_architectures = (CompilationTargets.NATIVE_NON_PURECAP,)
+    default_architecture = CompilationTargets.NATIVE_NON_PURECAP
 
     @classmethod
     def qemu_binary_for_target(cls, xtarget: CrossCompileTarget, config: CheriConfig):


### PR DESCRIPTION
Always build QEMU for hybrid. We don't support purecap yet.

This fixes building QEMU natively on CheriBSD/Morello.