### PR TITLE
Targets for the portable stand-alone variant of the CheriBSD test suite

### DIFF
--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -1704,10 +1704,10 @@ class CompilationTargets(BasicCompilationTargets):
         _cheri_isa=RiscvCheriISA.EXPERIMENTAL_STD093,
     )
     UPSTREAM_LINUX_AARCH64 = CrossCompileTarget("aarch64", CPUArchitecture.AARCH64, UpstreamLinuxTargetInfo)
-    CHERI_LINUX_AARCH64 = CrossCompileTarget("aarch64", CPUArchitecture.AARCH64, CheriLinuxTargetInfo)
+    CHERI_LINUX_AARCH64 = CrossCompileTarget("wip-aarch64", CPUArchitecture.AARCH64, CheriLinuxTargetInfo)
     MORELLO_LINUX_AARCH64 = CrossCompileTarget("aarch64", CPUArchitecture.AARCH64, MorelloLinuxTargetInfo)
     CHERI_LINUX_MORELLO_PURECAP = CrossCompileTarget(
-        "morello-purecap",
+        "wip-morello-purecap",
         CPUArchitecture.AARCH64,
         CheriLinuxWithMorelloCompilerTargetInfo,
         is_cheri_purecap=True,

--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -1704,18 +1704,22 @@ class CompilationTargets(BasicCompilationTargets):
         _cheri_isa=RiscvCheriISA.EXPERIMENTAL_STD093,
     )
     UPSTREAM_LINUX_AARCH64 = CrossCompileTarget("aarch64", CPUArchitecture.AARCH64, UpstreamLinuxTargetInfo)
-    CHERI_LINUX_AARCH64 = CrossCompileTarget("wip-aarch64", CPUArchitecture.AARCH64, CheriLinuxTargetInfo)
-    MORELLO_LINUX_AARCH64 = CrossCompileTarget("aarch64", CPUArchitecture.AARCH64, MorelloLinuxTargetInfo)
+    CHERI_LINUX_AARCH64 = CrossCompileTarget("aarch64", CPUArchitecture.AARCH64, CheriLinuxTargetInfo)
+    MORELLO_LINUX_AARCH64 = CrossCompileTarget("legacy-aarch64", CPUArchitecture.AARCH64, MorelloLinuxTargetInfo)
     CHERI_LINUX_MORELLO_PURECAP = CrossCompileTarget(
-        "wip-morello-purecap",
+        "morello-purecap",
         CPUArchitecture.AARCH64,
         CheriLinuxWithMorelloCompilerTargetInfo,
         is_cheri_purecap=True,
         check_conflict_with=CHERI_LINUX_AARCH64,
         non_cheri_target=CHERI_LINUX_AARCH64,
     )
+    # This target is kept for historical reasons as Morello Linux (from Arm) was the first Linux kernel
+    # and target that added CHERI support. CHERI-Linux (from CHERI Alliance) has built on top of Morello
+    # Linux to include more features, targets (RISC-V), and is the currently active project and should
+    # be used instead of the following target unless there is a good reason not to.
     MORELLO_LINUX_MORELLO_PURECAP = CrossCompileTarget(
-        "morello-purecap",
+        "legacy-morello-purecap",
         CPUArchitecture.AARCH64,
         MorelloLinuxTargetInfo,
         is_cheri_purecap=True,

--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -191,6 +191,10 @@ class _ClangBasedTargetInfo(TargetInfo, ABC):
         return self._compiler_dir / "ld.lld"
 
     @property
+    def objcopy(self) -> Path:
+        return self._compiler_dir / "objcopy"
+
+    @property
     def ar(self) -> Path:
         return self._compiler_dir / "llvm-ar"
 

--- a/pycheribuild/projects/cross/cheri_os_tests.py
+++ b/pycheribuild/projects/cross/cheri_os_tests.py
@@ -44,7 +44,7 @@ class BuildPortableOSTests(CrossCompileMakefileProject):
     target = "cheri-os-tests"
     build_in_source_dir = False
     make_kind = MakeCommandKind.BsdMake
-    repository = GitRepository("https://github.com/CTSRD-CHERI/portable-cheribsd-test-suite.git")
+    repository = GitRepository("git@github.com:CTSRD-CHERI/cheri-os-tests.git")
 
     @classproperty
     def default_install_dir(self):
@@ -96,7 +96,7 @@ class BuildPortableOSTests(CrossCompileMakefileProject):
             **self.env_make_args,
         )
 
