### PR TITLE
freebsd-morello-purecap and freebsd-riscv64-purecap targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you are building CHERI on a FreeBSD machine, the following command will insta
 the most commonly used cheribuild targets:
 
 ```shell
-pkg install autoconf automake bison cmake expat glib gsed libtool llvm mercurial meson ninja pkgconf pixman samba
+pkg install autoconf automake bison cmake expat glib gmake gsed libtool llvm mercurial meson mpfr ninja pkgconf pixman python3 samba420 texinfo
 ```
 
 #### Arch Linux

--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -468,7 +468,13 @@ class FreeBSDTargetInfo(_ClangBasedTargetInfo):
             CPUArchitecture.RISCV64: "riscv64",
             CPUArchitecture.X86_64: "amd64",
         }
-        return mapping[self.target.cpu_architecture]
+        base = mapping[self.target.cpu_architecture]
+
+        if self.target.is_cheri_purecap():
+            purecap_suffix = "c"
+        else:
+            purecap_suffix = ""
+        return base + purecap_suffix
 
     @classmethod
     def base_sysroot_targets(cls, target: "CrossCompileTarget", config: "CheriConfig") -> "list[str]":
@@ -702,6 +708,16 @@ class FreeBSDWithDefaultOptionsTargetInfo(FreeBSDTargetInfo):
         return typing.cast(LaunchFreeBSDInterface, result)
 
 
+class FreeBSDCheriTargetInfo(FreeBSDTargetInfo):
+    shortname: str = "FreeBSD-CHERI"
+    uses_upstream_llvm: bool = False
+
+
+class FreeBSDMorelloTargetInfo(FreeBSDCheriTargetInfo):
+    shortname: str = "FreeBSD-Morello"
+    uses_morello_llvm: bool = True
+
+
 class CheriBSDTargetInfo(FreeBSDTargetInfo):
     shortname: str = "CheriBSD"
     os_prefix: Optional[str] = ""  # CheriBSD is the default target, so we omit the OS prefix from target names
@@ -715,15 +731,6 @@ class CheriBSDTargetInfo(FreeBSDTargetInfo):
     @classmethod
     def is_cheribsd(cls) -> bool:
         return True
-
-    @property
-    def freebsd_target_arch(self):
-        base = super().freebsd_target_arch
-        if self.target.is_cheri_purecap():
-            purecap_suffix = "c"
-        else:
-            purecap_suffix = ""
-        return base + purecap_suffix
 
     @classmethod
     def base_sysroot_targets(cls, target: "CrossCompileTarget", config: "CheriConfig") -> "list[str]":
@@ -1651,7 +1658,33 @@ class CompilationTargets(BasicCompilationTargets):
     FREEBSD_I386 = CrossCompileTarget("i386", CPUArchitecture.I386, FreeBSDTargetInfo)
     FREEBSD_MIPS64 = CrossCompileTarget("mips64", CPUArchitecture.MIPS64, FreeBSDTargetInfo)
     FREEBSD_RISCV64 = CrossCompileTarget("riscv64", CPUArchitecture.RISCV64, FreeBSDTargetInfo)
