### PR TITLE
CHERI-Linux: Refactor target names

### DIFF
--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -897,8 +897,8 @@ class LinuxTargetInfoBase(_ClangBasedTargetInfo, ABC):
 
 class UpstreamLinuxTargetInfo(LinuxTargetInfoBase):
     uses_upstream_llvm: bool = True
-    kernel_target = "linux-kernel"
-    musl_target = "muslc"
+    kernel_target = "upstream-linux-kernel"
+    musl_target = "upstream-muslc"
     compiler_rt_target = "upstream-compiler-rt-builtins"
 
     @property
@@ -907,8 +907,8 @@ class UpstreamLinuxTargetInfo(LinuxTargetInfoBase):
 
 
 class CheriLinuxTargetInfo(LinuxTargetInfoBase):
-    kernel_target = "cheri-std093-linux-kernel"
-    musl_target = "cheri-std093-muslc"
+    kernel_target = "linux-kernel"
+    musl_target = "muslc"
     compiler_rt_target = "cheri-std093-compiler-rt-builtins"
 
     @property
@@ -919,6 +919,7 @@ class CheriLinuxTargetInfo(LinuxTargetInfoBase):
 
 class CheriLinuxWithMorelloCompilerTargetInfo(CheriLinuxTargetInfo):
     uses_morello_llvm = True
+    compiler_rt_target = "morello-compiler-rt-builtins-for-cheri-alliance-linux"
 
 
 class MorelloLinuxTargetInfo(LinuxTargetInfoBase):

--- a/pycheribuild/projects/cross/busybox.py
+++ b/pycheribuild/projects/cross/busybox.py
@@ -42,7 +42,7 @@ from ...utils import classproperty
 
 
 class BuildBusyBox(CrossCompileAutotoolsProject):
-    target = "busybox"
+    target = "upstream-busybox"
     repository = GitRepository("https://git.busybox.net/busybox/")
     is_sdk_target = False
     _supported_architectures = CompilationTargets.ALL_UPSTREAM_LINUX_TARGETS
@@ -229,7 +229,7 @@ class BuildMorelloBusyBox(BuildBusyBox):
 
 
 class BuildAllianceBusyBox(BuildBusyBox):
-    target = "cheri-std093-busybox"
+    target = "busybox"
     repository = GitRepository("https://github.com/CHERI-Alliance/busybox.git")
     _supported_architectures = CompilationTargets.ALL_CHERI_LINUX_TARGETS
     _default_architecture = CompilationTargets.CHERI_LINUX_MORELLO_PURECAP

--- a/pycheribuild/projects/cross/compiler_rt.py
+++ b/pycheribuild/projects/cross/compiler_rt.py
@@ -255,15 +255,6 @@ class BuildUpstreamCompilerRtBuiltins(BuildCompilerRtBuiltins):
         *CompilationTargets.ALL_UPSTREAM_LINUX_TARGETS,
     )
 
-    @classmethod
-    def dependencies(cls, config) -> "tuple[str, ...]":
-        result = super().dependencies(config)
-        xtarget = cls.get_crosscompile_target()
-        if xtarget.target_info_cls.is_linux() and not xtarget.is_native():
-            # The builtins for Linux need C library and kernel headers available.
-            result += ("muslc-headers",)
-        return result
-
 
 class BuildAllianceCompilerRtBuiltins(BuildCompilerRtBuiltins):
     target = "cheri-std093-compiler-rt-builtins"
@@ -289,11 +280,7 @@ class BuildMorelloCompilerRtBuiltins(BuildCompilerRtBuiltins):
         *CompilationTargets.ALL_MORELLO_LINUX_TARGETS,
     )
 
-    @classmethod
-    def dependencies(cls, config) -> "tuple[str, ...]":
-        result = super().dependencies(config)
-        xtarget = cls.get_crosscompile_target()
-        if xtarget.target_info_cls.is_linux() and not xtarget.is_native():
-            # The builtins for Linux need C library and kernel headers available.
-            result += ("morello-muslc-headers",)
-        return result
+
+class BuildCheriLinuxCompilerRtBuiltins(BuildMorelloCompilerRtBuiltins):
+    target = "morello-compiler-rt-builtins-for-cheri-alliance-linux"
+    _supported_architectures = (CompilationTargets.CHERI_LINUX_MORELLO_PURECAP,)

--- a/pycheribuild/projects/cross/linux.py
+++ b/pycheribuild/projects/cross/linux.py
@@ -46,7 +46,7 @@ from ...utils import classproperty
 
 
 class BuildLinux(CrossCompileAutotoolsProject):
-    target = "linux-kernel"
+    target = "upstream-linux-kernel"
     repository = GitRepository("https://github.com/torvalds/linux.git")
     _needs_sysroot = False
     is_sdk_target = False
@@ -153,7 +153,7 @@ class BuildLinux(CrossCompileAutotoolsProject):
 
 
 class BuildCheriAllianceLinux(BuildLinux):
