### PR TITLE
linux-kernel: remove no-longer necessary patch

### DIFF
--- a/pycheribuild/projects/cross/linux.py
+++ b/pycheribuild/projects/cross/linux.py
@@ -119,17 +119,8 @@ class BuildLinux(CrossCompileAutotoolsProject):
         return "defconfig"
 
     def _apply_build_patches(self):
-        # Work around https://github.com/ClangBuiltLinux/linux/issues/2092
-        if self.compiling_for_riscv(include_purecap=False):
-            # FIXME: apparently this value is always overwritten by the build system with the default value no
-            # matter what I do, apply the patch instead for now
-            # self._set_config("CONFIG_CC_HAS_ASM_GOTO_OUTPUT", "n")
-            self.info("Working around https://github.com/ClangBuiltLinux/linux/issues/2092")
-            self._apply_patch_from_url(
-                self.build_dir / "asm-goto.patch",
-                "https://lore.kernel.org/linux-riscv/"
-                "20250811-riscv-wa-llvm-asm-goto-outputs-assertion-failure-v1-1-7bb8c9cbb92b@kernel.org/raw",
-            )
+        # Placeholder for future patches that might be required to be applied here
+        pass
 
     def compile(self, **kwargs):
         self._apply_build_patches()
@@ -180,11 +171,6 @@ class BuildCheriAllianceLinux(BuildLinux):
             return "morello_pcuabi_defconfig"
         else:
             return "defconfig"
-
-    def _apply_build_patches(self):
-        # No patches needed, worked around https://github.com/ClangBuiltLinux/linux/issues/2092
-        # by marking ASM GOTO support as broken.
-        return
 
     def configure(self, **kwargs):
         super().configure(**kwargs)


### PR DESCRIPTION
upstream-linux-kernel-[aarch64|riscv64] build/boot fine without this patch. It also no longer applies, so likely fixed upstream.