### PR TITLE
linux-kernel: allow specifying defconfigs

### DIFF
--- a/pycheribuild/projects/cross/linux.py
+++ b/pycheribuild/projects/cross/linux.py
@@ -35,11 +35,13 @@ from typing import Optional
 
 from .crosscompileproject import CrossCompileAutotoolsProject
 from ..project import (
+    ComputedDefaultValue,
     DefaultInstallDir,
     GitRepository,
     MakeCommandKind,
 )
 from ..run_qemu import LaunchQEMUBase
+from ..simple_project import StringConfigOption
 from ...config.chericonfig import CheriConfig, RiscvCheriISA
 from ...config.compilation_targets import CompilationTargets, LinuxGccTargetInfo
 from ...config.target_info import CPUArchitecture
@@ -115,8 +117,16 @@ class BuildLinux(CrossCompileAutotoolsProject):
         # Don't overwrite our manually edited .config file with default values
         self.make_args.set_env(KCONFIG_NOSILENTUPDATE=1)
 
-    @property
-    def defconfig(self) -> str:
+    defconfig = StringConfigOption(
+        "defconfig",
+        default=ComputedDefaultValue(
+            function=lambda _, p: p.default_defconfig(),
+            as_string="platform-dependent, usually defconfig",
+        ),
+        help="The Linux kernel's defconfig to use",
+    )
+
+    def default_defconfig(self) -> str:
         return "defconfig"
 
     def _apply_build_patches(self):
@@ -239,7 +249,8 @@ copy_file_range(int fd_in, off_t *off_in, int fd_out, off_t *_Nullable off_out,
             self.info(f"Patch from {patch_url} already applied, skipping.")
 
     def configure(self, **kwargs):
-        self.run_make(self.defconfig, cwd=self.source_dir, parallel=False)
+        assert self.defconfig is not None
+        self.run_make(str(self.defconfig), cwd=self.source_dir, parallel=False)
 
         # Enable 9P filesystem for sharing directories between host and target
         self._set_config("CONFIG_NET_9P")
@@ -276,9 +287,9 @@ class BuildCheriAllianceLinux(BuildLinux):
     supported_riscv_cheri_standard = RiscvCheriISA.EXPERIMENTAL_STD093
     _default_architecture = CompilationTargets.CHERI_LINUX_RISCV64_PURECAP_093
 
-    @property
-    def defconfig(self) -> str:
-        if self.crosscompile_target.is_hybrid_or_purecap_cheri([CPUArchitecture.RISCV64]):
+    # Override default defconfig for CHERI-enabled kernels
+    def default_defconfig(self) -> str:
+        if self.crosscompile_target.is_cheri_purecap([CPUArchitecture.RISCV64]):
             return "qemu_riscv64cheripc_defconfig"
         elif self.crosscompile_target.is_cheri_purecap([CPUArchitecture.AARCH64]):
             return "morello_pcuabi_defconfig"
@@ -311,10 +322,10 @@ class BuildMorelloLinux(BuildLinux):
     _supported_architectures = CompilationTargets.ALL_MORELLO_LINUX_TARGETS
     _default_architecture = CompilationTargets.MORELLO_LINUX_MORELLO_PURECAP
 
-    @property
-    def defconfig(self) -> str:
-        if self.crosscompile_target.is_hybrid_or_purecap_cheri([CPUArchitecture.AARCH64]):
-            return "morello_transitional_pcuabi_defconfig"
+    # Override default defconfig for CHERI-enabled kernels
+    def default_defconfig(self) -> str:
+        if self.crosscompile_target.is_cheri_purecap([CPUArchitecture.AARCH64]):
+            return "morello_pcuabi_defconfig"
         else:
             return "defconfig"
 


### PR DESCRIPTION
Similar to CheriBSD's kernel-config, this commit allows the user to specify a defconfig that is not a default eg for CVA6-CHERI or Codasip's X730 by passing its name to --linux-kernel/defconfig $XXX.