-        self.run_make(cwd=self.source_dir / "cheribsdtest")
+        self.run_make(cwd=self.source_dir / "cheriostest")
 
     def set_env_make_args(self, machine_cpuarch: str, machine_abi: str, machine_arch: str):
         self.env_make_args = {
@@ -106,7 +106,7 @@ class BuildPortableOSTests(CrossCompileMakefileProject):
         }
 
     def install(self, **kwargs):
-        self.run_make_install(cwd=self.source_dir / "cheribsdtest")
+        self.run_make_install(cwd=self.source_dir / "cheriostest")
 
     def process(self):
         self.check_required_system_tool("bmake", homebrew="bmake", cheribuild_target="bmake")

--- a/pycheribuild/projects/cross/cheri_os_tests.py
+++ b/pycheribuild/projects/cross/cheri_os_tests.py
@@ -41,7 +41,7 @@ class BuildPortableOSTests(CrossCompileMakefileProject):
         CompilationTargets.MORELLO_LINUX_MORELLO_PURECAP,
     )
     _default_architecture = CompilationTargets.CHERI_LINUX_RISCV64_PURECAP_093
-    target = "cheri-portable-os-tests"
+    target = "cheri-os-tests"
     build_in_source_dir = False
     make_kind = MakeCommandKind.BsdMake
     repository = GitRepository("https://github.com/CTSRD-CHERI/portable-cheribsd-test-suite.git")
@@ -77,7 +77,7 @@ class BuildPortableOSTests(CrossCompileMakefileProject):
         # The binaries will be put into /opt/cheri-api-tests
         # This ensures Pyrefly that destdir won't be None
         assert self.destdir is not None
-        self.destdir = self.destdir / "rootfs" / "opt" / "cheri-portable-os-tests"
+        self.destdir = self.destdir / "rootfs" / "opt" / "cheri-os-tests"
         self.makedirs(self.destdir)
 
         self.make_args.set_env(

--- a/pycheribuild/projects/cross/cheriportableostests.py
+++ b/pycheribuild/projects/cross/cheriportableostests.py
@@ -37,6 +37,7 @@ class BuildPortableOSTests(CrossCompileMakefileProject):
     _needs_sysroot = True
     _supported_architectures = (
         CompilationTargets.CHERI_LINUX_RISCV64_PURECAP_093,
+        CompilationTargets.CHERI_LINUX_MORELLO_PURECAP,
         CompilationTargets.MORELLO_LINUX_MORELLO_PURECAP,
     )
     _default_architecture = CompilationTargets.CHERI_LINUX_RISCV64_PURECAP_093

--- a/pycheribuild/projects/cross/cheriportableostests.py
+++ b/pycheribuild/projects/cross/cheriportableostests.py
@@ -90,6 +90,8 @@ class BuildPortableOSTests(CrossCompileMakefileProject):
             # This is not supported by Morello LLVM,
             MAKESYSPATH=str(self.source_dir / "mk"),
             MAKEOBJDIRPREFIX=str(self.build_dir),
+            # This property was added to _ClangBasedTargetInfo to support this specific use case.
+            OBJCOPY=self.target_info.objcopy,
             **self.env_make_args,
         )
 

