### PR TITLE
CHERI-Linux: use alliance's LLVM for non-CHERI builds

### DIFF
--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -105,6 +105,7 @@ def _linker_supports_riscv_relaxations(linker: Path, config: CheriConfig, xtarge
 
 
 class _ClangBasedTargetInfo(TargetInfo, ABC):
+    uses_alliance_llvm: bool = False
     uses_morello_llvm: bool = False
     uses_upstream_llvm: bool = False
 
@@ -131,8 +132,9 @@ class _ClangBasedTargetInfo(TargetInfo, ABC):
         elif cls.uses_upstream_llvm:
             assert not xtarget.is_hybrid_or_purecap_cheri(), "Not supported with upstream LLVM"
             llvm_target = SimpleProject.get_class_for_target_name("upstream-llvm", None)
-        elif xtarget.is_experimental_cheri093_std(config):
-            # Use the CHERI Alliance compiler when building for RISCV CHERI
+        elif xtarget.is_experimental_cheri093_std(config) or cls.uses_alliance_llvm:
+            # Use the CHERI Alliance compiler when building for RISCV CHERI or building
+            # non-CHERI aarch64/riscv64 CHERI Alliance projects (that use the Alliance LLVM).
             llvm_target = SimpleProject.get_class_for_target_name("cheri-std093-llvm", None)
         else:
             llvm_target = SimpleProject.get_class_for_target_name("llvm", None)
@@ -869,6 +871,7 @@ class UpstreamLinuxTargetInfo(LinuxTargetInfoBase):
 
 
 class CheriLinuxTargetInfo(LinuxTargetInfoBase):
+    uses_alliance_llvm: bool = True
     kernel_target = "linux-kernel"
     musl_target = "muslc"
     compiler_rt_target = "cheri-std093-compiler-rt-builtins"

--- a/pycheribuild/projects/cross/llvm.py
+++ b/pycheribuild/projects/cross/llvm.py
@@ -849,7 +849,7 @@ class BuildCheriAllianceLLVM(BuildLLVMMonoRepoBase):
         return [x + "-" for x in triples]
 
     def configure(self, **kwargs):
-        self.add_cmake_options(LLVM_TARGETS_TO_BUILD="RISCV;host")
+        self.add_cmake_options(LLVM_TARGETS_TO_BUILD="ARM;AArch64;RISCV;host")
         # The current master branch isn't ready yet to switch over to the new pass manager
         # CLANG_ROUND_TRIP_CC1_ARGS doesn't work for us yet. See e.g. https://reviews.llvm.org/D97462#2677130
         self.add_cmake_options(CLANG_ROUND_TRIP_CC1_ARGS=False)


### PR DESCRIPTION
This commit enables using CHERI Alliance's LLVM when building vanilla CHERI-Linux aarch64 and riscv64 projects. Without this commit, building CHERI-Linux for aarch64/riscv64 will use CHERI-LLVM, and will fail to build because it will attempt to build CHERI-Alliance's compiler-rt which won't exist on clean builds.