-    ALL_SUPPORTED_FREEBSD_TARGETS = (FREEBSD_AARCH64, FREEBSD_AMD64, FREEBSD_I386, FREEBSD_RISCV64)
+    FREEBSD_RISCV_PURECAP = CrossCompileTarget(
+        "riscv64-purecap",
+        CPUArchitecture.RISCV64,
+        FreeBSDCheriTargetInfo,
+        is_cheri_purecap=True,
+        non_cheri_target=FREEBSD_RISCV64,
+        hybrid_target=FREEBSD_RISCV64,  # HACK: there is no hybrid
+    )
+    FREEBSD_MORELLO_PURECAP = CrossCompileTarget(
+        "morello-purecap",
+        CPUArchitecture.AARCH64,
+        FreeBSDMorelloTargetInfo,
+        is_cheri_purecap=True,
+        non_cheri_target=FREEBSD_AARCH64,
+        hybrid_target=FREEBSD_AARCH64,  # HACK: there is no hybrid
+    )
+    NON_CHERI_FREEBSD_TARGETS = (
+        FREEBSD_AARCH64,
+        FREEBSD_AMD64,
+        FREEBSD_I386,
+        FREEBSD_RISCV64,
+    )
+    ALL_SUPPORTED_FREEBSD_TARGETS = (
+        *NON_CHERI_FREEBSD_TARGETS,
+        FREEBSD_MORELLO_PURECAP,
+        FREEBSD_RISCV_PURECAP,
+    )
 
     # FreeBSD with default options targets
     FREEBSD_WITH_DEFAULT_OPTIONS_AARCH64 = CrossCompileTarget(

--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -392,7 +392,7 @@ class _ClangBasedTargetInfo(TargetInfo, ABC):
 
 class FreeBSDTargetInfo(_ClangBasedTargetInfo):
     shortname: str = "FreeBSD"
-    FREEBSD_VERSION: int = 13
+    FREEBSD_VERSION: int = 16
     uses_upstream_llvm = True
 
     @property
@@ -705,7 +705,7 @@ class FreeBSDWithDefaultOptionsTargetInfo(FreeBSDTargetInfo):
 class CheriBSDTargetInfo(FreeBSDTargetInfo):
     shortname: str = "CheriBSD"
     os_prefix: Optional[str] = ""  # CheriBSD is the default target, so we omit the OS prefix from target names
-    FREEBSD_VERSION: int = 13
+    FREEBSD_VERSION: int = 15
     uses_upstream_llvm = False
 
     def _get_run_project(self, xtarget: "CrossCompileTarget", caller: AbstractProject) -> LaunchFreeBSDInterface:

--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -721,8 +721,6 @@ class CheriBSDTargetInfo(FreeBSDTargetInfo):
         base = super().freebsd_target_arch
         if self.target.is_cheri_purecap():
             purecap_suffix = "c"
-            if self.target.is_mips(include_purecap=True):
-                purecap_suffix += self.config.mips_cheri_bits_str
         else:
             purecap_suffix = ""
         return base + purecap_suffix
@@ -1668,15 +1666,11 @@ class CompilationTargets(BasicCompilationTargets):
     FREEBSD_WITH_DEFAULT_OPTIONS_RISCV64 = CrossCompileTarget(
         "riscv64", CPUArchitecture.RISCV64, FreeBSDWithDefaultOptionsTargetInfo
     )
-    FREEBSD_WITH_DEFAULT_OPTIONS_MIPS64 = CrossCompileTarget(
-        "mips64", CPUArchitecture.MIPS64, FreeBSDWithDefaultOptionsTargetInfo
-    )
     ALL_SUPPORTED_FREEBSD_WITH_DEFAULT_OPTIONS_TARGETS = (
         FREEBSD_WITH_DEFAULT_OPTIONS_AARCH64,
         FREEBSD_WITH_DEFAULT_OPTIONS_AMD64,
         FREEBSD_WITH_DEFAULT_OPTIONS_I386,
         FREEBSD_WITH_DEFAULT_OPTIONS_RISCV64,
-        FREEBSD_WITH_DEFAULT_OPTIONS_MIPS64,
     )
 
     # RTEMS targets

--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -439,16 +439,11 @@ class CheriBSDConfigTable:
     X86_CONFIGS: "list[CheriBSDConfig]" = [
         CheriBSDConfig("GENERIC", {ConfigPlatform.QEMU}, default=True),
     ]
-    MIPS_CONFIGS: "list[CheriBSDConfig]" = [
-        CheriBSDConfig("MALTA64", {ConfigPlatform.QEMU}, default=True),
-    ]
 
     @classmethod
     def get_target_configs(cls, xtarget: CrossCompileTarget, config: "CheriConfig") -> "list[CheriBSDConfig]":
         if xtarget.is_any_x86():
             return cls.X86_CONFIGS
-        elif xtarget.is_mips(include_purecap=False):
-            return cls.MIPS_CONFIGS
         elif xtarget.is_riscv(include_purecap=True):
             if xtarget.is_experimental_cheri093_std(config):
                 return RISCVStdKernelConfigFactory().make_all()
@@ -741,9 +736,7 @@ class BuildFreeBSD(BuildFreeBSDBase):
     repository: GitRepository = GitRepository("https://github.com/freebsd/freebsd.git")
     _needs_sysroot = False  # We are building the full OS so we don't need a sysroot
     is_rootfs_target: typing.ClassVar[bool] = True  # All derived classes are also rootfs targets
-    # We still allow building FreeBSD for MIPS64. While the main branch no longer has support, this allows building
-    # the stable/13 branch using cheribuild. However, MIPS is no longer included in ALL_SUPPORTED_FREEBSD_TARGETS.
-    _supported_architectures = (*CompilationTargets.ALL_SUPPORTED_FREEBSD_TARGETS, CompilationTargets.FREEBSD_MIPS64)
+    _supported_architectures = CompilationTargets.ALL_SUPPORTED_FREEBSD_TARGETS
 
     _default_install_dir_fn: ComputedDefaultValue[Path] = _arch_suffixed_custom_install_dir("freebsd")
     add_custom_make_options: bool = True
@@ -929,8 +922,6 @@ class BuildFreeBSD(BuildFreeBSDBase):
                     result["TARGET_CPUTYPE"] = "rvy"
                 else:
                     result["TARGET_CPUTYPE"] = "cheri"
-                if self.compiling_for_mips(include_purecap=True):
-                    result["CHERI"] = self.config.mips_cheri_bits_str
         return result
 
     def _setup_make_args(self) -> None:
@@ -1171,15 +1162,6 @@ class BuildFreeBSD(BuildFreeBSDBase):
     def _setup_arch_specific_options(self) -> str:
         if self.crosscompile_target.is_any_x86() or self.crosscompile_target.is_aarch64(include_purecap=True):
             target_flags = ""
-        elif self.compiling_for_mips(include_purecap=True):
-            target_flags = "-fcolor-diagnostics"
-            # TODO: should probably set that inside CheriBSD makefiles instead
-            if self.target_info.is_cheribsd():
-                target_flags += " -mcpu=beri"
-            self.cross_toolchain_config.set_with_options(
-                RESCUE=False,  # Won't compile with CHERI clang yet
-                BOOT=False,
-            )  # bootloaders won't link with LLD yet
         elif self.compiling_for_riscv(include_purecap=True):
             target_flags = ""
         else:
@@ -1197,9 +1179,6 @@ class BuildFreeBSD(BuildFreeBSDBase):
     def kernel_make_args_for_config(self, kernconfs: "list[str]", extra_make_args) -> MakeOptions:
         self._setup_make_args()  # ensure make args are complete
         kernel_options = self.make_args.copy()
-        if self.compiling_for_mips(include_purecap=True):
-            # Don't build kernel modules for MIPS
-            kernel_options.set(NO_MODULES="yes")
         if not self.use_bootstrapped_toolchain:
             kernel_options.update(self.cross_toolchain_config)
             kernel_options.remove_var("LDFLAGS")
@@ -1724,7 +1703,7 @@ class BuildFreeBSD(BuildFreeBSDBase):
             colour_diags=colour_diags,
         )
         make_args.set(BUILDENV_SHELL="sh -ex -c '" + build_cmd + "' || exit 1")