--- a/pycheribuild/projects/cross/cheriportableostests.py
+++ b/pycheribuild/projects/cross/cheriportableostests.py
@@ -1,0 +1,110 @@
+#
+# Copyright (c) 2025-2026 Paul Metzger
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+
+import os
+import typing
+
+from .crosscompileproject import CrossCompileMakefileProject, DefaultInstallDir, GitRepository, MakeCommandKind
+from ...config.compilation_targets import CompilationTargets, LinuxTargetInfoBase
+from ...utils import classproperty
+
+
+class BuildPortableOSTests(CrossCompileMakefileProject):
+    _always_add_suffixed_targets = True
+    _needs_sysroot = True
+    _supported_architectures = (
+        CompilationTargets.CHERI_LINUX_RISCV64_PURECAP_093,
+        CompilationTargets.MORELLO_LINUX_MORELLO_PURECAP,
+    )
+    _default_architecture = CompilationTargets.CHERI_LINUX_RISCV64_PURECAP_093
+    target = "cheri-portable-os-tests"
+    build_in_source_dir = False
+    make_kind = MakeCommandKind.BsdMake
+    repository = GitRepository("https://github.com/CTSRD-CHERI/portable-cheribsd-test-suite.git")
+
+    @classproperty
+    def default_install_dir(self):
+        return DefaultInstallDir.ROOTFS_LOCALBASE
+
+    @classmethod
+    def dependencies(cls, config) -> "tuple[str, ...]":
+        ti = typing.cast(typing.Type[LinuxTargetInfoBase], cls.get_crosscompile_target().target_info_cls)
+        return ti.musl_target, "libxo", "libbsd"
+
+    def setup(self) -> None:
+        # Don't depend on libgcc_s
+        self.COMMON_LDFLAGS.append("--unwindlib=none")
+
+        if self.get_crosscompile_target().is_aarch64(include_purecap=True):
+            self.set_env_make_args(machine_cpuarch="aarch64c", machine_abi="purecap", machine_arch="aarch64c")
+        elif self.get_crosscompile_target().is_experimental_cheri093_std(self.config):
+            self.set_env_make_args(
+                machine_cpuarch="rv64imafdc_zcherihybrid_zcherilevels",
+                machine_abi="purecap",
+                machine_arch="rv64imafdc_zcherihybrid_zcherilevels",
+            )
+        else:
+            target = self.target_info.target
+            raise NotImplementedError(f"Unsupported architecture: {target.cpu_architecture} {target._cheri_isa}")
+
+        return super().setup()
+
+    def compile(self, **kwargs):
+        # The binaries will be put into /opt/cheri-api-tests
+        # This ensures Pyrefly that destdir won't be None
+        assert self.destdir is not None
+        self.destdir = self.destdir / "rootfs" / "opt" / "cheri-portable-os-tests"
+        self.makedirs(self.destdir)
+
+        self.make_args.set_env(
+            # Put the binary into root's home directory
+            DESTDIR=str(self.destdir),
+            BINOWN=os.getuid(),
+            BINGRP=os.getgid(),
+            BINMODE=755,
+            # Suppress a warning related to absent exception handlers.
+            LD_FATAL_WARNINGS="no",
+            # This is not supported by Morello LLVM,
+            MAKESYSPATH=str(self.source_dir / "mk"),
+            MAKEOBJDIRPREFIX=str(self.build_dir),
+            **self.env_make_args,
+        )
+
+        self.run_make(cwd=self.source_dir / "cheribsdtest")
+
+    def set_env_make_args(self, machine_cpuarch: str, machine_abi: str, machine_arch: str):
+        self.env_make_args = {
+            "MACHINE_CPUARCH": machine_cpuarch,
+            "MACHINE_ABI": machine_abi,
+            "MACHINE_ARCH": machine_arch,
+        }
+
+    def install(self, **kwargs):
+        self.run_make_install(cwd=self.source_dir / "cheribsdtest")
+
+    def process(self):
+        self.check_required_system_tool("bmake", homebrew="bmake", cheribuild_target="bmake")
+        super().process()

--- a/pycheribuild/projects/cross/libbsd.py
+++ b/pycheribuild/projects/cross/libbsd.py
@@ -40,10 +40,12 @@ class BuildLibbsd(CrossCompileAutotoolsProject):
     )
     _default_architecture = CompilationTargets.CHERI_LINUX_RISCV64_PURECAP_093
     make_kind = MakeCommandKind.GnuMake
