### PR TITLE
Morello/baremetal: match Freestanding's sysroot dir

### DIFF
--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -1051,9 +1051,8 @@ class MorelloBaremetalTargetInfo(BaremetalFreestandingTargetInfo):
 
     @property
     def sysroot_dir(self) -> Path:
-        suffix = self.target.get_rootfs_target().generic_arch_suffix
         sysroot_dir = self.config.sysroot_output_root / self.config.default_morello_sdk_directory_name
-        return sysroot_dir / "baremetal" / suffix / self.target_triple
+        return sysroot_dir / "baremetal" / self.target.get_rootfs_target().generic_arch_suffix
 
     @classmethod
     def triple_for_target(cls, target, config, include_version: bool) -> str:


### PR DESCRIPTION
NewlibBaremetalTargetInfo targets should add the target triple to the sysroot, as this was the layout expected by Newlib’s multilib install layout (and GCC's sysroot). The current MorelloBaremetal targets shouldn't assume a Newlib/GCC sysroot and should follow the FreeStanding target one. If there's a need for GCC's sysroot and multilib layout, this should go to a new NewlibMorelloBaremetalTargetInfo or something.