### PR TITLE
Add GitHub Actions workflow to build/push portable container

### DIFF
--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -1,0 +1,56 @@
+name: Build and Push Portable Docker Image
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'docker/Dockerfile.rocky8'
+      - '.github/workflows/build-push-docker.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'docker/Dockerfile.rocky8'
+      - '.github/workflows/build-push-docker.yml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: cheri-portable-build-container
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Convert repository owner to lowercase
+        run: |
+          echo "OWNER_LOWERCASE=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docker
+          file: ./docker/Dockerfile.rocky8
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.OWNER_LOWERCASE }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.OWNER_LOWERCASE }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -293,6 +293,17 @@ See `cheribuild.py --list-targets` for a full list of targets.
 
 There is currently experimental support to build libcxx as a baremetal library running on top of newlib.
 This can be done by running `cheribuild.py libcxx-baremetal -d`.
+## Running inside Docker / CI Container
+
+cheribuild includes support for running builds inside a Docker container using the `--docker` option.
+
+For portable builds (e.g. for building portable native host compilers and toolchains), a pre-built, highly compatible Rocky Linux 8 based container image is built automatically by GitHub Actions and pushed to the GitHub Container Registry (GHCR). This image comes pre-installed with static versions of all foundational libraries (such as static `zlib`, `pixman`, `libffi`, `glib`, and `zstd`) to guarantee maximum portability of compiled binaries.
+
+Other projects can easily pull and use this Docker image in their own CI pipelines:
+
+```bash
+docker pull ghcr.io/ctsrd-cheri/cheri-portable-build-container:latest
+```
 
 ## Adapting the build configuration
 There are a lot of options to customize the behaviour of this script: e.g. the directory for


### PR DESCRIPTION
This can be used by other projects in their CI to build portable Linux binaries that can run almost anywhere.