-    # `default_branch` is set because the build scripts assume that
-    # a git tag is checked out. In more detail ./get-version returns an
-    # empty string if main is checked out.
-    repository = GitRepository("https://gitlab.freedesktop.org/libbsd/libbsd.git", default_branch="0.12.2")
+    repository = GitRepository(
+        "https://gitlab.freedesktop.org/libbsd/libbsd.git",
+        temporary_url_override="https://gitlab.freedesktop.org/paul-metzger/libbsd-private-fork-pmetzger.git",
+        default_branch="0_12_2_with_alignment_macro_fix",
+        force_branch=True,
+    )
 
     @classproperty
     def default_install_dir(self):
@@ -53,28 +55,6 @@ class BuildLibbsd(CrossCompileAutotoolsProject):
     def dependencies(cls, config) -> "tuple[str, ...]":
         ti = typing.cast(typing.Type[LinuxTargetInfoBase], cls.get_crosscompile_target().target_info_cls)
         return ti.musl_target, "libmd"
-
-    def _apply_patch(self) -> None:
-        patch = """
-diff --git a/src/merge.c b/src/merge.c
-index 3f1b3fb..f8cb602 100644
---- a/src/merge.c
-+++ b/src/merge.c
-@@ -84,8 +84,8 @@ static void insertionsort(unsigned char *, size_t, size_t,
-  */
- /* Assumption: PSIZE is a power of 2. */
- #define EVAL(p) (unsigned char **)					\\
--	 (((unsigned char *)p + PSIZE - 1 -				\\
--	   (unsigned char *)0) & ~(PSIZE - 1))
-+	 __builtin_cheri_address_set(p, ((__builtin_cheri_address_get(p) + PSIZE - 1 -				\\
-+	   0) & ~(PSIZE - 1)))
-
- /*
-  * Arguments are as for qsort.
-"""
-        self.write_file(self.source_dir / "merge.patch", patch, overwrite=True)
-        self.run_cmd("git", "restore", ".", cwd=self.source_dir)
-        self.run_cmd("git", "apply", "merge.patch", cwd=self.source_dir)
 
     def setup(self) -> None:
         super().setup()
@@ -89,7 +69,6 @@ index 3f1b3fb..f8cb602 100644
         super().configure(**kwargs)
 
     def compile(self, **kwargs):
-        self._apply_patch()
         self.run_make()
         super().compile()
 