-        # If --libcompat-buildenv was passed skip the MIPS lib
+        # If --libcompat-buildenv was passed skip the legacy lib
         has_libcompat = self.crosscompile_target.is_hybrid_or_purecap_cheri() and is_lib  # TODO: handle lib32
         if has_libcompat and (self.config.libcompat_buildenv or libcompat_only):
             self.info("Skipping default ABI build of", subdir, "since --libcompat-buildenv was passed.")
@@ -1735,7 +1714,7 @@ class BuildFreeBSD(BuildFreeBSDBase):
                 env=make_args.env_vars,
                 cwd=self.source_dir,
             )
-        # If we are building a library, we want to build both the CHERI and the mips version (unless the
+        # If we are building a library, we want to build both the CHERI and the legacy version (unless the
         # user explicitly specified --libcompat-buildenv)
         if has_libcompat and not noncheri_only and self.libcompat_name():
             compat_target = self.libcompat_name() + "buildenv"
@@ -1844,7 +1823,6 @@ class BuildCHERIBSD(BuildFreeBSD):
     hide_options_from_help: bool = False  # FreeBSD options are hidden, but this one should be visible
     has_installsysroot_target: bool = True
 
-    # NB: Full CHERI-MIPS purecap kernel support was never merged
     purecap_kernel_targets: "tuple[CrossCompileTarget, ...]" = (
         CompilationTargets.CHERIBSD_RISCV_HYBRID,
         CompilationTargets.CHERIBSD_RISCV_PURECAP,

--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -71,9 +71,6 @@ from ...utils import OSInfo, ThreadJoiner, is_jenkins_build
 def _arch_suffixed_custom_install_dir(prefix: str) -> "ComputedDefaultValue[Path]":
     def inner(config: CheriConfig, project: Project):
         xtarget = project.crosscompile_target
-        # Check that we don't accidentally inherit the FreeBSD install directories for CheriBSD
-        if not isinstance(project, BuildCHERIBSD) and xtarget.is_hybrid_or_purecap_cheri():
-            raise ValueError(f"{project.target} should not build for CHERI architectures")
         return config.output_root / (prefix + project.build_configuration_suffix(xtarget))
 
     return ComputedDefaultValue(function=inner, as_string="$INSTALL_ROOT/" + prefix + "-<arch>")
@@ -876,8 +873,6 @@ class BuildFreeBSD(BuildFreeBSDBase):
 
     def default_kernel_config(self, platform: "Optional[ConfigPlatform]" = None, **filter_kwargs) -> str:
         xtarget = self.crosscompile_target
-        # Only handle FreeBSD native configs here
-        assert not xtarget.is_hybrid_or_purecap_cheri(), "Unexpected FreeBSD target"
         if platform is None:
             platform = self.get_default_kernel_platform()
         config = CheriBSDConfigTable.get_default(self.config, xtarget, platform, KernelABI.NOCHERI, **filter_kwargs)

--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -543,7 +543,6 @@ class BuildFreeBSDBase(Project):
     default_extra_make_options: "list[str]" = [
         # "-DWITHOUT_HTML",  # should not be needed
         # "-DWITHOUT_SENDMAIL", "-DWITHOUT_MAIL",  # no need for sendmail
-        # "-DWITHOUT_SVNLITE",  # no need for SVN
         # "-DWITHOUT_GAMES",  # not needed
         # "-DWITHOUT_MAN",  # seems to be a majority of the install time
         # "-DWITH_FAST_DEPEND",  # no separate make depend step, do it while compiling
@@ -659,8 +658,6 @@ class BuildFreeBSDBase(Project):
             self.make_args.set_with_options(
                 MAN=False,
                 KERBEROS=False,
-                SVN=False,
-                SVNLITE=False,
                 MAIL=False,
                 ZFS=False,
                 SENDMAIL=False,


### PR DESCRIPTION
Add bare minimum targets for purecap freebsd.

A bunch of minor cleanups prior to the main change.