-    target = "cheri-std093-linux-kernel"
+    target = "linux-kernel"
     repository = GitRepository("https://github.com/CHERI-Alliance/linux.git", default_branch="codasip-cheri-riscv-6.18")
     _supported_architectures = (
         *CompilationTargets.ALL_CHERI_LINUX_TARGETS,
@@ -240,19 +240,20 @@ class LaunchUpstreamLinux(LaunchLinuxBase):
 
     @classmethod
     def dependencies(cls, config: CheriConfig) -> "tuple[str, ...]":
-        return *super().dependencies(config), "linux-kernel", "busybox"
+        return *super().dependencies(config), "upstream-linux-kernel", "upstream-busybox"
 
 
 class LaunchCheriAllianceLinux(LaunchLinuxBase):
-    target = "run-minimal-cheri-std093"
+    target = "run-minimal-cheri-linux"
     _supported_architectures = CompilationTargets.ALL_CHERI_LINUX_TARGETS
+    include_os_in_target_suffix = False  # Avoid adding -linux- as we are running cheri-linux
 
     @classmethod
     def dependencies(cls, config: CheriConfig) -> "tuple[str, ...]":
         result = super().dependencies(config)
         if cls.get_crosscompile_target().is_hybrid_or_purecap_cheri([CPUArchitecture.RISCV64]):
             result += ("cheri-std093-opensbi-baremetal-riscv64-purecap",)
-        return *result, "cheri-std093-linux-kernel", "cheri-std093-busybox"
+        return *result, "linux-kernel", "busybox"
 
 
 class LaunchMorelloLinux(LaunchLinuxBase):

--- a/pycheribuild/projects/cross/muslc.py
+++ b/pycheribuild/projects/cross/muslc.py
@@ -40,6 +40,7 @@ from ..project import (
 from ..repository import ReuseOtherProjectRepository
 from ...config.chericonfig import RiscvCheriISA
 from ...config.compilation_targets import CompilationTargets, LinuxTargetInfoBase
+from ...config.target_info import CPUArchitecture
 from ...utils import classproperty
 
 
@@ -104,9 +105,9 @@ class BuildAllianceLinuxMuslc(BuildMuslc):
     supported_riscv_cheri_standard = RiscvCheriISA.EXPERIMENTAL_STD093
 
     def setup(self) -> None:
-        if self.crosscompile_target.is_riscv(include_purecap=True):
+        if self.crosscompile_target.is_cheri_purecap([CPUArchitecture.RISCV64]):
             self.configure_args.append("--enable-bakewell")
-        elif self.crosscompile_target.is_aarch64(include_purecap=True):
+        elif self.crosscompile_target.is_cheri_purecap([CPUArchitecture.AARCH64]):
             self.configure_args.append("--enable-morello")
         self.configure_args.append("--enable-debug")
         # FIXME Need to add the compiler resource directory as Codasip's muslc includes

--- a/pycheribuild/projects/cross/muslc.py
+++ b/pycheribuild/projects/cross/muslc.py
@@ -44,7 +44,7 @@ from ...utils import classproperty
 
 
 class BuildMuslc(CrossCompileAutotoolsProject):
-    target = "muslc"
+    target = "upstream-muslc"
     repository = GitRepository("https://git.musl-libc.org/git/musl")
     _needs_sysroot = False
     is_sdk_target = False
@@ -98,7 +98,7 @@ class BuildMorelloLinuxMuslc(BuildMuslc):
 
 
 class BuildAllianceLinuxMuslc(BuildMuslc):
-    target = "cheri-std093-muslc"
+    target = "muslc"
     repository = GitRepository("https://github.com/CHERI-Alliance/musl.git")
     _supported_architectures = CompilationTargets.ALL_CHERI_LINUX_TARGETS
     supported_riscv_cheri_standard = RiscvCheriISA.EXPERIMENTAL_STD093
@@ -129,13 +129,13 @@ class InstallMuslcHeadersMixin:
 
 
 class InstallMuslcHeaders(InstallMuslcHeadersMixin, BuildMuslc):
-    target = "muslc-headers"
+    target = "upstream-muslc-headers"
     repository = ReuseOtherProjectRepository(BuildMuslc, do_update=True)
     _build_dir: ReuseOtherProjectBuildDir = ReuseOtherProjectBuildDir(build_project=BuildMuslc)
 
 
 class InstallAllianceMuslcHeaders(InstallMuslcHeadersMixin, BuildAllianceLinuxMuslc):
-    target = "cheri-std093-muslc-headers"
+    target = "muslc-headers"
     repository = ReuseOtherProjectRepository(BuildAllianceLinuxMuslc, do_update=True)
     _build_dir = ReuseOtherProjectBuildDir(build_project=BuildAllianceLinuxMuslc)
 


### PR DESCRIPTION
Moving towards consolidating RVY + Morello Linux repos/targets and using CHERI Alliance repos only, this PR refactors CHERI-Linux target names with the following assumptions:

* CHERI-Linux (the kernel and userspace) now means CHERI Alliance Linux that is able to build RVY+Morello off the same repos. Morello Linux (gitlab) still exists for now, but is deemed to be abandoned once we sort out all build+runtime issues.  
* Use default project names for CHERI as the default target names, similar to other projects. Building with cheribuild likely implies building CHERI- supported variants/repos. This removes "cheri-std093" prefixes from current CHERI Alliance Linux targets, as they are now misleading given they are also used for Morello.
* Use CHERI Alliance's repos as the default for CHERI-Linux targets.
* Upstream repos/targets are special and not default; therefore, prefix those with "upstream-", similar to other projects (e.g. upstream-llvm, upstream-qemu). This also removes existing "cheri-" prefixes, assuming that cheribuild builds CHERI-enabled projects by default.
* Resulting commands are now simplified, e.g.:
```
  * ./cheribuild.py run-minimal-cheri-linux-riscv64-purecap -d
  * ./cheribuild.py run-minimal-cheri-linux-morello-purecap -d
```

And for building just the kernel:
```
  * ./cheribuild.py linux-kernel-riscv64-purecap -d
  * ./cheribuild.py linux-kernel-morello-purecap -d
```

PS: RVY CHERI-Linux boots fine, but Morello CHERI-Linux only builds completely but userspace currently has run-time issues. 
Preferably don't merge this until https://github.com/CTSRD-CHERI/cheribuild/pull/477 and https://github.com/CTSRD-CHERI/cheribuild/pull/471 are merged.