### PR TITLE
musl: allow building CA's muslc for Morello

### DIFF
--- a/pycheribuild/projects/cross/muslc.py
+++ b/pycheribuild/projects/cross/muslc.py
@@ -102,10 +102,10 @@ class BuildAllianceLinuxMuslc(BuildMuslc):
 
     def setup(self) -> None:
         if self.crosscompile_target.is_riscv(include_purecap=True):
-            self.configure_args.extend(["--enable-bakewell --enable-debug"])
+            self.configure_args.append("--enable-bakewell")
         elif self.crosscompile_target.is_aarch64(include_purecap=True):
-            self.configure_args.extend(["--enable-morello"])
-
+            self.configure_args.append("--enable-morello")
+        self.configure_args.append("--enable-debug")
         # FIXME Need to add the compiler resource directory as Codasip's muslc includes
         # cheri_init_globals_bw.h while building with -nostdinc
         resource_dir = self.get_compiler_info(self.CC).get_resource_dir()

--- a/pycheribuild/projects/cross/muslc.py
+++ b/pycheribuild/projects/cross/muslc.py
@@ -101,7 +101,11 @@ class BuildAllianceLinuxMuslc(BuildMuslc):
     dependencies = ("cheri-std093-compiler-rt-builtins", "cheri-std093-linux-kernel")
 
     def setup(self) -> None:
-        self.configure_args.extend(["--enable-bakewell --enable-debug"])
+        if self.crosscompile_target.is_riscv(include_purecap=True):
+            self.configure_args.extend(["--enable-bakewell --enable-debug"])
+        elif self.crosscompile_target.is_aarch64(include_purecap=True):
+            self.configure_args.extend(["--enable-morello"])
+
         # FIXME Need to add the compiler resource directory as Codasip's muslc includes
         # cheri_init_globals_bw.h while building with -nostdinc
         resource_dir = self.get_compiler_info(self.CC).get_resource_dir()


### PR DESCRIPTION
This commit enables building CHERI Alliance's muslc for Morello (once https://github.com/CHERI-Alliance/musl/pull/4 is merged) 