--- a/pycheribuild/projects/cross/libbsd.py
+++ b/pycheribuild/projects/cross/libbsd.py
@@ -1,0 +1,98 @@
+#
+# Copyright (c) 2025-2026 Paul Metzger
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+
+import typing
+
+from .crosscompileproject import CrossCompileAutotoolsProject, DefaultInstallDir, GitRepository, MakeCommandKind
+from ...config.compilation_targets import CompilationTargets, LinuxTargetInfoBase
+from ...utils import classproperty
+
+
+class BuildLibbsd(CrossCompileAutotoolsProject):
+    _always_add_suffixed_targets = True
+    _can_use_autogen_sh = True
+    _supported_architectures = (
+        CompilationTargets.CHERI_LINUX_RISCV64_PURECAP_093,
+        CompilationTargets.MORELLO_LINUX_MORELLO_PURECAP,
+    )
+    _default_architecture = CompilationTargets.CHERI_LINUX_RISCV64_PURECAP_093
+    make_kind = MakeCommandKind.GnuMake
+    # `default_branch` is set because the build scripts assume that
+    # a git tag is checked out. In more detail ./get-version returns an
+    # empty string if main is checked out.
+    repository = GitRepository("https://gitlab.freedesktop.org/libbsd/libbsd.git", default_branch="0.12.2")
+
+    @classproperty
+    def default_install_dir(self):
+        return DefaultInstallDir.ROOTFS_LOCALBASE
+
+    @classmethod
+    def dependencies(cls, config) -> "tuple[str, ...]":
+        ti = typing.cast(typing.Type[LinuxTargetInfoBase], cls.get_crosscompile_target().target_info_cls)
+        return ti.musl_target, "libmd"
+
+    def _apply_patch(self) -> None:
+        patch = """
+diff --git a/src/merge.c b/src/merge.c
+index 3f1b3fb..f8cb602 100644
+--- a/src/merge.c
++++ b/src/merge.c
+@@ -84,8 +84,8 @@ static void insertionsort(unsigned char *, size_t, size_t,
+  */
+ /* Assumption: PSIZE is a power of 2. */
+ #define EVAL(p) (unsigned char **)					\\
+-	 (((unsigned char *)p + PSIZE - 1 -				\\
+-	   (unsigned char *)0) & ~(PSIZE - 1))
++	 __builtin_cheri_address_set(p, ((__builtin_cheri_address_get(p) + PSIZE - 1 -				\\
++	   0) & ~(PSIZE - 1)))
+
+ /*
+  * Arguments are as for qsort.
+"""
+        self.write_file(self.source_dir / "merge.patch", patch, overwrite=True)
+        self.run_cmd("git", "restore", ".", cwd=self.source_dir)
+        self.run_cmd("git", "apply", "merge.patch", cwd=self.source_dir)
+
+    def setup(self) -> None:
+        super().setup()
+        # Remove dependency on libgcc_eh
+        self.COMMON_LDFLAGS.append("--unwindlib=none")
+        # Remove dependcy on libgcc_s
+        self.COMMON_LDFLAGS.append("-Wc,--unwindlib=none")
+
+    def configure(self, **kwargs):
+        if not self.configure_command.exists():
+            self.run_cmd(self.source_dir / "autogen", cwd=self.source_dir)
+        super().configure(**kwargs)
+
+    def compile(self, **kwargs):
+        self._apply_patch()
+        self.run_make()
+        super().compile()
+
+    def install(self, **kwargs):
+        self.run_make_install()
+        super().install(**kwargs)

--- a/pycheribuild/projects/cross/libbsd.py
+++ b/pycheribuild/projects/cross/libbsd.py
@@ -36,6 +36,7 @@ class BuildLibbsd(CrossCompileAutotoolsProject):
     _can_use_autogen_sh = True
     _supported_architectures = (
         CompilationTargets.CHERI_LINUX_RISCV64_PURECAP_093,
+        CompilationTargets.CHERI_LINUX_MORELLO_PURECAP,
         CompilationTargets.MORELLO_LINUX_MORELLO_PURECAP,
     )
     _default_architecture = CompilationTargets.CHERI_LINUX_RISCV64_PURECAP_093

--- a/pycheribuild/projects/cross/libmd.py
+++ b/pycheribuild/projects/cross/libmd.py
@@ -36,6 +36,7 @@ class BuildLibmd(CrossCompileAutotoolsProject):
     _can_use_autogen_sh = True
     _supported_architectures = (
         CompilationTargets.CHERI_LINUX_RISCV64_PURECAP_093,
+        CompilationTargets.CHERI_LINUX_MORELLO_PURECAP,
         CompilationTargets.MORELLO_LINUX_MORELLO_PURECAP,
     )
     _default_architecture = CompilationTargets.CHERI_LINUX_RISCV64_PURECAP_093

