### PR TITLE
alliance-llvm: remove a TODO

### DIFF
--- a/pycheribuild/projects/cross/llvm.py
+++ b/pycheribuild/projects/cross/llvm.py
@@ -821,12 +821,8 @@ class BuildMorelloLLVM(BuildLLVMMonoRepoBase):
 class BuildCheriAllianceLLVM(BuildLLVMMonoRepoBase):
     repository = GitRepository(
         "https://github.com/CHERI-Alliance/llvm-project.git",
-        # TODO: Use the previous default once it can build CheriBSD:
-        # default_branch="codasip-cheri-riscv",
-        # https://github.com/CHERI-Alliance/llvm-project/pull/18
-        default_branch="cheribsd-rvy-intrinsics-19",
+        default_branch="codasip-cheri-riscv-19.1.7",
         force_branch=True,
-        temporary_url_override="https://github.com/qwattash/cheri-alliance-llvm-project.git",
     )
     default_directory_basename = "cheri-std093-llvm-project"
     target = "cheri-std093-llvm"


### PR DESCRIPTION
https://github.com/CHERI-Alliance/llvm-project/pull/18 is now incorporating in the latest/default Alliance's 19.1.7 branch