### PR TITLE
Fix install dir conflict checks to not call setup()

### DIFF
--- a/pycheribuild/projects/project.py
+++ b/pycheribuild/projects/project.py
@@ -1674,21 +1674,18 @@ add_custom_target(cheribuild-full VERBATIM USES_TERMINAL COMMAND {command} {targ
                 xtarget.check_conflict_with is not None
                 and xtarget.check_conflict_with in self.supported_architectures()
             ):
-                # Check that we are not installing to the same directory as MIPS to avoid conflicts
+                # Check that we are not installing to the same directory to avoid conflicts
                 base = getattr(self, "synthetic_base", None)
                 assert base is not None
                 assert issubclass(base, SimpleProject)
-                other_instance = base.get_instance_for_cross_target(
-                    xtarget.check_conflict_with, self.config, caller=self
-                )
+                other_xtarget = xtarget.check_conflict_with
+                other_cls = base.get_class_for_target(other_xtarget)
                 if self.config.verbose:
                     self.info(self.target, "install dir for", xtarget.name, "is", self.install_dir)
-                    other_xtarget = other_instance.crosscompile_target
                     self.info(self.target, "install dir for", other_xtarget.name, "is", self.install_dir)
-                assert other_instance.install_dir != self.install_dir, (
-                    other_instance.target
-                    + " reuses the same install prefix! This will cause conflicts: "
-                    + str(other_instance.install_dir)
+                other_install_dir = other_cls.get_install_dir(self, other_xtarget)
+                assert other_install_dir != self.install_dir, (
+                    f"{other_cls.target} reuses the same install prefix! This will cause conflicts: {other_install_dir}"
                 )
 
         if self.skip_update:


### PR DESCRIPTION
This caused problems when running the
`morello-busybox-linux-morello-purecap` target since instantiating the aarch64 class just to get the install dir triggered the following error:

```
Fatal error (in target morello-busybox-linux-morello-purecap): Project morello-busybox-linux-aarch64 needs a sysroot, but /..../cheri/output/morello-sdk/linux/linux-aarch64 is empty or does not exist.
```

Inside setup() we call `essential_compiler_and_linker_flags` which checks whether the sysroot exists and causes the error. Fix this by not calling setup() in the overlapping install dir check.