--- a/pycheribuild/projects/cross/libmd.py
+++ b/pycheribuild/projects/cross/libmd.py
@@ -1,0 +1,73 @@
+#
+# Copyright (c) 2025-2026 Paul Metzger
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+
+import typing
+
+from .crosscompileproject import CrossCompileAutotoolsProject, DefaultInstallDir, GitRepository, MakeCommandKind
+from ...config.compilation_targets import CompilationTargets, LinuxTargetInfoBase
+from ...utils import classproperty
+
+
+class BuildLibmd(CrossCompileAutotoolsProject):
+    _always_add_suffixed_targets = True
+    _can_use_autogen_sh = True
+    _supported_architectures = (
+        CompilationTargets.CHERI_LINUX_RISCV64_PURECAP_093,
+        CompilationTargets.MORELLO_LINUX_MORELLO_PURECAP,
+    )
+    _default_architecture = CompilationTargets.CHERI_LINUX_RISCV64_PURECAP_093
+    make_kind = MakeCommandKind.GnuMake
+    is_sdk_target = False
+    repository = GitRepository("https://git.hadrons.org/git/libmd.git")
+
+    @classproperty
+    def default_install_dir(self):
+        return DefaultInstallDir.ROOTFS_LOCALBASE
+
+    @classmethod
+    def dependencies(cls, config) -> "tuple[str, ...]":
+        ti = typing.cast(typing.Type[LinuxTargetInfoBase], cls.get_crosscompile_target().target_info_cls)
+        return (ti.musl_target,)
+
+    def setup(self) -> None:
+        super().setup()
+        # Remove dependency on libgcc_eh
+        self.COMMON_LDFLAGS.append("--unwindlib=none")
+        # Remove dependcy on libgcc_s
+        self.COMMON_LDFLAGS.append("-Wc,--unwindlib=none")
+
+    def configure(self, **kwargs):
+        if not self.configure_command.exists():
+            self.run_cmd(self.source_dir / "autogen", cwd=self.source_dir)
+        super().configure(**kwargs)
+
+    def compile(self, **kwargs):
+        self.run_make()
+        super().compile(**kwargs)
+
+    def install(self, **kwargs):
+        self.run_make_install()
+        super().install(**kwargs)

--- a/pycheribuild/projects/cross/libxo.py
+++ b/pycheribuild/projects/cross/libxo.py
@@ -36,6 +36,7 @@ class BuildLibxo(CrossCompileAutotoolsProject):
     _can_use_autogen_sh = True
     _supported_architectures = (
         CompilationTargets.CHERI_LINUX_RISCV64_PURECAP_093,
+        CompilationTargets.CHERI_LINUX_MORELLO_PURECAP,
         CompilationTargets.MORELLO_LINUX_MORELLO_PURECAP,
     )
     _default_architecture = CompilationTargets.CHERI_LINUX_RISCV64_PURECAP_093

--- a/pycheribuild/projects/cross/libxo.py
+++ b/pycheribuild/projects/cross/libxo.py
@@ -1,0 +1,87 @@
+#
+# Copyright (c) 2025-2026 Paul Metzger
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+
+import typing
+
+from .crosscompileproject import CrossCompileAutotoolsProject, DefaultInstallDir, GitRepository, MakeCommandKind
+from ...config.compilation_targets import CompilationTargets, LinuxTargetInfoBase
+from ...utils import classproperty
+
+
+class BuildLibxo(CrossCompileAutotoolsProject):
+    _always_add_suffixed_targets = True
+    _can_use_autogen_sh = True
+    _supported_architectures = (
+        CompilationTargets.CHERI_LINUX_RISCV64_PURECAP_093,
+        CompilationTargets.MORELLO_LINUX_MORELLO_PURECAP,
+    )
+    _default_architecture = CompilationTargets.CHERI_LINUX_RISCV64_PURECAP_093
+    make_kind = MakeCommandKind.GnuMake
+    repository = GitRepository("https://github.com/Juniper/libxo.git")
+
+    @classproperty
+    def default_install_dir(self):
+        return DefaultInstallDir.ROOTFS_LOCALBASE
+
+    @classmethod
+    def dependencies(cls, config) -> "tuple[str, ...]":
+        ti = typing.cast(typing.Type[LinuxTargetInfoBase], cls.get_crosscompile_target().target_info_cls)
+        return ti.musl_target, "libbsd", "libmd"
+
+    def _patch_to_use_libbsd(self, path):
+        self.run_cmd("sed", "-i", "s|<sys/queue.h>|<bsd/sys/queue.h>|g", path, cwd=self.source_dir)
+
+    def _patch_includes(self) -> None:
+        self._patch_to_use_libbsd("libxo/xo_encoder.c")
+        self._patch_to_use_libbsd("xopo/xopo.c")
+
+    def _patch_configure_ac(self) -> None:
+        self.run_cmd("sed", "-i", "s|AC_FUNC_REALLOC|#AC_FUNC_REALLOC|g", "configure.ac", cwd=self.source_dir)
+        self.run_cmd("sed", "-i", "s|AC_FUNC_MALLOC|#AC_FUNC_MALLOC|g", "configure.ac", cwd=self.source_dir)
+
+    def configure(self, **kwargs):
+        # Don't depend on libgcc_s. If this isn't set then clang wants to link
+        # with libgcc_s, which is not available on Morello Linux.
+        self.LDFLAGS.append("--unwindlib=none")
+        # This prompts libtool to pass '--unwindlib=none' to clang during
+        # linking. Libtool ignores "--unwindlib=none" and needs
+        # "-Wc,--unwindlib=none" instead. "-Wc,--unwindlib=none" is turned
+        # into "--unwindlib=none" by libtool when it invokes clang.
+        self.CFLAGS.append("-Wc,--unwindlib=none")
+
+        self._patch_configure_ac()
+        self._patch_includes()
+        self.run_shell_script("sh bin/setup.sh", shell="sh", cwd=self.source_dir)
+
+        super().configure(**kwargs)
+
+    def compile(self, **kwargs):
+        self.run_make()
+        super().compile(**kwargs)
+
+    def install(self, **kwargs):
+        self.run_make_install()
+        super().install(**kwargs)

