### PR TITLE
test-scripts: fix race condition in parallel libc++ tests

### DIFF
--- a/test-scripts/run_libcxx_tests.py
+++ b/test-scripts/run_libcxx_tests.py
@@ -400,12 +400,19 @@ def run_parallel_impl(
                         loop_start_time - start_time,
                     )
                 if len(processes_in_next_stage) == len(processes):
+                    # We have received the NEXT_STAGE message from all shards, but they might not have reached the
+                    # barrier wait() yet.
+                    while mp_barrier.n_waiting < len(processes):
+                        for p in processes:
+                            if not p.is_alive():
+                                boot_cheribsd.failure(f"Shard {p.name} died before reaching the barrier!", exit=True)
+                        time.sleep(0.1)
                     boot_cheribsd.success(
                         f"All shards have reached stage {processes_in_next_stage[0]} succesfully. "
                         f"Releasing barrier (num_waiting = {mp_barrier.n_waiting})",
                     )
                     assert mp_barrier.n_waiting == len(processes), f"{mp_barrier.n_waiting} != {len(processes)}"
-                    mp_barrier.wait(timeout=1)
+                    mp_barrier.wait()
                     boot_cheribsd.success(f"Barrier has been released, entering {target_process.stage} stage.")
                     processes_in_next_stage = []
             elif shard_result[0] == run_remote_lit_test.FAILURE:

--- a/tests/run_smoke_tests.sh
+++ b/tests/run_smoke_tests.sh
@@ -62,7 +62,14 @@ try_run env PATH=/does/not/exist "$(command -v python3)" "${srcdir}/cheribuild.p
 try_run env WORKSPACE=/tmp "${srcdir}/jenkins-cheri-build.py" --allow-more-than-one-target --build --test --cpu=default -p __run_everything__
 # Check that the CheriBSD test script works
 try_run "${srcdir}/test-scripts/run_cheribsd_tests.py" -p --architecture morello-purecap --ssh-key path/to/test/ssh_key.pub --qemu-cmd /path/to/sdk/bin/qemu-system-morello --disk-image /path/to/output/cheribsd-morello-purecap.img --test-output-dir=/path/to/build/test-results/run-morello-purecap
-try_run "${srcdir}/test-scripts/run_libcxx_tests.py" -p --architecture riscv64 --ssh-key /path/to/build/insecure_test_ssh_key.pub --kernel /path/to/output/kernel-riscv64.QEMU-MFS-ROOT --qemu-cmd /path/to/output/sdk/bin/qemu-system-riscv64cheri --build-dir /path/to/build/upstream-llvm-libs-riscv64-build --sysroot-dir /path/to/output/rootfs-riscv64 --lit-debug-output --ssh-executor-script /path/to/upstream-llvm-project/runtimes/../libcxx/utils/ssh.py --parallel-jobs 2 --multiprocessing-debug
+LIBCXX_SMOKE_TEST_CMD="${srcdir}/test-scripts/run_libcxx_tests.py -p --architecture riscv64 --ssh-key /path/to/build/insecure_test_ssh_key.pub --kernel /path/to/output/kernel-riscv64.QEMU-MFS-ROOT --qemu-cmd /path/to/output/sdk/bin/qemu-system-riscv64cheri --build-dir /path/to/build/upstream-llvm-libs-riscv64-build --sysroot-dir /path/to/output/rootfs-riscv64 --lit-debug-output --ssh-executor-script /path/to/upstream-llvm-project/runtimes/../libcxx/utils/ssh.py --parallel-jobs 2 --multiprocessing-debug"
+# shellcheck disable=SC2086
+try_run $LIBCXX_SMOKE_TEST_CMD
+if command -v taskset >/dev/null 2>&1; then
+    # Also run with taskset -c 0 to simulate heavy load/single CPU which previously triggered a race condition
+    # shellcheck disable=SC2086
+    try_run taskset -c 0 $LIBCXX_SMOKE_TEST_CMD
+fi
 # We were previously hitting an error while argument completing, check that it works now:
 if python3 -c 'import argcomplete'; then
     # We previously crashed while completing options that inherited their value from a parent class, but that parent


### PR DESCRIPTION
The main process could sometimes check the barrier's waiting count
before all shards had reached the barrier, even after receiving
the NEXT_STAGE message. This was especially prevalent in single-CPU
or high-load environments.

Fix this by:
1. Adding a loop to wait for mp_barrier.n_waiting == len(processes).
2. Removing the short 1s timeout on mp_barrier.wait(), as the
   barrier already has a 4-hour timeout and a short one is prone
   to spurious failures under load.
3. Adding a check to ensure shards are still alive while waiting.