--- a/pycheribuild/projects/cross/linux.py
+++ b/pycheribuild/projects/cross/linux.py
@@ -169,7 +169,7 @@ class BuildLinux(CrossCompileAutotoolsProject):
 
 class BuildCheriAllianceLinux(BuildLinux):
     target = "linux-kernel"
-    repository = GitRepository("https://github.com/CHERI-Alliance/linux.git", default_branch="codasip-cheri-riscv-6.18")
+    repository = GitRepository("https://github.com/CHERI-Alliance/linux.git", default_branch="cambridge-morello-7.0")
     _supported_architectures = (
         *CompilationTargets.ALL_CHERI_LINUX_TARGETS,
         CompilationTargets.LINUX_KERNEL_RISCV64_GCC,

--- a/pycheribuild/projects/simple_project.py
+++ b/pycheribuild/projects/simple_project.py
@@ -887,6 +887,11 @@ class SimpleProjectBase(AbstractProject, ABC):
 
     # noinspection PyPep8Naming
     @property
+    def OBJCOPY(self) -> Path:  # noqa: N802
+        return self.target_info.objcopy
+
+    # noinspection PyPep8Naming
+    @property
     def host_CC(self) -> Path:  # noqa: N802
         return TargetInfo.host_c_compiler(self.config)
 


### PR DESCRIPTION
This PR contains CHERI/Morello Linux targets for a portable stand-alone variant of the CheriBSD test suite. We'd like to be able to use it on CHERI/Morello Linux for testing and to help with cataloguing design differences between the CHERI-related parts of CheriBSD's and CHERI/Morello Linux's OS interfaces.
@heshamelmatary is interested in this PR for testing.

Setup for Morello Linux:
1. Build the test suite: `./cheribuild.py cheri-portable-os-tests --qemu/no-use-smbd -d`
2. Start Morello Linux in Qemu: `./cheribuild.py run-minimal-morello-linux-morello-purecap --qemu/no-use-smbd -d`
3. The test cases are then in `/opt/cheri-portable-os-tests`.
This issue causes a compile time error and needs to be fixed by hand for Morello Muslc: https://github.com/CHERI-Alliance/musl/pull/3
The test suite needs to be built first in order for it to be included into the image built in the second step.
The workflow for RVY CHERI Linux is similar.

The repository with the adapted test cases is private currently, but the intention is to make it publicly available soon.