### PR TITLE
Config option cleanup

### DIFF
--- a/pycheribuild/config/config_loader_base.py
+++ b/pycheribuild/config/config_loader_base.py
@@ -395,18 +395,18 @@ class ConfigOptionBase(AbstractConfigOption[T]):
         return self._is_default_value
 
     def __get__(self, instance, owner) -> T:
-        assert instance is not None or not callable(self.default), (
+        # If instance is None, we can pass the class (owner) as a fallback for instance
+        # so that ComputedDefaultValue can query class attributes/methods if it handles it.
+        lookup_instance = instance if instance is not None else owner
+        assert lookup_instance is not None or not callable(self.default), (
             f"Tried to access read config option {self.full_option_name} without an object instance. "
             f"Config options using computed defaults can only be used with an object instance. Owner = {owner}"
         )
 
-        # TODO: would be nice if this was possible (but too much depends on accessing values without instances)
-        # if instance is None:
-        #     return self
         assert not self._owning_class or issubclass(owner, self._owning_class)
         if self._cached is None:
             # noinspection PyProtectedMember
-            self._cached = self.load_option(self._loader._cheri_config, instance, owner)
+            self._cached = self.load_option(self._loader._cheri_config, lookup_instance, owner)
         return self._cached
 
     def _get_default_value(self, config: "ConfigBase", instance: "Optional[object]" = None) -> Optional[T]:

--- a/pycheribuild/config/config_loader_base.py
+++ b/pycheribuild/config/config_loader_base.py
@@ -410,11 +410,10 @@ class ConfigOptionBase(AbstractConfigOption[T]):
         return self._cached
 
     def _get_default_value(self, config: "ConfigBase", instance: "Optional[object]" = None) -> Optional[T]:
-        if callable(self.default):
-            # pyrefly: ignore [bad-return]
-            return self.default(config, instance)
-        else:
-            return self.default
+        val = self.default
+        while callable(val):
+            val = val(config, instance)
+        return typing.cast(Optional[T], val)
 
     def _convert_type(self, loaded_result: _LoadedConfigValue) -> "Optional[T]":
         # check for None to make sure we don't call str(None) which would result in "None"

--- a/pycheribuild/jenkins.py
+++ b/pycheribuild/jenkins.py
@@ -40,7 +40,7 @@ from typing import Optional
 
 from .config.jenkinsconfig import JenkinsAction, JenkinsConfig
 from .config.loader import CommandLineConfigLoader
-from .jenkins_utils import jenkins_override_install_dirs_hack
+from .jenkins_utils import jenkins_override_install_dirs
 from .processutils import get_program_version, run_and_kill_children_on_exit, run_command
 
 # make sure all projects are loaded so that target_manager gets populated
@@ -283,17 +283,16 @@ def _jenkins_main() -> None:
         fatal_error("More than one target is not supported yet.", pretend=False)
         sys.exit()
 
-    jenkins_override_install_dirs_hack(cheri_config, cheri_config.installation_prefix)
+    with jenkins_override_install_dirs(cheri_config, cheri_config.installation_prefix):
+        if JenkinsAction.BUILD in cheri_config.action or JenkinsAction.TEST in cheri_config.action:
+            # Check system dependencies before building any targets to get an error message earlier.
+            for target in cheri_config.targets:
+                target_manager.get_target_raw(target).check_system_deps(cheri_config)
+            for tgt in cheri_config.targets:
+                build_target(cheri_config, target_manager.get_target_raw(tgt))
 
-    if JenkinsAction.BUILD in cheri_config.action or JenkinsAction.TEST in cheri_config.action:
-        # Check system dependencies before building any targets to get an error message earlier.
-        for target in cheri_config.targets:
-            target_manager.get_target_raw(target).check_system_deps(cheri_config)
-        for tgt in cheri_config.targets:
-            build_target(cheri_config, target_manager.get_target_raw(tgt))
-
-    if JenkinsAction.CREATE_TARBALL in cheri_config.action:
-        create_tarball(cheri_config)
+        if JenkinsAction.CREATE_TARBALL in cheri_config.action:
+            create_tarball(cheri_config)
 
 
 def build_target(cheri_config, target: Target) -> None:

--- a/pycheribuild/jenkins_utils.py
+++ b/pycheribuild/jenkins_utils.py
@@ -33,7 +33,7 @@ from typing import Optional
 
 from .config.jenkinsconfig import CheriConfig, JenkinsConfig
 from .config.loader import CommandLineConfigOption
-from .config.target_info import CrossCompileTarget
+from .config.target_info import AbstractProject, CrossCompileTarget
 from .projects.project import ComputedDefaultValue, Project
 from .targets import MultiArchTargetAlias, SimpleTargetAlias, Target, target_manager
 from .utils import fatal_error, status_update
@@ -64,18 +64,10 @@ def jenkins_override_install_dirs_hack(cheri_config: CheriConfig, install_prefix
         if target.xtarget.is_native():
             fatal_error("Cannot use non-existent sysroot for native target", target.name, pretend=False)
 
-    def expected_install_root(tgt: Target, as_template=False) -> Path:
+    def expected_install_root(p: AbstractProject, tgt: Target) -> Path:
         if tgt in sysroot_targets:
-            if as_template:
-                return Path("$SYSROOT")
-            # noinspection PyProtectedMember
-            proj = tgt._get_or_create_project_no_setup(cross_target=None, config=cheri_config, caller=None)
-            target_info = proj.target_info
-            sysroot_dir = target_info.sysroot_dir
-            return sysroot_dir
+            return p.target_info.sysroot_dir
         else:
-            if as_template:
-                return Path("$OUTPUT_ROOT")
             return cheri_config.output_root
 
     def expected_install_prefix(tgt: Target) -> Path:
@@ -86,16 +78,16 @@ def jenkins_override_install_dirs_hack(cheri_config: CheriConfig, install_prefix
         else:
             return install_prefix_arg
 
-    def expected_install_path(tgt: Target, as_template=False) -> Path:
-        root_dir = expected_install_root(tgt, as_template)
+    def expected_install_path(p: AbstractProject, tgt: Target) -> Path:
+        root_dir = expected_install_root(p, tgt)
         install_prefix = expected_install_prefix(tgt)
         return Path(f"{root_dir}{install_prefix}")
 
     for target in all_targets:
         cls = target.project_class
         cls._default_install_dir_fn = ComputedDefaultValue(
-            function=lambda config, project: expected_install_path(target),
-            as_string=str(expected_install_path(target, True)),
+            function=lambda config, p: expected_install_path(p, target),
+            as_string="$SYSROOT" if target in sysroot_targets else "$OUTPUT_ROOT",
         )
 
     Target.instantiating_targets_should_warn = False
@@ -119,15 +111,15 @@ def jenkins_override_install_dirs_hack(cheri_config: CheriConfig, install_prefix
             status_update("Install directory for", cls.target, "was specified on commandline:", from_cmdline)
             project._install_dir = from_cmdline
         else:
-            project._install_dir = expected_install_root(target)
+            project._install_dir = expected_install_root(project, target)
             project._check_install_dir_conflict = False
             # Using "/" as the install prefix results inconsistently prefixing some paths with '/usr/'.
             # To avoid this, just use the full install path as the prefix.
             if expected_install_prefix(target) == Path("/"):
-                project._install_prefix = expected_install_path(target)
+                project._install_prefix = expected_install_path(project, target)
                 project.destdir = Path("/")
             else:
                 project._install_prefix = expected_install_prefix(target)
-                project.destdir = expected_install_root(target)
-            assert project.real_install_root_dir == expected_install_path(target)
+                project.destdir = expected_install_root(project, target)
+            assert project.real_install_root_dir == expected_install_path(project, target)
         assert isinstance(inspect.getattr_static(project, "_install_dir"), Path)

--- a/pycheribuild/jenkins_utils.py
+++ b/pycheribuild/jenkins_utils.py
@@ -27,6 +27,7 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 #
+import contextlib
 import inspect
 from pathlib import Path
 from typing import Optional
@@ -45,7 +46,8 @@ def default_install_prefix(xtarget: CrossCompileTarget, cheri_config: CheriConfi
     return Path("/opt", dirname)
 
 
-def jenkins_override_install_dirs_hack(cheri_config: CheriConfig, install_prefix_arg: Optional[Path]):
+@contextlib.contextmanager
+def jenkins_override_install_dirs(cheri_config: CheriConfig, install_prefix_arg: Optional[Path]):
     # Ugly workaround to override all install dirs to go to the tarball
     all_targets = [
         x
@@ -82,6 +84,13 @@ def jenkins_override_install_dirs_hack(cheri_config: CheriConfig, install_prefix
         root_dir = expected_install_root(p, tgt)
         install_prefix = expected_install_prefix(tgt)
         return Path(f"{root_dir}{install_prefix}")
+
+    # Save original class-level defaults to restore them later
+    original_fns = {}
+    for target in all_targets:
+        cls = target.project_class
+        if "_default_install_dir_fn" in cls.__dict__:
+            original_fns[cls] = cls.__dict__["_default_install_dir_fn"]
 
     for target in all_targets:
         cls = target.project_class
@@ -123,3 +132,15 @@ def jenkins_override_install_dirs_hack(cheri_config: CheriConfig, install_prefix
                 project.destdir = expected_install_root(project, target)
             assert project.real_install_root_dir == expected_install_path(project, target)
         assert isinstance(inspect.getattr_static(project, "_install_dir"), Path)
+
+    try:
+        yield
+    finally:
+        # Restore original class-level defaults to avoid test pollution
+        for target in all_targets:
+            cls = target.project_class
+            if cls in original_fns:
+                cls._default_install_dir_fn = original_fns[cls]
+            else:
+                if "_default_install_dir_fn" in cls.__dict__:
+                    del cls._default_install_dir_fn

--- a/pycheribuild/projects/build_qemu.py
+++ b/pycheribuild/projects/build_qemu.py
@@ -48,7 +48,7 @@ from .project import (
     MakeCommandKind,
     Project,
 )
-from .simple_project import BoolConfigOption, SimpleProject, _cached_get_homebrew_prefix
+from .simple_project import BoolConfigOption, SimpleProject, StringConfigOption, _cached_get_homebrew_prefix
 from ..config.compilation_targets import BaremetalFreestandingTargetInfo, CompilationTargets
 from ..config.config_loader_base import ConfigOptionHandle
 from ..utils import OSInfo
@@ -96,6 +96,15 @@ class BuildQEMUBase(AutotoolsProject):
         default=True,
         help="Prefer full LTO over LLVM ThinLTO when using LTO",
     )
+    qemu_targets = StringConfigOption(
+        "targets",
+        show_help=True,
+        help="Build QEMU for the following targets",
+        default=ComputedDefaultValue(
+            function=lambda config, proj: proj.default_targets,
+            as_string="QEMU default targets",
+        ),
+    )
 
     @classmethod
     def is_toolchain_target(cls):
@@ -110,16 +119,6 @@ class BuildQEMUBase(AutotoolsProject):
         if self.build_type.is_release():
             return ["-O3"]  # Build with -O3 instead of -O2, we want QEMU to be as fast as possible
         return super()._build_type_basic_compiler_flags
-
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(**kwargs)
-        cls.qemu_targets = cls.add_config_option(
-            "targets",
-            show_help=True,
-            help="Build QEMU for the following targets",
-            default=cls.default_targets,
-        )
 
     @classmethod
     def qemu_binary(

--- a/pycheribuild/projects/cherios.py
+++ b/pycheribuild/projects/cherios.py
@@ -30,7 +30,7 @@
 
 from .cmake_project import CMakeProject
 from .project import BuildType, ComputedDefaultValue, GitRepository
-from .run_qemu import LaunchQEMUBase, get_default_ssh_forwarding_port
+from .run_qemu import LaunchQEMUBase
 from .simple_project import BoolConfigOption, IntConfigOption
 from ..config.compilation_targets import CompilationTargets
 from ..utils import OSInfo
@@ -73,10 +73,6 @@ class LaunchCheriOSQEMU(LaunchQEMUBase):
     forward_ssh_port = False
     qemu_user_networking = False
     hide_options_from_help = True
-
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(default_ssh_port=get_default_ssh_forwarding_port(40), **kwargs)
 
     @property
     def source_project(self):

--- a/pycheribuild/projects/cmake_project.py
+++ b/pycheribuild/projects/cmake_project.py
@@ -35,7 +35,7 @@ from pathlib import Path
 from typing import Optional, Sequence
 
 from .project import MakeCommandKind, Project, _CMakeAndMesonSharedLogic
-from .simple_project import _default_stdout_filter
+from .simple_project import ListConfigOption, _default_stdout_filter
 from ..config.chericonfig import BuildType
 from ..processutils import commandline_to_str
 from ..targets import target_manager
@@ -63,7 +63,9 @@ class CMakeProject(_CMakeAndMesonSharedLogic):
     ctest_script_extra_args: Sequence[str] = tuple()
     # 3.13.4 is the minimum version for LLVM and that also allows us to use "cmake --build -j <N>" unconditionally.
     _minimum_cmake_or_meson_version: "tuple[int, ...]" = (3, 13, 4)
-    cmake_options: "list[str]"
+    cmake_options = ListConfigOption(
+        "cmake-options", metavar="OPTIONS", help="Additional command line options to pass to CMake"
+    )
     configure_command = Path(os.getenv("CMAKE_COMMAND", "cmake"))
 
     def _toolchain_file_list_to_str(self, value: "Sequence[str | Path]") -> str:
@@ -91,13 +93,6 @@ class CMakeProject(_CMakeAndMesonSharedLogic):
     def _build_type_basic_compiler_flags(self):
         # No need to add any flags here, cmake does it for us already
         return []
-
-    @classmethod
-    def setup_config_options(cls, **kwargs) -> None:
-        super().setup_config_options(**kwargs)
-        cls.cmake_options = cls.add_list_option(
-            "cmake-options", metavar="OPTIONS", help="Additional command line options to pass to CMake"
-        )
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)

--- a/pycheribuild/projects/cross/benchmarks.py
+++ b/pycheribuild/projects/cross/benchmarks.py
@@ -45,6 +45,13 @@ from .crosscompileproject import (
 )
 from .llvm_test_suite import BuildLLVMTestSuite, BuildLLVMTestSuiteBase
 from ..project import ReuseOtherProjectRepository
+from ..simple_project import (
+    BoolConfigOption,
+    ListConfigOption,
+    OptionalPathConfigOption,
+    PathConfigOption,
+    StringConfigOption,
+)
 from ...config.target_info import CPUArchitecture
 from ...processutils import get_program_version
 from ...targets import target_manager
@@ -64,16 +71,12 @@ class BuildMibench(BenchmarkMixin, CrossCompileProject):
     # The makefiles here can't support any other tagets:
     _supported_architectures = (CompilationTargets.NATIVE,)
 
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(**kwargs)
-        cls.benchmark_size: str = cls.add_config_option(
-            "benchmark-size",
-            choices=("small", "large"),
-            default="large",
-            kind=str,
-            help="Size of benchmark input data to use",
-        )
+    benchmark_size = StringConfigOption(
+        "benchmark-size",
+        choices=("small", "large"),
+        default="large",
+        help="Size of benchmark input data to use",
+    )
 
     @property
     def bundle_dir(self):
@@ -342,15 +345,14 @@ class BuildSpec2006New(_BuildLLVMTestSuiteSubdir):
     # TODO: External/SPEC/CFP2006",
     _test_suite_subdirs = ["External/SPEC/CINT2006"]
 
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(**kwargs)
-        cls.spec_iso_path = cls.add_optional_path_option(
-            "iso-path", altname="spec-sources", help="Path to the SPEC2006 ISO image or extracted sources"
-        )
-        cls.fast_benchmarks_only = cls.add_bool_option("fast-benchmarks-only", default=False)
-        cls.workload = cls.add_config_option("workload", choices=("test", "train", "ref"), default="test")
-        cls.benchmark_override = cls.add_list_option("benchmarks", help="override the list of benchmarks to run")
+    spec_iso_path = OptionalPathConfigOption(
+        "iso-path", altname="spec-sources", help="Path to the SPEC2006 ISO image or extracted sources"
+    )
+    fast_benchmarks_only = BoolConfigOption("fast-benchmarks-only", help="Only run fast benchmarks", default=False)
+    workload = StringConfigOption(
+        "workload", help="SPEC2006 workload type", choices=("test", "train", "ref"), default="test"
+    )
+    benchmark_override = ListConfigOption("benchmarks", help="override the list of benchmarks to run")
 
     @property
     def extracted_spec_sources(self) -> Path:
@@ -449,13 +451,10 @@ class BuildSpec2017(_BuildLLVMTestSuiteSubdir):
     target = "spec2017"
     _test_suite_subdirs = ["External/SPEC/CINT2017rate", "External/SPEC/CFP2017rate"]
 
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(**kwargs)
-        cls.spec_sources = cls.add_path_option(
-            "spec-sources", default=Path(), help="Path to the extracted SPEC2017 sources"
-        )
-        cls.workload = cls.add_config_option("workload", choices=("test", "train", "ref"), default="test")
+    spec_sources = PathConfigOption("spec-sources", default=Path(), help="Path to the extracted SPEC2017 sources")
+    workload = StringConfigOption(
+        "workload", help="SPEC2017 workload type", choices=("test", "train", "ref"), default="test"
+    )
 
     def setup(self):
         if self.spec_sources == Path():
@@ -531,10 +530,6 @@ class BuildLMBench(BenchmarkMixin, CrossCompileProject):
     _extra_git_clean_excludes = ["--exclude=*-bundle"]
     # The makefiles here can't support any other tagets:
     _supported_architectures = (CompilationTargets.NATIVE,)
-
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(**kwargs)
 
     @property
     def bundle_dir(self):
@@ -614,12 +609,9 @@ class BuildUnixBench(BenchmarkMixin, CrossCompileProject):
     # The makefiles here can't support any other tagets:
     _supported_architectures = (CompilationTargets.NATIVE,)
 
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(**kwargs)
-        cls.fixed_iterations = cls.add_bool_option(
-            "fixed-iterations", default=False, help="Run benchmarks for given number of iterations instead of duration."
-        )
+    fixed_iterations = BoolConfigOption(
+        "fixed-iterations", default=False, help="Run benchmarks for given number of iterations instead of duration."
+    )
 
     @property
     def bundle_dir(self):
@@ -694,15 +686,12 @@ class NetPerfBench(BenchmarkMixin, CrossCompileAutotoolsProject):
         CompilationTargets.CHERIBSD_RISCV_PURECAP,
     )
 
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(**kwargs)
-        cls.hw_counters = cls.add_config_option(
-            "enable-hw-counters",
-            choices=("pmc", "statcounters"),
-            default="statcounters",
-            help="Use hardware performance counters",
-        )
+    hw_counters = StringConfigOption(
+        "enable-hw-counters",
+        choices=("pmc", "statcounters"),
+        default="statcounters",
+        help="Use hardware performance counters",
+    )
 
     def configure(self, **kwargs):
         self.configure_args.append("--enable-unixdomain")

--- a/pycheribuild/projects/cross/cheri_microkit.py
+++ b/pycheribuild/projects/cross/cheri_microkit.py
@@ -31,7 +31,6 @@
 #
 import subprocess
 import threading
-import typing
 from pathlib import Path
 
 from .crosscompileproject import (
@@ -44,6 +43,7 @@ from .crosscompileproject import (
 from ..build_qemu import BuildCheriAllianceQEMU, BuildQEMU
 from ..project import CheriConfig, CPUArchitecture
 from ..run_qemu import LaunchQEMUBase
+from ..simple_project import BoolConfigOption, OptionalStringConfigOption, StringConfigOption
 from ...config.chericonfig import RiscvCheriISA
 
 
@@ -89,48 +89,33 @@ class BuildCheriMicrokit(CrossCompileAutotoolsProject):
     )
     supported_riscv_cheri_standard = RiscvCheriISA.EXPERIMENTAL_STD093
 
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(**kwargs)
-        cls.configs: str = typing.cast(
-            str,
-            cls.add_config_option(
-                "configs",
-                metavar="CONFIGS",
-                show_help=True,
-                default="cheri",
-                help="CHERI-Microkit comma-separated configs (release, debug, benchmark, and cheri).",
-            ),
-        )
-        cls.boards: str = typing.cast(
-            str,
-            cls.add_config_option(
-                "boards",
-                metavar="BOARDS",
-                show_help=True,
-                default=None,
-                help="CHERI-Microkit comma-separated list of boards to build for.",
-            ),
-        )
-        cls.example: str = typing.cast(
-            str,
-            cls.add_config_option(
-                "example",
-                metavar="EXAMPLE",
-                show_help=True,
-                default="hello,hierarchy,passive_server,rust",
-                help="CHERI-Microkit example to build.",
-            ),
-        )
-        cls.build_all: str = typing.cast(
-            str,
-            cls.add_bool_option(
-                "build_all",
-                show_help=True,
-                default=False,
-                help="Build all Microkit configs, targets, boards, etc.",
-            ),
-        )
+    configs = StringConfigOption(
+        "configs",
+        metavar="CONFIGS",
+        show_help=True,
+        default="cheri",
+        help="CHERI-Microkit comma-separated configs (release, debug, benchmark, and cheri).",
+    )
+    boards = OptionalStringConfigOption(
+        "boards",
+        metavar="BOARDS",
+        show_help=True,
+        default=None,
+        help="CHERI-Microkit comma-separated list of boards to build for.",
+    )
+    example = StringConfigOption(
+        "example",
+        metavar="EXAMPLE",
+        show_help=True,
+        default="hello,hierarchy,passive_server,rust",
+        help="CHERI-Microkit example to build.",
+    )
+    build_all = BoolConfigOption(
+        "build_all",
+        show_help=True,
+        default=False,
+        help="Build all Microkit configs, targets, boards, etc.",
+    )
 
     def compile(self, **kwargs):
         cmdline = [

--- a/pycheribuild/projects/cross/cheribsd.py
+++ b/pycheribuild/projects/cross/cheribsd.py
@@ -57,6 +57,8 @@ from ..project import (
 from ..simple_project import (
     BoolConfigOption,
     IntConfigOption,
+    OptionalPathConfigOption,
+    OptionalStringConfigOption,
     SimpleProject,
     TargetAliasWithDependencies,
     _clear_line_sequence,
@@ -2252,14 +2254,11 @@ else:
 
 
 class BuildFreeBSDReleaseMixin(ReleaseMixinBase):
-    @classmethod
-    def setup_config_options(cls, **kwargs) -> None:
-        super().setup_config_options(**kwargs)
-        cls.build_vm_images = cls.add_bool_option(
-            "build-vm-images",
-            _allow_unknown_targets=True,
-            help="Build VM images with releases.",
-        )
+    build_vm_images = BoolConfigOption(
+        "build-vm-images",
+        _allow_unknown_targets=True,
+        help="Build VM images with releases.",
+    )
 
     def check_system_dependencies(self) -> None:
         super().check_system_dependencies()
@@ -2418,21 +2417,18 @@ class BuildCheriBsdSysrootArchive(SimpleProject):
             if not self.config.pretend:
                 sys.exit("Cannot continue...")
 
-    @classmethod
-    def setup_config_options(cls, **kwargs) -> None:
-        super().setup_config_options(**kwargs)
-        cls.copy_remote_sysroot = cls.add_bool_option(
-            "copy-remote-sysroot", help="Copy sysroot from remote server instead of from local machine"
-        )
-        cls.remote_path = cls.add_optional_config_option(
-            "remote-sdk-path",
-            show_help=True,
-            metavar="PATH",
-            help="The path to the CHERI SDK on the remote FreeBSD machine (e.g. vica:~foo/cheri/output/sdk)",
-        )
-        cls.install_dir_override = cls.add_optional_path_option(
-            "install-directory", help="Override for the sysroot install directory"
-        )
+    copy_remote_sysroot = BoolConfigOption(
+        "copy-remote-sysroot", help="Copy sysroot from remote server instead of from local machine"
+    )
+    remote_path = OptionalStringConfigOption(
+        "remote-sdk-path",
+        show_help=True,
+        metavar="PATH",
+        help="The path to the CHERI SDK on the remote FreeBSD machine (e.g. vica:~foo/cheri/output/sdk)",
+    )
+    install_dir_override = OptionalPathConfigOption(
+        "install-directory", help="Override for the sysroot install directory"
+    )
 
     @property
     def cross_sysroot_path(self) -> Path:

--- a/pycheribuild/projects/cross/cheritest.py
+++ b/pycheribuild/projects/cross/cheritest.py
@@ -29,7 +29,7 @@
 #
 from ..project import DefaultInstallDir, GitRepository, MakeCommandKind, Project
 from ..sail import BuildSailCheriMips
-from ..simple_project import BoolConfigOption
+from ..simple_project import BoolConfigOption, OptionalStringConfigOption
 
 
 class _BuildCheriMipsTestBase(Project):
@@ -47,12 +47,7 @@ class _BuildCheriMipsTestBase(Project):
         default=True,
     )
 
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(**kwargs)
-        cls.single_test = cls.add_optional_config_option(
-            "single-test", kind=str, help="Run a single test instead of all of them"
-        )
+    single_test = OptionalStringConfigOption("single-test", help="Run a single test instead of all of them")
 
     def setup(self):
         super().setup()

--- a/pycheribuild/projects/cross/dlmalloc.py
+++ b/pycheribuild/projects/cross/dlmalloc.py
@@ -29,6 +29,11 @@
 #
 
 from .crosscompileproject import CrossCompileProject, DefaultInstallDir, GitRepository, MakeCommandKind
+from ..simple_project import (
+    BoolConfigOption,
+    OptionalFloatConfigOption,
+    OptionalIntConfigOption,
+)
 from ...processutils import commandline_to_str
 
 
@@ -38,41 +43,22 @@ class DLMalloc(CrossCompileProject):
     make_kind = MakeCommandKind.GnuMake
     native_install_dir = DefaultInstallDir.CHERI_SDK
 
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(**kwargs)
-
-        cls.just_so = cls.add_bool_option("just-so", help="Just build the .so shim")
-        cls.debug = cls.add_bool_option("debug", help="Turn on debugging features")
-
-        cls.cheri_set_bounds = cls.add_bool_option("cheri-bounds", default=True, help="Set bounds on allocations")
-
-        cls.qmabs = cls.add_optional_config_option("qmabs", kind=int, help="Quarantine memory absolute threshold")
-
-        cls.qmratio = cls.add_optional_config_option("qmratio", kind=float, help="Quarantine memory ratio threshold")
-
-        cls.qmmin = cls.add_optional_config_option(
-            "qmmin", kind=int, help="Minimum amount quarantined to trigger a revocation based on ratio"
-        )
-
-        cls.revoke = cls.add_bool_option("revoke", help="Revoke quarantine before reusing")
-
-        cls.consolidate_on_free = cls.add_bool_option(
-            "consolidate", default=True, help="Consolidate memory when quarantining"
-        )
-
-        cls.zero_memory = cls.add_bool_option("zero-memory", help="Zero allocated memory")
-
-        cls.stats_at_exit = cls.add_bool_option("stats-at-exit", default=True, help="print statistics on exit")
-
-        cls.unmap_support = cls.add_bool_option("unmap-support", default=True, help="support for unmapping")
-
-        cls.unmap_threshold = cls.add_optional_config_option(
-            "unmap-threshold",
-            kind=int,
-            help="Threshold (in pages) at which interior pages of quanantined chunks are unmapped",
-        )
-        cls.quar_unsafe = cls.add_bool_option("unsafe-quarantine", help="Don't isolate quarantine structures")
+    just_so = BoolConfigOption("just-so", help="Just build the .so shim")
+    debug = BoolConfigOption("debug", help="Turn on debugging features")
+    cheri_set_bounds = BoolConfigOption("cheri-bounds", default=True, help="Set bounds on allocations")
+    qmabs = OptionalIntConfigOption("qmabs", help="Quarantine memory absolute threshold")
+    qmratio = OptionalFloatConfigOption("qmratio", help="Quarantine memory ratio threshold")
+    qmmin = OptionalIntConfigOption("qmmin", help="Minimum amount quarantined to trigger a revocation based on ratio")
+    revoke = BoolConfigOption("revoke", help="Revoke quarantine before reusing")
+    consolidate_on_free = BoolConfigOption("consolidate", default=True, help="Consolidate memory when quarantining")
+    zero_memory = BoolConfigOption("zero-memory", help="Zero allocated memory")
+    stats_at_exit = BoolConfigOption("stats-at-exit", default=True, help="print statistics on exit")
+    unmap_support = BoolConfigOption("unmap-support", default=True, help="support for unmapping")
+    unmap_threshold = OptionalIntConfigOption(
+        "unmap-threshold",
+        help="Threshold (in pages) at which interior pages of quanantined chunks are unmapped",
+    )
+    quar_unsafe = BoolConfigOption("unsafe-quarantine", help="Don't isolate quarantine structures")
 
     def setup(self):
         super().setup()

--- a/pycheribuild/projects/cross/freertos.py
+++ b/pycheribuild/projects/cross/freertos.py
@@ -30,13 +30,12 @@
 # SUCH DAMAGE.
 #
 import os
-import typing
-from typing import ClassVar
 
 from .compiler_rt import BuildCompilerRtBuiltins
 from .crosscompileproject import CompilationTargets, CrossCompileAutotoolsProject, DefaultInstallDir, GitRepository
 from ..project import ComputedDefaultValue
 from ..run_qemu import LaunchQEMUBase
+from ..simple_project import StringConfigOption
 
 
 class BuildFreeRTOS(CrossCompileAutotoolsProject):
@@ -68,9 +67,26 @@ class BuildFreeRTOS(CrossCompileAutotoolsProject):
 
     default_demo = "RISC-V-Generic"
     default_demo_app = "main_blinky"
-    demo: "ClassVar[str]"
-    demo_app: "ClassVar[str]"
-    demo_bsp: "ClassVar[str]"
+    demo = StringConfigOption(
+        "demo", metavar="DEMO", show_help=True, default=default_demo, help="The FreeRTOS Demo build."
+    )
+    demo_app = StringConfigOption(
+        "prog",
+        metavar="PROG",
+        show_help=True,
+        default=default_demo_app,
+        help="The FreeRTOS program to build.",
+    )
+    demo_bsp = StringConfigOption(
+        "bsp",
+        metavar="BSP",
+        show_help=True,
+        default=ComputedDefaultValue(function=lambda _, p: p.default_demo_bsp(), as_string="target-dependent default"),
+        help="The FreeRTOS BSP to build. This is only valid for the "
+        "paramterized RISC-V-Generic. The BSP option chooses "
+        "platform, RISC-V arch and RISC-V abi in the "
+        "$platform-$arch-$abi format. See RISC-V-Generic/README for more details",
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -103,36 +119,6 @@ class BuildFreeRTOS(CrossCompileAutotoolsProject):
             self.supported_demo_apps["RISC-V_Galois_P1"] = ["main_blinky", "main_netboot"]
 
             self.make_args.set(EXTENSION="cheri")
-
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(**kwargs)
-
-        cls.demo: str = cls.add_config_option(
-            "demo", metavar="DEMO", show_help=True, default=cls.default_demo, help="The FreeRTOS Demo build."
-        )
-
-        cls.demo_app: str = cls.add_config_option(
-            "prog",
-            metavar="PROG",
-            show_help=True,
-            default=cls.default_demo_app,
-            help="The FreeRTOS program to build.",
-        )
-
-        cls.demo_bsp: str = cls.add_config_option(
-            "bsp",
-            metavar="BSP",
-            show_help=True,
-            kind=str,
-            default=ComputedDefaultValue(
-                function=lambda _, p: p.default_demo_bsp(), as_string="target-dependent default"
-            ),
-            help="The FreeRTOS BSP to build. This is only valid for the "
-            "paramterized RISC-V-Generic. The BSP option chooses "
-            "platform, RISC-V arch and RISC-V abi in the "
-            "$platform-$arch-$abi format. See RISC-V-Generic/README for more details",
-        )  # ty:ignore[invalid-assignment]
 
     def default_demo_bsp(self):
         return (
@@ -198,43 +184,31 @@ class LaunchFreeRTOSQEMU(LaunchQEMUBase):
     default_demo = "RISC-V-Generic"
     default_demo_app = "main_blinky"
 
+    demo = StringConfigOption(
+        "demo", metavar="DEMO", show_help=True, default=default_demo, help="The FreeRTOS Demo to run."
+    )
+    demo_app = StringConfigOption(
+        "prog",
+        metavar="PROG",
+        show_help=True,
+        default=default_demo_app,
+        help="The FreeRTOS program to run.",
+    )
+    demo_bsp = StringConfigOption(
+        "bsp",
+        metavar="BSP",
+        show_help=True,
+        default=ComputedDefaultValue(function=lambda _, p: p.default_demo_bsp(), as_string="target-dependent default"),
+        help="The FreeRTOS BSP to run. This is only valid for the "
+        "paramterized RISC-V-Generic. The BSP option chooses "
+        "platform, RISC-V arch and RISC-V abi in the "
+        "$platform-$arch-$abi format. See RISC-V-Generic/README for more details",
+    )
+
     def setup(self):
         super().setup()
         self.kernel_project = BuildFreeRTOS.get_instance(self)
         self.current_kernel = self.kernel_project.install_dir / f"FreeRTOS/Demo/{self.demo}_{self.demo_app}.elf"
-
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(defaultSshPort=None, **kwargs)
-
-        cls.demo: str = cls.add_config_option(
-            "demo", metavar="DEMO", show_help=True, default=cls.default_demo, help="The FreeRTOS Demo to run."
-        )
-
-        cls.demo_app: str = cls.add_config_option(
-            "prog",
-            metavar="PROG",
-            show_help=True,
-            default=cls.default_demo_app,
-            help="The FreeRTOS program to run.",
-        )
-
-        cls.demo_bsp = typing.cast(
-            str,
-            cls.add_config_option(
-                "bsp",
-                metavar="BSP",
-                show_help=True,
-                kind=str,
-                default=ComputedDefaultValue(
-                    function=lambda _, p: p.default_demo_bsp(), as_string="target-dependent default"
-                ),
-                help="The FreeRTOS BSP to run. This is only valid for the "
-                "paramterized RISC-V-Generic. The BSP option chooses "
-                "platform, RISC-V arch and RISC-V abi in the "
-                "$platform-$arch-$abi format. See RISC-V-Generic/README for more details",
-            ),
-        )
 
     def default_demo_bsp(self):
         return (

--- a/pycheribuild/projects/cross/juliet_test_suite.py
+++ b/pycheribuild/projects/cross/juliet_test_suite.py
@@ -36,6 +36,7 @@ from .crosscompileproject import (
     GitRepository,
 )
 from ..project import ReuseOtherProjectRepository
+from ..simple_project import OptionalStringConfigOption
 
 
 class BuildJulietTestSuite(CrossCompileCMakeProject):
@@ -45,10 +46,6 @@ class BuildJulietTestSuite(CrossCompileCMakeProject):
     default_install_dir = DefaultInstallDir.DO_NOT_INSTALL
     _supported_architectures = CompilationTargets.ALL_SUPPORTED_CHERIBSD_AND_HOST_TARGETS
     default_build_type = BuildType.DEBUG
-
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(**kwargs)
 
     def process(self):
         if self.build_type != BuildType.DEBUG:
@@ -76,11 +73,8 @@ class BuildJulietCWESubdir(CrossCompileCMakeProject):
     cwe_warning_flags = []
     cwe_setup_commands = []
 
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(**kwargs)
-        cls.testcase_timeout = cls.add_optional_config_option("testcase-timeout", kind=str)
-        cls.ld_preload_path = cls.add_optional_config_option("ld-preload-path", kind=str)
+    testcase_timeout = OptionalStringConfigOption("testcase-timeout", help="Juliet testcase execution timeout")
+    ld_preload_path = OptionalStringConfigOption("ld-preload-path", help="LD_PRELOAD path for Juliet testcases")
 
     def setup(self):
         super().setup()

--- a/pycheribuild/projects/cross/libcxx.py
+++ b/pycheribuild/projects/cross/libcxx.py
@@ -43,8 +43,15 @@ from .crosscompileproject import (
 from .llvm import BuildCheriLLVM, BuildLLVMMonoRepoBase, BuildUpstreamLLVM, extra_llvm_lit_opts
 from ..build_qemu import BuildQEMU
 from ..cmake_project import CMakeProject
-from ..project import ReuseOtherProjectDefaultTargetRepository
+from ..project import ComputedDefaultValue, ReuseOtherProjectDefaultTargetRepository
 from ..run_qemu import LaunchCheriBSD, LaunchFreeBSD
+from ..simple_project import (
+    BoolConfigOption,
+    IntConfigOption,
+    OptionalIntConfigOption,
+    OptionalPathConfigOption,
+    StringConfigOption,
+)
 from ...colour import AnsiColour, coloured
 from ...config.chericonfig import BuildType
 from ...ssh_utils import generate_ssh_config_file_for_qemu, ssh_host_accessible_uncached
@@ -121,7 +128,7 @@ class BuildLibCXXRT(_CxxRuntimeCMakeProject):
                 )
 
 
-def _default_ssh_port(c, p: CMakeProject):
+def _default_ssh_port(c, p: CMakeProject) -> "typing.Optional[int]":
     xtarget = p.crosscompile_target
     if not xtarget.target_info_cls.is_cheribsd():
         return None
@@ -134,51 +141,51 @@ class BuildLibCXX(_CxxRuntimeCMakeProject):
     _supported_architectures = CompilationTargets.ALL_SUPPORTED_CHERIBSD_AND_BAREMETAL_AND_HOST_TARGETS
     dependencies = ("libcxxrt",)
 
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(**kwargs)
-        cls.only_compile_tests = cls.add_bool_option(
-            "only-compile-tests",
-            help="Don't attempt to run tests, only compile them",
-        )
-        cls.exceptions = cls.add_bool_option("exceptions", default=True, help="Build with support for C++ exceptions")
-        cls.collect_test_binaries = cls.add_optional_path_option(
-            "collect-test-binaries",
-            metavar="TEST_PATH",
-            help="Instead of running tests copy them to $TEST_PATH",
-        )
-        cls.nfs_mounted_path = cls.add_optional_path_option(
-            "nfs-mounted-path",
-            metavar="PATH",
-            help=(
-                "Use a PATH as a directorythat is NFS mounted inside QEMU instead of using scp to copy individual tests"
-            ),
-        )
-        cls.nfs_path_in_qemu = cls.add_optional_path_option(
-            "nfs-mounted-path-in-qemu",
-            metavar="PATH",
-            help="The path used inside QEMU to refer to nfs-mounted-path",
-        )
-        cls.qemu_host = cls.add_config_option(
-            "ssh-host",
-            help="The QEMU SSH hostname to connect to for running tests",
-            default="localhost",
-        )
-        cls.qemu_port = cls.add_config_option(
-            "ssh-port",
-            help="The QEMU SSH port to connect to for running tests",
-            _allow_unknown_targets=True,
-            default=_default_ssh_port,
-            only_add_for_targets=CompilationTargets.ALL_SUPPORTED_CHERIBSD_TARGETS,
-        )
-        cls.qemu_user = cls.add_config_option("ssh-user", default="root", help="The CheriBSD used for running tests")
+    only_compile_tests = BoolConfigOption(
+        "only-compile-tests",
+        help="Don't attempt to run tests, only compile them",
+    )
+    exceptions = BoolConfigOption("exceptions", default=True, help="Build with support for C++ exceptions")
+    collect_test_binaries = OptionalPathConfigOption(
+        "collect-test-binaries",
+        metavar="TEST_PATH",
+        help="Instead of running tests copy them to $TEST_PATH",
+    )
+    nfs_mounted_path = OptionalPathConfigOption(
+        "nfs-mounted-path",
+        metavar="PATH",
+        help="Use a PATH as a directorythat is NFS mounted inside QEMU instead of using scp to copy individual tests",
+    )
+    nfs_path_in_qemu = OptionalPathConfigOption(
+        "nfs-mounted-path-in-qemu",
+        metavar="PATH",
+        help="The path used inside QEMU to refer to nfs-mounted-path",
+    )
+    qemu_host = StringConfigOption(
+        "ssh-host",
+        help="The QEMU SSH hostname to connect to for running tests",
+        default="localhost",
+    )
+    qemu_port = OptionalIntConfigOption(
+        "ssh-port",
+        help="The QEMU SSH port to connect to for running tests",
+        _allow_unknown_targets=True,
+        default=ComputedDefaultValue(
+            function=_default_ssh_port,
+            as_string="SSH forwarding port for CheriBSD target",
+        ),
+        only_add_for_targets=CompilationTargets.ALL_SUPPORTED_CHERIBSD_TARGETS,
+    )
+    qemu_user = StringConfigOption("ssh-user", default="root", help="The CheriBSD used for running tests")
 
-        cls.test_jobs = cls.add_config_option(
-            "parallel-test-jobs",
-            help="Number of QEMU instances spawned to run tests (default: number of build jobs (-j flag) / 2)",
-            default=lambda c, p: max(c.make_jobs / 2, 1),
-            kind=int,
-        )
+    test_jobs = IntConfigOption(
+        "parallel-test-jobs",
+        help="Number of QEMU instances spawned to run tests (default: number of build jobs (-j flag) / 2)",
+        default=ComputedDefaultValue(
+            function=lambda c, p: max(c.make_jobs / 2, 1),
+            as_string="half of make jobs",
+        ),
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -357,8 +364,6 @@ class _BuildLlvmRuntimes(CrossCompileCMakeProject):
     llvm_project: "typing.ClassVar[type[BuildLLVMMonoRepoBase]]"
     # TODO: add compiler-rt
     _enabled_runtimes: "typing.ClassVar[tuple[str, ...]]" = ("libunwind", "libcxxabi", "libcxx")
-    test_against_running_qemu_instance = False
-    test_localhost_via_ssh = False
 
     def get_enabled_runtimes(self) -> "list[str]":
         return list(self._enabled_runtimes)
@@ -590,25 +595,24 @@ class _BuildLlvmRuntimes(CrossCompileCMakeProject):
         flags = {f"{x.upper()}_{k}": v for x in self.get_enabled_runtimes() for k, v in kwargs.items()}
         self.add_cmake_options(**flags)
 
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(**kwargs)
-        if cls.get_crosscompile_target().is_native():
-            cls.test_localhost_via_ssh = cls.add_bool_option(
-                "test-localhost-via-ssh",
-                help="Use the ssh.py executor for localhost (to check that it works correctly)",
-            )
-        if not cls.get_crosscompile_target().is_native():
-            cls.test_against_running_qemu_instance = cls.add_bool_option(
-                "test-against-running-qemu-instance",
-                help="Run tests against a currently running QEMU instance using the ssh.py executor.",
-            )
-        cls.qemu_test_jobs = cls.add_config_option(
-            "parallel-qemu-test-jobs",
-            help="Number of QEMU instances spawned to run tests (default: number of build jobs (-j flag) / 2)",
-            default=lambda c, p: max(c.make_jobs / 2, 1),
-            kind=int,
-        )
+    test_localhost_via_ssh = BoolConfigOption(
+        "test-localhost-via-ssh",
+        extra_condition=lambda cls: cls._xtarget is not None and cls._xtarget.is_native(),
+        help="Use the ssh.py executor for localhost (to check that it works correctly)",
+    )
+    test_against_running_qemu_instance = BoolConfigOption(
+        "test-against-running-qemu-instance",
+        extra_condition=lambda cls: cls._xtarget is not None and cls._xtarget.target_info_cls.is_cheribsd(),
+        help="Run tests against a currently running QEMU instance using the ssh.py executor.",
+    )
+    qemu_test_jobs = IntConfigOption(
+        "parallel-qemu-test-jobs",
+        help="Number of QEMU instances spawned to run tests (default: number of build jobs (-j flag) / 2)",
+        default=ComputedDefaultValue(
+            function=lambda c, p: max(c.make_jobs / 2, 1),
+            as_string="half of make jobs",
+        ),
+    )
 
     def _supported_libcxx_hardening_modes(self) -> "list[str]":
         # We may have a partial history, so prefer scanning the CMakeLists.txt

--- a/pycheribuild/projects/cross/littlekernel.py
+++ b/pycheribuild/projects/cross/littlekernel.py
@@ -237,10 +237,6 @@ class LaunchLittlekernelQEMU(LaunchQEMUBase):
             # FIXME: GICv3 support not included in lk, have to force version 2
             self.qemu_options.machine_flags = ["-M", "virt,gic-version=2", "-cpu", "cortex-a53"]
 
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(defaultSshPort=None, **kwargs)
-
     def get_riscv_bios_args(self) -> "list[str]":
         # Currently we run in machine mode
         lk_instance = BuildLittleKernel.get_instance(self)

--- a/pycheribuild/projects/cross/llvm.py
+++ b/pycheribuild/projects/cross/llvm.py
@@ -35,7 +35,14 @@ from typing import ClassVar, Iterable, Optional
 
 from ..cmake_project import CMakeProject
 from ..project import BuildType, ComputedDefaultValue, DefaultInstallDir, GitRepository
-from ..simple_project import SimpleProject, SimpleProjectBase
+from ..simple_project import (
+    BoolConfigOption,
+    ListConfigOption,
+    OptionalStringConfigOption,
+    SimpleProject,
+    SimpleProjectBase,
+    StringConfigOption,
+)
 from ...config.chericonfig import CheriConfig
 from ...config.compilation_targets import (
     BuildLLVMInterface,
@@ -116,61 +123,50 @@ class BuildLLVMBase(CMakeProject):
     def can_build_with_asan(cls) -> bool:
         return True
 
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(**kwargs)
-        if "included_projects" not in cls.__dict__:
-            cls.included_projects = cls.add_list_option(
-                "include-projects",
-                default=["llvm", "clang", "lld"],
-                help="List of LLVM subprojects that should be built",
-            )
-        cls.add_default_sysroot = False
-        cls.enable_assertions = cls.add_bool_option("assertions", help="build with assertions enabled", default=True)
-        if "skip_static_analyzer" not in cls.__dict__:
-            cls.skip_static_analyzer = cls.add_bool_option(
-                "skip-static-analyzer",
-                default=_true_unless_build_all_set,
-                help="Don't build the clang static analyzer",
-            )
-        if "skip_misc_llvm_tools" not in cls.__dict__:
-            cls.skip_misc_llvm_tools = cls.add_bool_option(
-                "skip-unused-tools",
-                default=_true_unless_build_all_set,
-                help=(
-                    "Don't build some of the LLVM tools that should not be "
-                    "needed by default (e.g. llvm-mca, llvm-pdbutil)"
-                ),
-            )
-        cls.build_everything = cls.add_bool_option(
-            "build-everything",
-            default=False,
-            help="Build everything for the projects that are enabled (e.g. documentation,examples and bindings)",
-        )
-        cls.use_llvm_cxx = cls.add_bool_option(
-            "use-in-tree-cxx-libs",
-            default=False,
-            help="Use in-tree, not host, C++ runtime",
-        )
-        cls.use_modules_build = cls.add_bool_option(
-            "use-llvm-modules-build",
-            default=False,
-            help="Use the LLVM modules build (may be faster in some cases but probably won't allow debugging)",
-        )
-        cls.dylib = cls.add_bool_option("dylib", default=False, help="Build dynamic-link LLVM")
-        cls.install_toolchain_only = cls.add_bool_option(
-            "install-toolchain-only",
-            default=False,
-            help="Install only toolchain binaries (i.e. no test tools)",
-        )
-        cls.build_minimal_toolchain = cls.add_bool_option(
-            "build-minimal-toolchain",
-            default=False,
-            help=(
-                "Only build the binaries required for a minimal toolchain (this is useful to avoid excessive compile "
-                "times with LTO)"
-            ),
-        )
+    included_projects = ListConfigOption(
+        "include-projects",
+        default=["llvm", "clang", "lld"],
+        help="List of LLVM subprojects that should be built",
+    )
+    add_default_sysroot = False
+    enable_assertions = BoolConfigOption("assertions", help="build with assertions enabled", default=True)
+    skip_static_analyzer = BoolConfigOption(
+        "skip-static-analyzer",
+        default=_true_unless_build_all_set,
+        help="Don't build the clang static analyzer",
+    )
+    skip_misc_llvm_tools = BoolConfigOption(
+        "skip-unused-tools",
+        default=_true_unless_build_all_set,
+        help="Don't build some of the LLVM tools that should not be needed by default (e.g. llvm-mca, llvm-pdbutil)",
+    )
+    build_everything = BoolConfigOption(
+        "build-everything",
+        default=False,
+        help="Build everything for the projects that are enabled (e.g. documentation,examples and bindings)",
+    )
+    use_llvm_cxx = BoolConfigOption(
+        "use-in-tree-cxx-libs",
+        default=False,
+        help="Use in-tree, not host, C++ runtime",
+    )
+    use_modules_build = BoolConfigOption(
+        "use-llvm-modules-build",
+        default=False,
+        help="Use the LLVM modules build (may be faster in some cases but probably won't allow debugging)",
+    )
+    dylib = BoolConfigOption("dylib", default=False, help="Build dynamic-link LLVM")
+    install_toolchain_only = BoolConfigOption(
+        "install-toolchain-only",
+        default=False,
+        help="Install only toolchain binaries (i.e. no test tools)",
+    )
+    build_minimal_toolchain = BoolConfigOption(
+        "build-minimal-toolchain",
+        default=False,
+        help="Only build the binaries required for a minimal toolchain "
+        "(this is useful to avoid excessive compile times with LTO)",
+    )
 
     minimal_toolchain_targets = [
         "clang",
@@ -695,18 +691,12 @@ class BuildCheriLLVM(BuildLLVMMonoRepoBase):
     )
     build_all_targets: "ClassVar[bool]"
 
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(**kwargs)
-        cls.build_all_targets = cls.add_bool_option(
-            "build-all-targets",
-            default=_false_unless_build_all_set,
-            help=(
-                "Support code generation for all architectures instead of "
-                "only for CHERI+Host. This is off by "
-                "default to reduce compile time."
-            ),
-        )
+    build_all_targets = BoolConfigOption(
+        "build-all-targets",
+        default=_false_unless_build_all_set,
+        help="Support code generation for all architectures instead of only "
+        "for CHERI+Host. This is off by default to reduce compile time.",
+    )
 
     def setup(self):
         super().setup()
@@ -911,31 +901,48 @@ class BuildCheriOSLLVM(BuildLLVMMonoRepoBase):
 class BuildLLVMSplitRepoBase(BuildLLVMBase):
     do_not_add_to_targets = True
 
-    @classmethod
-    def setup_config_options(cls, include_lld_revision=True, include_lldb_revision=False, **kwargs):
-        super().setup_config_options(**kwargs)
-
-        def add_subproject_options(name):
-            rev: Optional[str] = cls.add_optional_config_option(
-                name + "-git-revision",
-                kind=str,
-                metavar="REVISION",
-                help="The git revision for tools/" + name,
-            )
-            repo: str = cls.add_config_option(
-                name + "-repository",
-                kind=str,
-                metavar="REPOSITORY",
-                default=cls.github_base_url + name + ".git",
-                help="The git repository for tools/" + name,
-            )
-            return repo, rev
-
-        cls.clang_repository, cls.clang_revision = add_subproject_options("clang")
-        if include_lld_revision:  # not built yet
-            cls.lld_repository, cls.lld_revision = add_subproject_options("lld")
-        if include_lldb_revision:  # not built yet
-            cls.lldb_repository, cls.lldb_revision = add_subproject_options("lldb")
+    clang_repository = StringConfigOption(
+        "clang-repository",
+        default=ComputedDefaultValue(
+            function=lambda config, project: project.github_base_url + "clang.git",
+            as_string=lambda cls: cls.github_base_url + "clang.git",
+        ),
+        extra_condition=lambda cls: "clang" in cls.included_projects,
+        help="The git repository for tools/clang",
+    )
+    clang_revision = OptionalStringConfigOption(
+        "clang-git-revision",
+        extra_condition=lambda cls: "clang" in cls.included_projects,
+        help="The git revision for tools/clang",
+    )
+    lld_repository = StringConfigOption(
+        "lld-repository",
+        default=ComputedDefaultValue(
+            function=lambda config, project: project.github_base_url + "lld.git",
+            as_string=lambda cls: cls.github_base_url + "lld.git",
+        ),
+        extra_condition=lambda cls: "lld" in cls.included_projects,
+        help="The git repository for tools/lld",
+    )
+    lld_revision = OptionalStringConfigOption(
+        "lld-git-revision",
+        extra_condition=lambda cls: "lld" in cls.included_projects,
+        help="The git revision for tools/lld",
+    )
+    lldb_repository = StringConfigOption(
+        "lldb-repository",
+        default=ComputedDefaultValue(
+            function=lambda config, project: project.github_base_url + "lldb.git",
+            as_string=lambda cls: cls.github_base_url + "lldb.git",
+        ),
+        extra_condition=lambda cls: "lldb" in cls.included_projects,
+        help="The git repository for tools/lldb",
+    )
+    lldb_revision = OptionalStringConfigOption(
+        "lldb-git-revision",
+        extra_condition=lambda cls: "lldb" in cls.included_projects,
+        help="The git revision for tools/lldb",
+    )
 
     def setup(self):
         super().setup()

--- a/pycheribuild/projects/cross/mrs.py
+++ b/pycheribuild/projects/cross/mrs.py
@@ -29,6 +29,11 @@
 #
 
 from .crosscompileproject import CompilationTargets, CrossCompileCMakeProject, DefaultInstallDir, GitRepository
+from ..simple_project import (
+    BoolConfigOption,
+    OptionalIntConfigOption,
+    OptionalStringConfigOption,
+)
 
 
 class MRS(CrossCompileCMakeProject):
@@ -39,49 +44,37 @@ class MRS(CrossCompileCMakeProject):
 
     # set --mrs/build-type <type> to control build type, default is RelWithDebInfo
 
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(**kwargs)
+    build_target = OptionalStringConfigOption("build-target", help="specify a target to build, or all")
+    debug = BoolConfigOption("debug", help="enable debug output")
+    offload_quarantine = BoolConfigOption(
+        "offload-quarantine", help="process the quarantine in a separate worker thread"
+    )
+    bypass_quarantine = BoolConfigOption("bypass-quarantine", help="MADV_FREE freed page-size allocations")
+    clear_on_alloc = BoolConfigOption("clear-on-alloc", help="zero regions during allocation")
+    clear_on_free = BoolConfigOption("clear-on-free", help="zero regions as they come out of quarantine")
+    print_stats = BoolConfigOption("print-stats", help="print heap statistics on exit")
+    print_caprevoke = BoolConfigOption("print-caprevoke", help="print per-revocation statistics")
+    concurrent_revocation_passes = OptionalIntConfigOption(
+        "concurrent-revocation-passes",
+        help="enable N concurrent revocation passes before the stop-the-world pass",
+    )
+    revoke_on_free = BoolConfigOption(
+        "revoke-on-free", help="perform revocation on free rather than during allocation routines"
+    )
 
-        cls.build_target = cls.add_optional_config_option(
-            "build-target", kind=str, help="specify a target to build, or all"
-        )
+    just_interpose = BoolConfigOption("just-interpose", help="just call the real functions")
+    just_bookkeeping = BoolConfigOption("just-bookkeeping", help="just update data structures")
+    just_quarantine = BoolConfigOption("just-quarantine", help="do bookkeeping and quarantining")
+    just_paint_bitmap = BoolConfigOption("just-paint-bitmap", help="do bookkeeping, quarantining, and bitmap painting")
 
-        cls.debug = cls.add_bool_option("debug", help="enable debug output")
-        cls.offload_quarantine = cls.add_bool_option(
-            "offload-quarantine", help="process the quarantine in a separate worker thread"
-        )
-        cls.bypass_quarantine = cls.add_bool_option("bypass-quarantine", help="MADV_FREE freed page-size allocations")
-        cls.clear_on_alloc = cls.add_bool_option("clear-on-alloc", help="zero regions during allocation")
-        cls.clear_on_free = cls.add_bool_option("clear-on-free", help="zero regions as they come out of quarantine")
-        cls.print_stats = cls.add_bool_option("print-stats", help="print heap statistics on exit")
-        cls.print_caprevoke = cls.add_bool_option("print-caprevoke", help="print per-revocation statistics")
-        cls.concurrent_revocation_passes = cls.add_optional_config_option(
-            "concurrent-revocation-passes",
-            kind=int,
-            help="enable N concurrent revocation passes before the stop-the-world pass",
-        )
-        cls.revoke_on_free = cls.add_bool_option(
-            "revoke-on-free", help="perform revocation on free rather than during allocation routines"
-        )
-
-        cls.just_interpose = cls.add_bool_option("just-interpose", help="just call the real functions")
-        cls.just_bookkeeping = cls.add_bool_option("just-bookkeeping", help="just update data structures")
-        cls.just_quarantine = cls.add_bool_option("just-quarantine", help="do bookkeeping and quarantining")
-        cls.just_paint_bitmap = cls.add_bool_option(
-            "just-paint-bitmap", help="do bookkeeping, quarantining, and bitmap painting"
-        )
-
-        cls.quarantine_ratio = cls.add_optional_config_option(
-            "quarantine-ratio",
-            kind=int,
-            help="limit the quarantine size to 1/QUARANTINE_RATIO times the size of the heap",
-        )
-        cls.quarantine_highwater = cls.add_optional_config_option(
-            "quarantine-highwater",
-            kind=int,
-            help="limit the quarantine size to QUARANTINE_HIGHWATER bytes (supersedes QUARANTINE_RATIO)",
-        )
+    quarantine_ratio = OptionalIntConfigOption(
+        "quarantine-ratio",
+        help="limit the quarantine size to 1/QUARANTINE_RATIO times the size of the heap",
+    )
+    quarantine_highwater = OptionalIntConfigOption(
+        "quarantine-highwater",
+        help="limit the quarantine size to QUARANTINE_HIGHWATER bytes (supersedes QUARANTINE_RATIO)",
+    )
 
     def setup(self):
         super().setup()

--- a/pycheribuild/projects/cross/opensbi.py
+++ b/pycheribuild/projects/cross/opensbi.py
@@ -41,6 +41,7 @@ from ..project import (
     Project,
     ReuseOtherProjectRepository,
 )
+from ..simple_project import OptionalStringConfigOption
 from ...config.chericonfig import RiscvCheriISA
 from ...config.compilation_targets import BaremetalClangTargetInfo, CompilationTargets
 from ...config.target_info import CrossCompileTarget
@@ -76,13 +77,8 @@ class BuildOpenSBI(Project):
     def xlen(self) -> int:
         return 32 if self.crosscompile_target.is_riscv32(include_purecap=True) else 64
 
-    @classmethod
-    def setup_config_options(cls, **kwargs) -> None:
-        super().setup_config_options(**kwargs)
-        cls.fw_jump_addr = cls.add_optional_config_option("fw-jump-addr", kind=str, help="OpenSBI FW_JUMP_ADDR")
-        cls.fw_jump_fdt_addr = cls.add_optional_config_option(
-            "fw-jump-fdt-addr", kind=str, help="OpenSBI FW_JUMP_FDT_ADDR"
-        )
+    fw_jump_addr = OptionalStringConfigOption("fw-jump-addr", help="OpenSBI FW_JUMP_ADDR")
+    fw_jump_fdt_addr = OptionalStringConfigOption("fw-jump-fdt-addr", help="OpenSBI FW_JUMP_FDT_ADDR")
 
     def check_system_dependencies(self) -> None:
         super().check_system_dependencies()

--- a/pycheribuild/projects/cross/qt5.py
+++ b/pycheribuild/projects/cross/qt5.py
@@ -46,7 +46,7 @@ from .crosscompileproject import (
 )
 from .wayland import BuildWayland
 from .x11 import BuildLibXCB
-from ..project import default_source_dir_in_subdir
+from ..project import ComputedDefaultValue, default_source_dir_in_subdir
 from ..simple_project import BoolConfigOption, SimpleProject
 from ...utils import InstallInstructions
 
@@ -237,33 +237,29 @@ class BuildQtWithConfigureScript(CrossCompileProject):
     has_optional_tests = True
     default_build_tests = False
 
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(**kwargs)
-        cls.build_examples = cls.add_bool_option("build-examples", show_help=True, help="build the Qt examples")
-        # Enable assertions by default for now
-        assertions_by_default = True
-        cls.assertions = cls.add_bool_option(
-            "assertions",
-            default=assertions_by_default,
-            show_help=True,
-            help="Include assertions (even in release builds)",
-        )
-        cls.minimal = cls.add_bool_option("minimal", show_help=True, help="Don't build QtWidgets or QtGui, etc")
-        # Link against X11 libs by default if we aren't compiling for macOS
-        native_is_macos = cls._xtarget is not None and cls._xtarget.target_info_cls.is_macos()
-        cls.use_x11 = cls.add_bool_option(
-            "use-x11",
-            default=not native_is_macos,
-            show_help=False,
-            help="Build Qt with the XCB backend.",
-        )
-        cls.use_opengl = cls.add_bool_option(
-            "use-opengl",
-            default=True,
-            show_help=False,
-            help="Build Qt with OpenGL support",
-        )
+    build_examples = BoolConfigOption("build-examples", show_help=True, help="build the Qt examples")
+    assertions = BoolConfigOption(
+        "assertions",
+        default=True,
+        show_help=True,
+        help="Include assertions (even in release builds)",
+    )
+    minimal = BoolConfigOption("minimal", show_help=True, help="Don't build QtWidgets or QtGui, etc")
+    use_x11 = BoolConfigOption(
+        "use-x11",
+        default=ComputedDefaultValue(
+            function=lambda config, proj: not proj.get_crosscompile_target().target_info_cls.is_macos(),
+            as_string="False if compiling for macOS, otherwise True",
+        ),
+        show_help=False,
+        help="Build Qt with the XCB backend.",
+    )
+    use_opengl = BoolConfigOption(
+        "use-opengl",
+        default=True,
+        show_help=False,
+        help="Build Qt with OpenGL support",
+    )
 
     def configure(self, **kwargs):
         if self.force_static_linkage:
@@ -611,14 +607,11 @@ class BuildQt5(BuildQtWithConfigureScript):
     repository = GitRepository("https://github.com/CTSRD-CHERI/qt5", default_branch="5.10", force_branch=True)
     skip_git_submodules = True  # init-repository does it for us
 
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(**kwargs)
-        cls.all_modules = cls.add_bool_option(
-            "all-modules",
-            show_help=True,
-            help="Build all modules (even those that don't make sense for CHERI)",
-        )
+    all_modules = BoolConfigOption(
+        "all-modules",
+        show_help=True,
+        help="Build all modules (even those that don't make sense for CHERI)",
+    )
 
     def configure(self, **kwargs):
         if not self.all_modules:
@@ -1062,6 +1055,12 @@ class BuildQtWebkit(CrossCompileCMakeProject):
     native_install_dir = DefaultInstallDir.CHERI_SDK
     default_source_dir = default_source_dir_in_subdir(Path("qt5"))
 
+    build_jsc_only = BoolConfigOption(
+        "build-jsc-only",
+        show_help=True,
+        help="only build the JavaScript interpreter executable",
+    )
+
     @property
     def llvm_binutils_dir(self) -> Path:
         if self.compiling_for_host():
@@ -1133,15 +1132,6 @@ class BuildQtWebkit(CrossCompileCMakeProject):
                 self.add_cmake_options(CHERI_PURE_CAPABILITY=True)
             if not self.compiling_for_host():
                 self.add_cmake_options(QTWEBKIT_LINK_STATIC_ONLY=self.force_static_linkage)
-
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(**kwargs)
-        cls.build_jsc_only = cls.add_bool_option(
-            "build-jsc-only",
-            show_help=True,
-            help="only build the JavaScript interpreter executable",
-        )
 
     def compile(self, **kwargs):
         # Generate the shared mime info cache to MASSIVELY speed up tests

--- a/pycheribuild/projects/cross/snmalloc.py
+++ b/pycheribuild/projects/cross/snmalloc.py
@@ -29,6 +29,12 @@
 #
 
 from .crosscompileproject import BuildType, CrossCompileCMakeProject, DefaultInstallDir, GitRepository
+from ..project import ComputedDefaultValue
+from ..simple_project import (
+    BoolConfigOption,
+    OptionalIntConfigOption,
+    OptionalStringConfigOption,
+)
 
 
 class SNMalloc(CrossCompileCMakeProject):
@@ -38,49 +44,32 @@ class SNMalloc(CrossCompileCMakeProject):
     cross_install_dir = DefaultInstallDir.ROOTFS_OPTBASE
     default_build_type = BuildType.DEBUG
 
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(**kwargs)
-
-        cls.just_so = cls.add_bool_option("just-so", help="Just build the .so shim")
-        cls.debug = cls.add_bool_option("debug", help="Turn on debugging features")
-        cls.stats = cls.add_bool_option("stats", help="Turn on statistics tracking")
-
-        cls.check_client = cls.add_bool_option("check-client", help="Don't accept malformed input to free")
-
-        cls.pagemap_pointers = cls.add_bool_option(
-            "pagemap-pointers", help="Change pagemap data structure to store pointers"
-        )
-        cls.pagemap_rederive = cls.add_bool_option(
-            "pagemap-rederive", help="Rederive internal pointers using the pagemap"
-        )
-        cls.cheri_align = cls.add_bool_option("cheri-align", help="Align sizes for CHERI bounds setting")
-        cheri_bounds_default = cls._xtarget is not None and cls._xtarget.is_cheri_purecap()
-        cls.cheri_bounds = cls.add_bool_option(
-            "cheri-bounds", default=cheri_bounds_default, help="Set bounds on returned allocations"
-        )
-
-        cls.quarantine = cls.add_bool_option("quarantine", help="Quarantine deallocations")
-
-        cls.qpathresh = cls.add_optional_config_option(
-            "qpathresh", kind=int, help="Quarantine physical memory per allocator threshold"
-        )
-        cls.qpacthresh = cls.add_optional_config_option(
-            "qpacthresh", kind=int, help="Quarantine chunk per allocator threshold"
-        )
-        cls.qcsc = cls.add_optional_config_option("qcsc", kind=int, help="Quarantine chunk size class")
-
-        cls.decommit = cls.add_optional_config_option("decommit", kind=str, help="Specify memory decommit policy")
-
-        cls.zero = cls.add_bool_option("zero", help="Specify memory decommit policy")
-
-        cls.revoke = cls.add_bool_option("revoke", help="Revoke quarantine before reusing")
-        cls.revoke_dry_run = cls.add_bool_option("revoke-dry-run", help="Do everything but caprevoke()")
-        cls.revoke_paranoia = cls.add_bool_option("revoke-paranoia", help="Double-check the revoker")
-        cls.revoke_tput = cls.add_bool_option("revoke-throughput", help="Optimize for throughput")
-
-        # XXX misnamed now, but so be it
-        cls.revoke_verbose = cls.add_bool_option("revoke-verbose", help="Report revocation statistics")
+    just_so = BoolConfigOption("just-so", help="Just build the .so shim")
+    debug = BoolConfigOption("debug", help="Turn on debugging features")
+    stats = BoolConfigOption("stats", help="Turn on statistics tracking")
+    check_client = BoolConfigOption("check-client", help="Don't accept malformed input to free")
+    pagemap_pointers = BoolConfigOption("pagemap-pointers", help="Change pagemap data structure to store pointers")
+    pagemap_rederive = BoolConfigOption("pagemap-rederive", help="Rederive internal pointers using the pagemap")
+    cheri_align = BoolConfigOption("cheri-align", help="Align sizes for CHERI bounds setting")
+    cheri_bounds = BoolConfigOption(
+        "cheri-bounds",
+        default=ComputedDefaultValue(
+            function=lambda config, proj: proj.crosscompile_target.is_cheri_purecap(),
+            as_string="True if compiling for CHERI purecap, otherwise False",
+        ),
+        help="Set bounds on returned allocations",
+    )
+    quarantine = BoolConfigOption("quarantine", help="Quarantine deallocations")
+    qpathresh = OptionalIntConfigOption("qpathresh", help="Quarantine physical memory per allocator threshold")
+    qpacthresh = OptionalIntConfigOption("qpacthresh", help="Quarantine chunk per allocator threshold")
+    qcsc = OptionalIntConfigOption("qcsc", help="Quarantine chunk size class")
+    decommit = OptionalStringConfigOption("decommit", help="Specify memory decommit policy")
+    zero = BoolConfigOption("zero", help="Specify memory decommit policy")
+    revoke = BoolConfigOption("revoke", help="Revoke quarantine before reusing")
+    revoke_dry_run = BoolConfigOption("revoke-dry-run", help="Do everything but caprevoke()")
+    revoke_paranoia = BoolConfigOption("revoke-paranoia", help="Double-check the revoker")
+    revoke_tput = BoolConfigOption("revoke-throughput", help="Optimize for throughput")
+    revoke_verbose = BoolConfigOption("revoke-verbose", help="Report revocation statistics")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/pycheribuild/projects/cross/u_boot.py
+++ b/pycheribuild/projects/cross/u_boot.py
@@ -42,6 +42,7 @@ from ..project import (
     MakeCommandKind,
     Project,
 )
+from ..simple_project import BoolConfigOption
 from ...config.chericonfig import RiscvCheriISA
 from ...config.compilation_targets import CompilationTargets
 from ...config.target_info import CPUArchitecture
@@ -176,10 +177,7 @@ class BuildCheriAllianceUBoot(BuildUBoot):
     )
     supported_riscv_cheri_standard = RiscvCheriISA.EXPERIMENTAL_STD093
 
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(**kwargs)
-        cls.secure_boot = cls.add_bool_option("secure-boot", default=False, help="Enable secure boot image")
+    secure_boot = BoolConfigOption("secure-boot", default=False, help="Enable secure boot image")
 
     @property
     def platform(self) -> str:

--- a/pycheribuild/projects/cross/webkit.py
+++ b/pycheribuild/projects/cross/webkit.py
@@ -34,7 +34,7 @@ from typing import Optional
 
 from .cheribsd import BuildFreeBSD
 from .crosscompileproject import CrossCompileCMakeProject, DefaultInstallDir, GitRepository
-from ..simple_project import BoolConfigOption
+from ..simple_project import BoolConfigOption, EnumConfigOption
 
 
 class JsBackend(Enum):
@@ -65,18 +65,14 @@ class BuildMorelloWebkit(CrossCompileCMakeProject):
         help="Use offsets into the JS heap for object references instead of capabilities. "
         "This option only affects the purecap backends.",
     )
-
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(**kwargs)
-        cls.backend = cls.add_config_option(
-            "backend",
-            kind=JsBackend,
-            default=JsBackend.CLOOP,
-            enum_choice_strings=[t.value for t in JsBackend],
-            show_help=True,
-            help="The JavaScript backend to use for building WebKit",
-        )
+    backend = EnumConfigOption(
+        "backend",
+        kind=JsBackend,
+        default=JsBackend.CLOOP,
+        enum_choice_strings=[t.value for t in JsBackend],
+        show_help=True,
+        help="The JavaScript backend to use for building WebKit",
+    )
 
     @property
     def build_dir_suffix(self):

--- a/pycheribuild/projects/fvp_firmware.py
+++ b/pycheribuild/projects/fvp_firmware.py
@@ -41,7 +41,7 @@ from .project import (
     Project,
     ReuseOtherProjectDefaultTargetRepository,
 )
-from .simple_project import SimpleProject
+from .simple_project import OptionalStringConfigOption, SimpleProject
 from ..config.chericonfig import BuildType, CheriConfig
 from ..config.compilation_targets import CompilationTargets
 from ..utils import OSInfo
@@ -276,12 +276,9 @@ class BuildMorelloUEFI(MorelloFirmwareBase):
     default_directory_basename = "morello-edk2"
     _extra_git_clean_excludes = ["--exclude=edk2-platforms"]  # Don't delete edk2-platforms, we do it manually
 
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(**kwargs)
-        cls.edk2_platforms_rev = cls.add_optional_config_option(
-            "edk2-platforms-git-revision", kind=str, metavar="REVISION", help="The git revision for edk2-platforms"
-        )
+    edk2_platforms_rev = OptionalStringConfigOption(
+        "edk2-platforms-git-revision", help="The git revision for edk2-platforms"
+    )
 
     def update(self):
         super().update()

--- a/pycheribuild/projects/project.py
+++ b/pycheribuild/projects/project.py
@@ -54,7 +54,7 @@ from .repository import (
     SubversionRepository,
     TargetBranchInfo,
 )
-from .simple_project import PathConfigOption, SimpleProject, _default_stdout_filter
+from .simple_project import ListConfigOption, PathConfigOption, SimpleProject, _default_stdout_filter
 from ..config.chericonfig import (
     BuildType,
     CheriConfig,
@@ -2023,12 +2023,9 @@ class AutotoolsProject(Project):
     make_kind: MakeCommandKind = MakeCommandKind.GnuMake
     add_host_target_build_config_options: bool = True
 
-    @classmethod
-    def setup_config_options(cls, **kwargs) -> None:
-        super().setup_config_options(**kwargs)
-        cls.extra_configure_flags = cls.add_list_option(
-            "configure-options", metavar="OPTIONS", help="Additional command line options to pass to configure"
-        )
+    extra_configure_flags = ListConfigOption(
+        "configure-options", metavar="OPTIONS", help="Additional command line options to pass to configure"
+    )
 
     """
     Like Project but automatically sets up the defaults for autotools like projects

--- a/pycheribuild/projects/project.py
+++ b/pycheribuild/projects/project.py
@@ -54,7 +54,16 @@ from .repository import (
     SubversionRepository,
     TargetBranchInfo,
 )
-from .simple_project import ListConfigOption, PathConfigOption, SimpleProject, _default_stdout_filter
+from .simple_project import (
+    BoolConfigOption,
+    EnumConfigOption,
+    ListConfigOption,
+    OptionalStringConfigOption,
+    PathConfigOption,
+    SimpleProject,
+    StringConfigOption,
+    _default_stdout_filter,
+)
 from ..config.chericonfig import (
     BuildType,
     CheriConfig,
@@ -654,132 +663,137 @@ class Project(SimpleProject):
     use_lto: bool
 
     @classmethod
-    def setup_config_options(cls, install_directory_help="", **kwargs) -> None:
-        super().setup_config_options(**kwargs)
-        # --<target>-<suffix>/build-directory is not inherited from the unsuffixed target (unless there is only one
-        # supported target).
-        default_xtarget = cls.default_architecture()
-        if cls._xtarget is not None or default_xtarget is not None:
-            cls._initial_build_dir = cls.add_path_option(
-                "build-directory",
-                metavar="DIR",
-                default=cls.default_build_dir,
-                help="Override default source directory for " + cls.target,
-                use_default_fallback_config_names=cls._xtarget == default_xtarget,
-            )
-        if cls.can_build_with_asan():
-            asan_default = ComputedDefaultValue(
-                function=lambda config, proj: (
-                    False if proj.crosscompile_target.is_cheri_purecap() else proj.default_use_asan
-                ),
-                as_string=str(cls.default_use_asan),
-            )
-            cls.use_asan = cls.add_bool_option(
-                "use-asan", default=asan_default, help="Build with AddressSanitizer enabled"
-            )
-        else:
-            cls.use_asan = False
-        if cls.can_build_with_msan():
-            cls.use_msan = cls.add_bool_option("use-msan", default=False, help="Build with MemorySanitizer enabled")
-        else:
-            cls.use_msan = False
+    def default_install_dir_help(cls) -> str:
+        return "Override default install directory for " + cls.target
 
-        if cls.can_build_with_ccache():
-            cls.use_ccache = cls.add_bool_option("use-ccache", default=False, help="Build with CCache")
-        else:
-            cls.use_ccache = False
-        cls.auto_var_init = cls.add_config_option(
-            "auto-var-init",
-            kind=AutoVarInit,
-            default=ComputedDefaultValue(
-                lambda config, proj: proj.default_auto_var_init,
-                lambda c: (
-                    'the value of the global --skip-update option (defaults to "' + c.default_auto_var_init.value + '")'
-                ),
+    _initial_build_dir = PathConfigOption(
+        "build-directory",
+        metavar="DIR",
+        default=ComputedDefaultValue(
+            function=lambda config, project: project.default_build_dir,
+            as_string=lambda cls: "Override default build directory for " + cls.target,
+        ),
+        extra_condition=lambda cls: cls._xtarget is not None or cls.default_architecture() is not None,
+        use_default_fallback_config_names=lambda cls: cls._xtarget == cls.default_architecture(),
+        help="Override default source directory for",
+    )
+    use_asan = BoolConfigOption(
+        "use-asan",
+        default=ComputedDefaultValue(
+            function=lambda config, proj: (
+                False if proj.crosscompile_target.is_cheri_purecap() else proj.default_use_asan
             ),
-            help="Whether to initialize all local variables (currently only supported when compiling with clang)",
-        )
-        cls.skip_update = cls.add_bool_option(
-            "skip-update",
-            default=ComputedDefaultValue(
-                lambda config, proj: config.skip_update, "the value of the global --skip-update option"
+            as_string=lambda cls: str(cls.default_use_asan),
+        ),
+        extra_condition=lambda cls: cls.can_build_with_asan(),
+        help="Build with AddressSanitizer enabled",
+    )
+    use_msan = BoolConfigOption(
+        "use-msan",
+        default=False,
+        extra_condition=lambda cls: cls.can_build_with_msan(),
+        help="Build with MemorySanitizer enabled",
+    )
+    use_ccache = BoolConfigOption(
+        "use-ccache",
+        default=False,
+        extra_condition=lambda cls: cls.can_build_with_ccache(),
+        help="Build with CCache",
+    )
+    auto_var_init = EnumConfigOption(
+        "auto-var-init",
+        default=ComputedDefaultValue(
+            function=lambda config, proj: proj.default_auto_var_init,
+            as_string=lambda c: (
+                'the value of the global --skip-update option (defaults to "' + c.default_auto_var_init.value + '")'
             ),
-            help="Override --skip-update/--no-skip-update for this target only ",
-        )
-        cls.force_configure = cls.add_bool_option(
-            "reconfigure",
-            altname="force-configure",
-            default=ComputedDefaultValue(
-                lambda config, proj: config.force_configure,
-                "the value of the global --reconfigure/--force-configure option",
-            ),
-            help="Override --(no-)reconfigure/--(no-)force-configure for this target only",
-        )
-
-        if not install_directory_help:
-            install_directory_help = "Override default install directory for " + cls.target
-        cls._install_dir = cls.add_path_option(
-            "install-directory", metavar="DIR", help=install_directory_help, default=cls._default_install_dir_fn
-        )
-        if (
-            "repository" in dir(cls)
-            and isinstance(cls.repository, GitRepository)
-            and "git_revision" not in cls.__dict__
-        ):
-            cls.git_revision = cls.add_optional_config_option(
-                "git-revision",
-                kind=str,
-                metavar="REVISION",
-                help="The git revision to checkout prior to building. Useful if "
-                "HEAD is broken for one project but you still want to update the other projects.",
-            )
-            # TODO: can argparse action be used to store to the class member directly?
-            # seems like I can create a new action a pass a reference to the repository:
-            # class FooAction(argparse.Action):
-            # def __init__(self, option_strings, dest, nargs=None, **kwargs):
-            #     if nargs is not None:
-            #         raise ValueError("nargs not allowed")
-            #     super(FooAction, self).__init__(option_strings, dest, **kwargs)
-            # def __call__(self, parser, namespace, values, option_string=None):
-            #     print('%r %r %r' % (namespace, values, option_string))
-            #     setattr(namespace, self.dest, values)
-            cls._repository_url: str = cls.add_config_option(
-                "repository",
-                kind=str,
-                help="The URL of the git repository",
-                default=cls.repository.url,
-                metavar="REPOSITORY",
-            )
-        cls.use_lto = cls.add_bool_option(
-            "use-lto", help="Build with link-time optimization (LTO)", default=cls.lto_by_default
-        )
-        if cls.can_build_with_cfi():
-            cls.use_cfi = cls.add_bool_option("use-cfi", help="Build with LLVM CFI (requires LTO)", default=False)
-        else:
-            cls.use_cfi = False
-        cls._linkage = cls.add_config_option(
-            "linkage",
-            default=Linkage.DEFAULT,
-            kind=Linkage,
-            help="Build static or dynamic (or use the project default)",
-        )
-
-        cls.build_type = cls.add_config_option(
-            "build-type",
-            default=cls.default_build_type,
-            kind=BuildType,
-            enum_choice_strings=supported_build_type_strings,
-            help="Optimization+debuginfo defaults (supports the same values as CMake (as well as 'DEFAULT' which"
-            " does not pass any additional flags to the configure command).",
-        )
-
-        if cls.has_optional_tests and "build_tests" not in cls.__dict__:
-            cls.build_tests = cls.add_bool_option(
-                "build-tests",
-                help="Build the tests",
-                default=cls.default_build_tests,
-                show_help=cls.show_optional_tests_in_help,
-            )
+        ),
+        kind=AutoVarInit,
+        help="Whether to initialize all local variables (currently only supported when compiling with clang)",
+    )
+    skip_update = BoolConfigOption(
+        "skip-update",
+        default=ComputedDefaultValue(
+            lambda config, proj: config.skip_update, "the value of the global --skip-update option"
+        ),
+        help="Override --skip-update/--no-skip-update for this target only ",
+    )
+    force_configure = BoolConfigOption(
+        "reconfigure",
+        altname="force-configure",
+        default=ComputedDefaultValue(
+            lambda config, proj: config.force_configure,
+            "the value of the global --reconfigure/--force-configure option",
+        ),
+        help="Override --(no-)reconfigure/--(no-)force-configure for this target only",
+    )
+    _install_dir = PathConfigOption(
+        "install-directory",
+        metavar="DIR",
+        default=ComputedDefaultValue(
+            function=lambda config, project: project._default_install_dir_fn,
+            as_string=lambda cls: cls.default_install_dir_help(),
+        ),
+        help=lambda cls: cls.default_install_dir_help(),
+    )
+    git_revision = OptionalStringConfigOption(
+        "git-revision",
+        metavar="REVISION",
+        extra_condition=lambda cls: "repository" in dir(cls) and isinstance(cls.repository, GitRepository),
+        help="The git revision to checkout prior to building. Useful if "
+        "HEAD is broken for one project but you still want to update the other projects.",
+    )
+    _repository_url = StringConfigOption(
+        "repository",
+        default=ComputedDefaultValue(
+            function=lambda config, project: project.repository.url,
+            as_string=lambda cls: cls.repository.url,
+        ),
+        extra_condition=lambda cls: "repository" in dir(cls) and isinstance(cls.repository, GitRepository),
+        metavar="REPOSITORY",
+        help="The URL of the git repository",
+    )
+    use_lto = BoolConfigOption(
+        "use-lto",
+        default=ComputedDefaultValue(
+            function=lambda config, project: project.lto_by_default,
+            as_string=lambda cls: str(cls.lto_by_default),
+        ),
+        help="Build with link-time optimization (LTO)",
+    )
+    use_cfi = BoolConfigOption(
+        "use-cfi",
+        default=False,
+        extra_condition=lambda cls: cls.can_build_with_cfi(),
+        help="Build with LLVM CFI (requires LTO)",
+    )
+    _linkage = EnumConfigOption(
+        "linkage",
+        default=Linkage.DEFAULT,
+        kind=Linkage,
+        help="Build static or dynamic (or use the project default)",
+    )
+    build_type = EnumConfigOption(
+        "build-type",
+        default=ComputedDefaultValue(
+            function=lambda config, project: project.default_build_type,
+            as_string=lambda cls: cls.default_build_type.value,
+        ),
+        kind=BuildType,
+        enum_choice_strings=supported_build_type_strings,
+        help="Optimization+debuginfo defaults (supports the same values as CMake (as well as 'DEFAULT' which"
+        " does not pass any additional flags to the configure command).",
+    )
+    build_tests = BoolConfigOption(
+        "build-tests",
+        default=ComputedDefaultValue(
+            function=lambda config, project: project.default_build_tests,
+            as_string=lambda cls: str(cls.default_build_tests),
+        ),
+        extra_condition=lambda cls: cls.has_optional_tests,
+        show_help=lambda cls: cls.show_optional_tests_in_help,
+        help="Build the tests",
+    )
 
     def linkage(self) -> Linkage:
         if self.target_info.must_link_statically:
@@ -837,6 +851,7 @@ class Project(SimpleProject):
             return ["-O2"]
         elif cbt in (BuildType.MINSIZEREL, BuildType.MINSIZERELWITHDEBINFO):
             return ["-Os"]
+        return []
 
     @property
     def compiler_warning_flags(self) -> "list[str]":

--- a/pycheribuild/projects/run_fvp.py
+++ b/pycheribuild/projects/run_fvp.py
@@ -39,7 +39,15 @@ from typing import Optional
 
 from .disk_image import BuildCheriBSDDiskImage, BuildDiskImageBase, BuildFreeBSDImage
 from .fvp_firmware import BuildMorelloFlashImages, BuildMorelloScpFirmware, BuildMorelloUEFI
-from .simple_project import BoolConfigOption, IntConfigOption, OptionalPathConfigOption, SimpleProject
+from .simple_project import (
+    BoolConfigOption,
+    IntConfigOption,
+    ListConfigOption,
+    OptionalPathConfigOption,
+    OptionalStringConfigOption,
+    PathConfigOption,
+    SimpleProject,
+)
 from ..config.chericonfig import CheriConfig, ComputedDefaultValue
 from ..config.compilation_targets import CompilationTargets
 from ..config.target_info import CrossCompileTarget
@@ -534,37 +542,30 @@ class LaunchFVPBase(SimpleProject):
     fvp_trace_mmu = BoolConfigOption("trace-mmu", default=False, help="Emit FVP MMU trace events")
     smp = BoolConfigOption("smp", help="Simulate multiple CPU cores in the FVP", default=True)
 
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(**kwargs)
-
-        fw_default = ComputedDefaultValue(
+    firmware_path = PathConfigOption(
+        "firmware-path",
+        default=ComputedDefaultValue(
             function=lambda c, _: c.morello_sdk_dir / "firmware/morello-fvp",
             as_string="<MORELLO_SDK>/firmware/morello-fvp",
-        )
-        cls.firmware_path = cls.add_path_option(
-            "firmware-path", default=fw_default, help="Path to the UEFI firmware binaries"
-        )
-        cls.remote_disk_image_path = cls.add_optional_config_option(
-            "remote-disk-image-path",
-            help="When set rsync will be used to update the image from the remote server prior to running it.",
-        )
-        cls.extra_tcp_forwarding = cls.add_list_option(
-            "extra-tcp-forwarding",
-            help="Additional TCP bridge ports beyond ssh/22; list of [hostip:]port=[guestip:]port",
-        )
-        cls.license_server = cls.add_optional_config_option(
-            "license-server", help="License server to use for the model"
-        )
-        cls.arch_model_path = cls.add_path_option(
-            "simulator-path", help="Path to the FVP Model", default=Path("/usr/local/FVP_Base_RevC-Rainier")
-        )
-        cls.fvp_trace = cls.add_optional_path_option(
-            "trace", help="Enable FVP tracing plugin to output to the given file"
-        )
-        cls.fvp_trace_icount = cls.add_optional_config_option(
-            "trace-start-icount", help="Instruction count from which to start Tarmac trace"
-        )
+        ),
+        help="Path to the UEFI firmware binaries",
+    )
+    remote_disk_image_path = OptionalStringConfigOption(
+        "remote-disk-image-path",
+        help="When set rsync will be used to update the image from the remote server prior to running it.",
+    )
+    extra_tcp_forwarding = ListConfigOption(
+        "extra-tcp-forwarding",
+        help="Additional TCP bridge ports beyond ssh/22; list of [hostip:]port=[guestip:]port",
+    )
+    license_server = OptionalStringConfigOption("license-server", help="License server to use for the model")
+    arch_model_path = PathConfigOption(
+        "simulator-path", help="Path to the FVP Model", default=Path("/usr/local/FVP_Base_RevC-Rainier")
+    )
+    fvp_trace = OptionalPathConfigOption("trace", help="Enable FVP tracing plugin to output to the given file")
+    fvp_trace_icount = OptionalStringConfigOption(
+        "trace-start-icount", help="Instruction count from which to start Tarmac trace"
+    )
 
     @property
     def use_virtio_net(self):

--- a/pycheribuild/projects/run_qemu.py
+++ b/pycheribuild/projects/run_qemu.py
@@ -962,8 +962,11 @@ class LaunchMinimalCheriBSD(LaunchCheriBSD):
 
     @classmethod
     def setup_config_options(cls, **kwargs):
-        add_to_port = cls.get_cross_target_index()
-        super().setup_config_options(default_ssh_port=get_default_ssh_forwarding_port(20 + add_to_port), **kwargs)
+        if "default_ssh_port" in kwargs:
+            super().setup_config_options(**kwargs)
+        else:
+            add_to_port = cls.get_cross_target_index()
+            super().setup_config_options(default_ssh_port=get_default_ssh_forwarding_port(30 + add_to_port), **kwargs)
 
     @property
     def _extra_test_args(self) -> "list[str]":
@@ -975,6 +978,14 @@ class LaunchCheriBsdMfsRoot(LaunchMinimalCheriBSD):
     _freebsd_class = BuildCheriBsdMfsKernel
     _disk_image_class = None
     _uses_disk_image = False
+
+    @classmethod
+    def setup_config_options(cls, **kwargs):
+        if "default_ssh_port" in kwargs:
+            super().setup_config_options(**kwargs)
+        else:
+            add_to_port = cls.get_cross_target_index()
+            super().setup_config_options(default_ssh_port=get_default_ssh_forwarding_port(40 + add_to_port), **kwargs)
 
     # XXX: Existing code isn't ready to run these but we want to support building them
     @classmethod

--- a/pycheribuild/projects/run_qemu.py
+++ b/pycheribuild/projects/run_qemu.py
@@ -990,10 +990,8 @@ class LaunchCheriBsdMfsRoot(LaunchMinimalCheriBSD):
     # XXX: Existing code isn't ready to run these but we want to support building them
     @classmethod
     def supported_architectures(cls) -> "tuple[CrossCompileTarget, ...]":
-        return tuple(
-            set(super().supported_architectures())
-            - {CompilationTargets.CHERIBSD_AARCH64, *CompilationTargets.ALL_CHERIBSD_MORELLO_TARGETS}
-        )
+        exclude = {CompilationTargets.CHERIBSD_AARCH64, *CompilationTargets.ALL_CHERIBSD_MORELLO_TARGETS}
+        return tuple(x for x in super().supported_architectures() if x not in exclude)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/pycheribuild/projects/simple_project.py
+++ b/pycheribuild/projects/simple_project.py
@@ -1235,8 +1235,15 @@ class SimpleProjectBase(AbstractProject, ABC):
             # If the option has been overwritten to be a constant in a subclass we should not register it - check the
             # type of the ClassVar to determine if this is actually needed.
             option = inspect.getattr_static(cls, k)
-            if isinstance(option, PerProjectConfigOption):
-                if option.extra_condition is not None and not option.extra_condition(cls):
+            # Register the option if it's a raw descriptor or a ConfigOptionHandle inherited from a concrete
+            # parent target class that hasn't been registered specifically on this subclass yet (i.e. not in
+            # cls.__dict__). For example, BuildCheriAllianceQEMU (cheri-std093-qemu) inherits the 'targets' option
+            # as a ConfigOptionHandle from its concrete parent BuildQEMU (qemu), and we must register it
+            # specifically on cheri-std093-qemu so it resolves to the custom default_targets list.
+            if isinstance(option, PerProjectConfigOption) or (
+                isinstance(option, ConfigOptionHandle) and k not in cls.__dict__
+            ):
+                if v.extra_condition is not None and not v.extra_condition(cls):
                     # If the option's extra condition is not met, replace the descriptor with
                     # DefaultValueOnlyDescriptor to dynamically evaluate the default value without
                     # registering it in the loader.

--- a/pycheribuild/projects/simple_project.py
+++ b/pycheribuild/projects/simple_project.py
@@ -131,7 +131,9 @@ class DefaultValueOnlyDescriptor:
 
 
 class PerProjectConfigOption(typing.Generic[T]):
-    def __init__(self, name: str, help: str, default: "typing.Any", **kwargs) -> None:
+    def __init__(
+        self, name: str, *, help: "typing.Union[str, typing.Callable[[type], str]]", default: "typing.Any", **kwargs
+    ) -> None:
         self._name = name
         self._default = default
         self._help = help
@@ -160,7 +162,6 @@ if typing.TYPE_CHECKING:
     # noinspection PyPep8Naming
     def BoolConfigOption(  # noqa: N802
         name: str,
-        help: str,
         default: "typing.Union[bool, ComputedDefaultValue[bool]]" = False,
         **kwargs,
     ) -> bool:
@@ -169,7 +170,6 @@ if typing.TYPE_CHECKING:
     # noinspection PyPep8Naming
     def EnumConfigOption(  # noqa: N802
         name: str,
-        help: str,
         default: "typing.Union[EnumTy, ComputedDefaultValue[EnumTy]]",
         *,
         kind: "type[EnumTy]",
@@ -180,7 +180,6 @@ if typing.TYPE_CHECKING:
     # noinspection PyPep8Naming
     def OptionalEnumConfigOption(  # noqa: N802
         name: str,
-        help: str,
         default: "typing.Union[Optional[EnumTy], ComputedDefaultValue[Optional[EnumTy]]]" = None,
         *,
         kind: "type[EnumTy]",
@@ -191,7 +190,6 @@ if typing.TYPE_CHECKING:
     # noinspection PyPep8Naming
     def IntConfigOption(  # noqa: N802
         name: str,
-        help: str,
         default: "typing.Union[int, ComputedDefaultValue[int]]",
         **kwargs,
     ) -> int:
@@ -200,7 +198,6 @@ if typing.TYPE_CHECKING:
     # noinspection PyPep8Naming
     def OptionalIntConfigOption(  # noqa: N802
         name: str,
-        help: str,
         default: "typing.Union[Optional[int], ComputedDefaultValue[Optional[int]]]" = None,
         **kwargs,
     ) -> "Optional[int]":
@@ -209,7 +206,6 @@ if typing.TYPE_CHECKING:
     # noinspection PyPep8Naming
     def FloatConfigOption(  # noqa: N802
         name: str,
-        help: str,
         default: "typing.Union[float, ComputedDefaultValue[float]]",
         **kwargs,
     ) -> float:
@@ -218,7 +214,6 @@ if typing.TYPE_CHECKING:
     # noinspection PyPep8Naming
     def OptionalFloatConfigOption(  # noqa: N802
         name: str,
-        help: str,
         default: "typing.Union[Optional[float], ComputedDefaultValue[Optional[float]]]" = None,
         **kwargs,
     ) -> "Optional[float]":
@@ -227,7 +222,6 @@ if typing.TYPE_CHECKING:
     # noinspection PyPep8Naming
     def PathConfigOption(  # noqa: N802
         name: str,
-        help: str,
         default: "typing.Union[Path, ComputedDefaultValue[Path]]",
         **kwargs,
     ) -> "Path":
@@ -236,7 +230,6 @@ if typing.TYPE_CHECKING:
     # noinspection PyPep8Naming
     def OptionalPathConfigOption(  # noqa: N802
         name: str,
-        help: str,
         default: "typing.Union[Optional[Path], ComputedDefaultValue[Optional[Path]]]" = None,
         **kwargs,
     ) -> "Optional[Path]":
@@ -245,7 +238,6 @@ if typing.TYPE_CHECKING:
     # noinspection PyPep8Naming
     def StringConfigOption(  # noqa: N802
         name: str,
-        help: str,
         default: "typing.Union[str, ComputedDefaultValue[str]]",
         **kwargs,
     ) -> str:
@@ -254,7 +246,6 @@ if typing.TYPE_CHECKING:
     # noinspection PyPep8Naming
     def OptionalStringConfigOption(  # noqa: N802
         name: str,
-        help: str,
         default: "typing.Union[str, ComputedDefaultValue[Optional[str]], None]" = None,
         **kwargs,
     ) -> Optional[str]:
@@ -263,7 +254,6 @@ if typing.TYPE_CHECKING:
     # noinspection PyPep8Naming
     def ListConfigOption(  # noqa: N802
         name: str,
-        help: str,
         default: "typing.Union[Optional[list[T]], ComputedDefaultValue[list[T]]]" = None,
         **kwargs,
     ) -> "list[T]":
@@ -271,10 +261,8 @@ if typing.TYPE_CHECKING:
 else:
 
     class BoolConfigOption(PerProjectConfigOption[bool]):
-        def __init__(
-            self, name: str, help: str, default: "typing.Union[bool, ComputedDefaultValue[bool]]" = False, **kwargs
-        ):
-            super().__init__(name, help, default, **kwargs)
+        def __init__(self, name: str, default: "typing.Union[bool, ComputedDefaultValue[bool]]" = False, **kwargs):
+            super().__init__(name, default=default, **kwargs)
 
         def register_config_option(self, owner: "type[SimpleProjectBase]", **kwargs) -> ConfigOptionHandle:
             return typing.cast(
@@ -286,13 +274,12 @@ else:
         def __init__(
             self,
             name: str,
-            help: str,
             default: "typing.Union[EnumTy, ComputedDefaultValue[EnumTy]]",
             *,
             kind: "type[EnumTy]",
             **kwargs,
         ):
-            super().__init__(name, help, default, kind=kind, **kwargs)
+            super().__init__(name, default=default, kind=kind, **kwargs)
 
         def register_config_option(self, owner: "type[SimpleProjectBase]", **kwargs) -> ConfigOptionHandle:
             kind = self._kwargs["kind"]
@@ -308,13 +295,12 @@ else:
         def __init__(
             self,
             name: str,
-            help: str,
             default: "typing.Union[Optional[EnumTy], ComputedDefaultValue[Optional[EnumTy]]]" = None,
             *,
             kind: "type[EnumTy]",
             **kwargs,
         ):
-            super().__init__(name, help, default, kind=kind, **kwargs)
+            super().__init__(name, default=default, kind=kind, **kwargs)
 
         def register_config_option(self, owner: "type[SimpleProjectBase]", **kwargs) -> ConfigOptionHandle:
             kind = self._kwargs["kind"]
@@ -327,8 +313,8 @@ else:
             )
 
     class IntConfigOption(PerProjectConfigOption[int]):
-        def __init__(self, name: str, help: str, default: "typing.Union[int, ComputedDefaultValue[int]]", **kwargs):
-            super().__init__(name, help, default, **kwargs)
+        def __init__(self, name: str, default: "typing.Union[int, ComputedDefaultValue[int]]", **kwargs):
+            super().__init__(name, default=default, **kwargs)
 
         def register_config_option(self, owner: "type[SimpleProjectBase]", **kwargs) -> ConfigOptionHandle:
             return typing.cast(
@@ -342,11 +328,10 @@ else:
         def __init__(
             self,
             name: str,
-            help: str,
             default: "typing.Union[Optional[int], ComputedDefaultValue[Optional[int]]]" = None,
             **kwargs,
         ):
-            super().__init__(name, help, default, **kwargs)
+            super().__init__(name, default=default, **kwargs)
 
         def register_config_option(self, owner: "type[SimpleProjectBase]", **kwargs) -> ConfigOptionHandle:
             return typing.cast(
@@ -357,8 +342,8 @@ else:
             )
 
     class FloatConfigOption(PerProjectConfigOption[float]):
-        def __init__(self, name: str, help: str, default: "typing.Union[float, ComputedDefaultValue[float]]", **kwargs):
-            super().__init__(name, help, default, **kwargs)
+        def __init__(self, name: str, default: "typing.Union[float, ComputedDefaultValue[float]]", **kwargs):
+            super().__init__(name, default=default, **kwargs)
 
         def register_config_option(self, owner: "type[SimpleProjectBase]", **kwargs) -> ConfigOptionHandle:
             return typing.cast(
@@ -372,11 +357,10 @@ else:
         def __init__(
             self,
             name: str,
-            help: str,
             default: "typing.Union[Optional[float], ComputedDefaultValue[Optional[float]]]" = None,
             **kwargs,
         ):
-            super().__init__(name, help, default, **kwargs)
+            super().__init__(name, default=default, **kwargs)
 
         def register_config_option(self, owner: "type[SimpleProjectBase]", **kwargs) -> ConfigOptionHandle:
             return typing.cast(
@@ -390,17 +374,17 @@ else:
         def __init__(
             self,
             name: str,
-            help: str,
             default: "typing.Union[Path, ComputedDefaultValue[Path]]" = None,
             **kwargs,
         ):
-            super().__init__(name, help, default, **kwargs)
+            super().__init__(name, default=default, **kwargs)
 
         def register_config_option(self, owner: "type[SimpleProjectBase]", **kwargs) -> ConfigOptionHandle:
+            help_str = self._help(owner) if callable(self._help) else self._help
             return typing.cast(
                 ConfigOptionHandle,
                 owner.add_config_option(
-                    self._name, default=self._default, help=self._help, kind=Path, **self._kwargs, **kwargs
+                    self._name, default=self._default, help=help_str, kind=Path, **self._kwargs, **kwargs
                 ),
             )
 
@@ -408,11 +392,10 @@ else:
         def __init__(
             self,
             name: str,
-            help: str,
             default: "typing.Union[Optional[Path], ComputedDefaultValue[Optional[Path]]]" = None,
             **kwargs,
         ):
-            super().__init__(name, help, default, **kwargs)
+            super().__init__(name, default=default, **kwargs)
 
         def register_config_option(self, owner: "type[SimpleProjectBase]", **kwargs) -> ConfigOptionHandle:
             return typing.cast(
@@ -426,11 +409,10 @@ else:
         def __init__(
             self,
             name: str,
-            help: str,
             default: "typing.Union[str, ComputedDefaultValue[str]]",
             **kwargs,
         ):
-            super().__init__(name, help, default, **kwargs)
+            super().__init__(name, default=default, **kwargs)
 
         def register_config_option(self, owner: "type[SimpleProjectBase]", **kwargs) -> ConfigOptionHandle:
             return typing.cast(
@@ -444,11 +426,10 @@ else:
         def __init__(
             self,
             name: str,
-            help: str,
             default: "typing.Union[str, ComputedDefaultValue[Optional[str]], None]" = None,
             **kwargs,
         ):
-            super().__init__(name, help, default, **kwargs)
+            super().__init__(name, default=default, **kwargs)
 
         def register_config_option(self, owner: "type[SimpleProjectBase]", **kwargs) -> ConfigOptionHandle:
             return typing.cast(
@@ -462,11 +443,10 @@ else:
         def __init__(
             self,
             name: str,
-            help: str,
             default: "typing.Union[Optional[list[T]], ComputedDefaultValue[list[T]]]" = None,
             **kwargs,
         ):
-            super().__init__(name, help, default, **kwargs)
+            super().__init__(name, default=default, **kwargs)
 
         def register_config_option(self, owner: "type[SimpleProjectBase]", **kwargs) -> ConfigOptionHandle:
             return typing.cast(
@@ -1081,6 +1061,10 @@ class SimpleProjectBase(AbstractProject, ABC):
         use_default_fallback_config_names=True,
         **kwargs,
     ) -> T:
+        if callable(use_default_fallback_config_names):
+            use_default_fallback_config_names = use_default_fallback_config_names(cls)
+        if callable(show_help):
+            show_help = show_help(cls)
         fullname = cls.target + "/" + name
         # We abuse shortname to implement altname
         if altname is not None:

--- a/pycheribuild/projects/simple_project.py
+++ b/pycheribuild/projects/simple_project.py
@@ -40,6 +40,7 @@ import threading
 import time
 import typing
 from abc import ABC, ABCMeta
+from enum import Enum
 from pathlib import Path
 from types import MappingProxyType
 from typing import Callable, Optional, Sequence, TypeVar, Union
@@ -76,6 +77,7 @@ from ..utils import (
 
 __all__ = [
     "BoolConfigOption",
+    "EnumConfigOption",
     "FloatConfigOption",
     "IntConfigOption",
     "ListConfigOption",
@@ -96,6 +98,7 @@ __all__ = [
 ]
 
 T = TypeVar("T")
+EnumTy = TypeVar("EnumTy", bound=Enum)
 
 
 def flush_stdio(stream) -> None:
@@ -135,7 +138,7 @@ class PerProjectConfigOption(typing.Generic[T]):
 
 
 if typing.TYPE_CHECKING:
-
+    # noinspection PyPep8Naming
     def BoolConfigOption(  # noqa: N802
         name: str,
         help: str,
@@ -143,6 +146,17 @@ if typing.TYPE_CHECKING:
         **kwargs,
     ) -> bool:
         return typing.cast(bool, default)
+
+    # noinspection PyPep8Naming
+    def EnumConfigOption(  # noqa: N802
+        name: str,
+        help: str,
+        default: "typing.Union[EnumTy, ComputedDefaultValue[EnumTy]]",
+        *,
+        kind: "type[EnumTy]",
+        **kwargs,
+    ) -> EnumTy:
+        return typing.cast(EnumTy, default)
 
     # noinspection PyPep8Naming
     def IntConfigOption(  # noqa: N802
@@ -236,6 +250,26 @@ else:
             return typing.cast(
                 ConfigOptionHandle,
                 owner.add_bool_option(self._name, default=self._default, help=self._help, **self._kwargs),
+            )
+
+    class EnumConfigOption(PerProjectConfigOption[EnumTy], typing.Generic[EnumTy]):
+        def __init__(
+            self,
+            name: str,
+            help: str,
+            default: "typing.Union[EnumTy, ComputedDefaultValue[EnumTy]]",
+            *,
+            kind: "type[EnumTy]",
+            **kwargs,
+        ):
+            super().__init__(name, help, default, kind=kind, **kwargs)
+
+        def register_config_option(self, owner: "type[SimpleProjectBase]") -> ConfigOptionHandle:
+            kind = self._kwargs["kind"]
+            kwargs = {k: v for k, v in self._kwargs.items() if k != "kind"}
+            return typing.cast(
+                ConfigOptionHandle,
+                owner.add_config_option(self._name, default=self._default, help=self._help, kind=kind, **kwargs),
             )
 
     class IntConfigOption(PerProjectConfigOption[int]):

--- a/pycheribuild/projects/simple_project.py
+++ b/pycheribuild/projects/simple_project.py
@@ -85,6 +85,7 @@ __all__ = [
     "PathConfigOption",
     "SimpleProject",
     "SimpleProjectBase",
+    "StringConfigOption",
     "TargetAlias",
     "TargetAliasWithDependencies",
     "_cached_get_homebrew_prefix",
@@ -197,6 +198,15 @@ if typing.TYPE_CHECKING:
         return typing.cast(Optional[Path], default)
 
     # noinspection PyPep8Naming
+    def StringConfigOption(  # noqa: N802
+        name: str,
+        help: str,
+        default: "typing.Union[str, ComputedDefaultValue[str]]",
+        **kwargs,
+    ) -> str:
+        return typing.cast(str, default)
+
+    # noinspection PyPep8Naming
     def ListConfigOption(  # noqa: N802
         name: str,
         help: str,
@@ -302,6 +312,22 @@ else:
                 owner.add_config_option(
                     self._name, default=self._default, help=self._help, kind=Optional[Path], **self._kwargs
                 ),
+            )
+
+    class StringConfigOption(PerProjectConfigOption[str]):
+        def __init__(
+            self,
+            name: str,
+            help: str,
+            default: "typing.Union[str, ComputedDefaultValue[str]]",
+            **kwargs,
+        ):
+            super().__init__(name, help, default, **kwargs)
+
+        def register_config_option(self, owner: "type[SimpleProjectBase]") -> ConfigOptionHandle:
+            return typing.cast(
+                ConfigOptionHandle,
+                owner.add_config_option(self._name, default=self._default, help=self._help, kind=str, **self._kwargs),
             )
 
     class ListConfigOption(PerProjectConfigOption[typing.List[str]]):

--- a/pycheribuild/projects/simple_project.py
+++ b/pycheribuild/projects/simple_project.py
@@ -128,10 +128,16 @@ class PerProjectConfigOption(typing.Generic[T]):
     def register_config_option(self, owner: "type[SimpleProjectBase]") -> ConfigOptionHandle[T]:
         raise NotImplementedError()
 
-    # noinspection PyProtectedMember
     def __set_name__(self, owner: "type[SimpleProjectBase]", name: str):
         # we know that _local_config_options is still a dict and not a MappingProxy when called here.
-        typing.cast(typing.MutableMapping[str, PerProjectConfigOption], owner._local_config_options)[name] = self
+        local_opts = getattr(owner, "_local_config_options", None)
+        if local_opts is None:
+            local_opts = dict()
+            # If this is a parent mixin class that doesn't inherit from SimpleProjectBase,
+            # we dynamically inject the mutable dict so that the metaclass __new__ hook
+            # will automatically copy and inherit it later during subclass creation.
+            setattr(owner, "_local_config_options", local_opts)
+        typing.cast(typing.MutableMapping[str, PerProjectConfigOption], local_opts)[name] = self
 
     def __get__(self, instance: "SimpleProjectBase", owner: "type[SimpleProjectBase]") -> T:
         raise ValueError("Should have been replaced!")
@@ -384,7 +390,7 @@ else:
         def register_config_option(self, owner: "type[SimpleProjectBase]") -> ConfigOptionHandle:
             return typing.cast(
                 ConfigOptionHandle,
-                owner.add_config_option(self._name, default=self._default, help=self._help, kind=Path, **self._kwargs),
+                owner.add_optional_path_option(self._name, default=self._default, help=self._help, **self._kwargs),
             )
 
     class StringConfigOption(PerProjectConfigOption[str]):
@@ -1794,18 +1800,28 @@ class ProjectSubclassDefinitionHook(ABCMeta):
     def __new__(cls, name: str, bases: "tuple[type, ...]", namespace: "dict[str, typing.Any]", **kwargs):
         # We have to set _local_config_options to a new dict here, as this is the first hook that runs before
         # the __set_name__ function on class members is called (__init_subclass__ is too late).
+        merged_opts = {}
         for base in bases:
             old = getattr(base, "_local_config_options", None)
             if old is not None:
-                # Create a copy of the dictionary so that modifying it does not change the value in the base class.
-                namespace = dict(namespace)
-                namespace["_local_config_options"] = dict(old)
+                merged_opts.update(old)
+        if merged_opts or "_local_config_options" in namespace:
+            namespace = dict(namespace)
+            namespace["_local_config_options"] = {**merged_opts, **namespace.get("_local_config_options", {})}
         return super().__new__(cls, name, bases, namespace, **kwargs)
 
     # pytype: disable=invalid-annotation
     def __init__(
         cls: "type[SimpleProjectBase]", name: str, bases: "tuple[type, ...]", clsdict: "dict[str, typing.Any]", **kwargs
     ) -> None:
+        # Retrieve the modifiable dict of local config options.
+        local_opts: "dict[str, PerProjectConfigOption]" = getattr(cls, "_local_config_options", {})
+        if local_opts and isinstance(local_opts, dict):
+            # Prune overridden options that have been redefined as static/non-descriptor values in this subclass
+            for key in list(local_opts.keys()):
+                current_val = inspect.getattr_static(cls, key, None)
+                if not isinstance(current_val, PerProjectConfigOption):
+                    del local_opts[key]
         super().__init__(name, bases, clsdict, **kwargs)
         # pytype: enable=invalid-annotation
         assert issubclass(cls, SimpleProjectBase)

--- a/pycheribuild/projects/simple_project.py
+++ b/pycheribuild/projects/simple_project.py
@@ -118,14 +118,27 @@ def _default_stdout_filter(_: bytes) -> None:
     raise NotImplementedError("Should never be called, this is a dummy")
 
 
+class DefaultValueOnlyDescriptor:
+    def __init__(self, default):
+        self.default = default
+
+    def __get__(self, instance: "Optional[SimpleProjectBase]", owner: "type[SimpleProjectBase]"):
+        if instance is None:
+            return self
+        if callable(self.default):
+            return self.default(instance.config, instance)
+        return self.default
+
+
 class PerProjectConfigOption(typing.Generic[T]):
     def __init__(self, name: str, help: str, default: "typing.Any", **kwargs) -> None:
         self._name = name
         self._default = default
         self._help = help
+        self.extra_condition = kwargs.pop("extra_condition", None)
         self._kwargs = kwargs
 
-    def register_config_option(self, owner: "type[SimpleProjectBase]") -> ConfigOptionHandle[T]:
+    def register_config_option(self, owner: "type[SimpleProjectBase]", **kwargs) -> ConfigOptionHandle[T]:
         raise NotImplementedError()
 
     def __set_name__(self, owner: "type[SimpleProjectBase]", name: str):
@@ -263,10 +276,10 @@ else:
         ):
             super().__init__(name, help, default, **kwargs)
 
-        def register_config_option(self, owner: "type[SimpleProjectBase]") -> ConfigOptionHandle:
+        def register_config_option(self, owner: "type[SimpleProjectBase]", **kwargs) -> ConfigOptionHandle:
             return typing.cast(
                 ConfigOptionHandle,
-                owner.add_bool_option(self._name, default=self._default, help=self._help, **self._kwargs),
+                owner.add_bool_option(self._name, default=self._default, help=self._help, **self._kwargs, **kwargs),
             )
 
     class EnumConfigOption(PerProjectConfigOption[EnumTy], typing.Generic[EnumTy]):
@@ -281,12 +294,14 @@ else:
         ):
             super().__init__(name, help, default, kind=kind, **kwargs)
 
-        def register_config_option(self, owner: "type[SimpleProjectBase]") -> ConfigOptionHandle:
+        def register_config_option(self, owner: "type[SimpleProjectBase]", **kwargs) -> ConfigOptionHandle:
             kind = self._kwargs["kind"]
-            kwargs = {k: v for k, v in self._kwargs.items() if k != "kind"}
+            other_kwargs = {k: v for k, v in self._kwargs.items() if k != "kind"}
             return typing.cast(
                 ConfigOptionHandle,
-                owner.add_config_option(self._name, default=self._default, help=self._help, kind=kind, **kwargs),
+                owner.add_config_option(
+                    self._name, default=self._default, help=self._help, kind=kind, **other_kwargs, **kwargs
+                ),
             )
 
     class OptionalEnumConfigOption(PerProjectConfigOption[Optional[EnumTy]], typing.Generic[EnumTy]):
@@ -301,22 +316,26 @@ else:
         ):
             super().__init__(name, help, default, kind=kind, **kwargs)
 
-        def register_config_option(self, owner: "type[SimpleProjectBase]") -> ConfigOptionHandle:
+        def register_config_option(self, owner: "type[SimpleProjectBase]", **kwargs) -> ConfigOptionHandle:
             kind = self._kwargs["kind"]
-            kwargs = {k: v for k, v in self._kwargs.items() if k != "kind"}
+            other_kwargs = {k: v for k, v in self._kwargs.items() if k != "kind"}
             return typing.cast(
                 ConfigOptionHandle,
-                owner.add_config_option(self._name, default=self._default, help=self._help, kind=kind, **kwargs),
+                owner.add_config_option(
+                    self._name, default=self._default, help=self._help, kind=kind, **other_kwargs, **kwargs
+                ),
             )
 
     class IntConfigOption(PerProjectConfigOption[int]):
         def __init__(self, name: str, help: str, default: "typing.Union[int, ComputedDefaultValue[int]]", **kwargs):
             super().__init__(name, help, default, **kwargs)
 
-        def register_config_option(self, owner: "type[SimpleProjectBase]") -> ConfigOptionHandle:
+        def register_config_option(self, owner: "type[SimpleProjectBase]", **kwargs) -> ConfigOptionHandle:
             return typing.cast(
                 ConfigOptionHandle,
-                owner.add_config_option(self._name, default=self._default, help=self._help, kind=int, **self._kwargs),
+                owner.add_config_option(
+                    self._name, default=self._default, help=self._help, kind=int, **self._kwargs, **kwargs
+                ),
             )
 
     class OptionalIntConfigOption(PerProjectConfigOption[Optional[int]]):
@@ -329,20 +348,24 @@ else:
         ):
             super().__init__(name, help, default, **kwargs)
 
-        def register_config_option(self, owner: "type[SimpleProjectBase]") -> ConfigOptionHandle:
+        def register_config_option(self, owner: "type[SimpleProjectBase]", **kwargs) -> ConfigOptionHandle:
             return typing.cast(
                 ConfigOptionHandle,
-                owner.add_config_option(self._name, default=self._default, help=self._help, kind=int, **self._kwargs),
+                owner.add_config_option(
+                    self._name, default=self._default, help=self._help, kind=int, **self._kwargs, **kwargs
+                ),
             )
 
     class FloatConfigOption(PerProjectConfigOption[float]):
         def __init__(self, name: str, help: str, default: "typing.Union[float, ComputedDefaultValue[float]]", **kwargs):
             super().__init__(name, help, default, **kwargs)
 
-        def register_config_option(self, owner: "type[SimpleProjectBase]") -> ConfigOptionHandle:
+        def register_config_option(self, owner: "type[SimpleProjectBase]", **kwargs) -> ConfigOptionHandle:
             return typing.cast(
                 ConfigOptionHandle,
-                owner.add_config_option(self._name, default=self._default, help=self._help, kind=float, **self._kwargs),
+                owner.add_config_option(
+                    self._name, default=self._default, help=self._help, kind=float, **self._kwargs, **kwargs
+                ),
             )
 
     class OptionalFloatConfigOption(PerProjectConfigOption[Optional[float]]):
@@ -355,10 +378,12 @@ else:
         ):
             super().__init__(name, help, default, **kwargs)
 
-        def register_config_option(self, owner: "type[SimpleProjectBase]") -> ConfigOptionHandle:
+        def register_config_option(self, owner: "type[SimpleProjectBase]", **kwargs) -> ConfigOptionHandle:
             return typing.cast(
                 ConfigOptionHandle,
-                owner.add_config_option(self._name, default=self._default, help=self._help, kind=float, **self._kwargs),
+                owner.add_config_option(
+                    self._name, default=self._default, help=self._help, kind=float, **self._kwargs, **kwargs
+                ),
             )
 
     class PathConfigOption(PerProjectConfigOption[Path]):
@@ -371,10 +396,12 @@ else:
         ):
             super().__init__(name, help, default, **kwargs)
 
-        def register_config_option(self, owner: "type[SimpleProjectBase]") -> ConfigOptionHandle:
+        def register_config_option(self, owner: "type[SimpleProjectBase]", **kwargs) -> ConfigOptionHandle:
             return typing.cast(
                 ConfigOptionHandle,
-                owner.add_config_option(self._name, default=self._default, help=self._help, kind=Path, **self._kwargs),
+                owner.add_config_option(
+                    self._name, default=self._default, help=self._help, kind=Path, **self._kwargs, **kwargs
+                ),
             )
 
     class OptionalPathConfigOption(PerProjectConfigOption[Optional[Path]]):
@@ -387,10 +414,12 @@ else:
         ):
             super().__init__(name, help, default, **kwargs)
 
-        def register_config_option(self, owner: "type[SimpleProjectBase]") -> ConfigOptionHandle:
+        def register_config_option(self, owner: "type[SimpleProjectBase]", **kwargs) -> ConfigOptionHandle:
             return typing.cast(
                 ConfigOptionHandle,
-                owner.add_optional_path_option(self._name, default=self._default, help=self._help, **self._kwargs),
+                owner.add_optional_path_option(
+                    self._name, default=self._default, help=self._help, **self._kwargs, **kwargs
+                ),
             )
 
     class StringConfigOption(PerProjectConfigOption[str]):
@@ -403,10 +432,12 @@ else:
         ):
             super().__init__(name, help, default, **kwargs)
 
-        def register_config_option(self, owner: "type[SimpleProjectBase]") -> ConfigOptionHandle:
+        def register_config_option(self, owner: "type[SimpleProjectBase]", **kwargs) -> ConfigOptionHandle:
             return typing.cast(
                 ConfigOptionHandle,
-                owner.add_config_option(self._name, default=self._default, help=self._help, kind=str, **self._kwargs),
+                owner.add_config_option(
+                    self._name, default=self._default, help=self._help, kind=str, **self._kwargs, **kwargs
+                ),
             )
 
     class OptionalStringConfigOption(PerProjectConfigOption[Optional[str]]):
@@ -419,11 +450,11 @@ else:
         ):
             super().__init__(name, help, default, **kwargs)
 
-        def register_config_option(self, owner: "type[SimpleProjectBase]") -> ConfigOptionHandle:
+        def register_config_option(self, owner: "type[SimpleProjectBase]", **kwargs) -> ConfigOptionHandle:
             return typing.cast(
                 ConfigOptionHandle,
                 owner.add_optional_config_option(
-                    self._name, default=self._default, help=self._help, kind=str, **self._kwargs
+                    self._name, default=self._default, help=self._help, kind=str, **self._kwargs, **kwargs
                 ),
             )
 
@@ -437,10 +468,10 @@ else:
         ):
             super().__init__(name, help, default, **kwargs)
 
-        def register_config_option(self, owner: "type[SimpleProjectBase]") -> ConfigOptionHandle:
+        def register_config_option(self, owner: "type[SimpleProjectBase]", **kwargs) -> ConfigOptionHandle:
             return typing.cast(
                 ConfigOptionHandle,
-                owner.add_list_option(self._name, default=self._default, help=self._help, **self._kwargs),
+                owner.add_list_option(self._name, default=self._default, help=self._help, **self._kwargs, **kwargs),
             )
 
 
@@ -1205,7 +1236,13 @@ class SimpleProjectBase(AbstractProject, ABC):
             # type of the ClassVar to determine if this is actually needed.
             option = inspect.getattr_static(cls, k)
             if isinstance(option, PerProjectConfigOption):
-                setattr(cls, k, v.register_config_option(cls))
+                if option.extra_condition is not None and not option.extra_condition(cls):
+                    # If the option's extra condition is not met, replace the descriptor with
+                    # DefaultValueOnlyDescriptor to dynamically evaluate the default value without
+                    # registering it in the loader.
+                    setattr(cls, k, DefaultValueOnlyDescriptor(v._default))
+                else:
+                    setattr(cls, k, v.register_config_option(cls))
 
     def __init__(self, config: CheriConfig, *, crosscompile_target: CrossCompileTarget) -> None:
         assert self._xtarget is not None, "Placeholder class should not be instantiated: " + repr(self)

--- a/pycheribuild/projects/simple_project.py
+++ b/pycheribuild/projects/simple_project.py
@@ -76,8 +76,10 @@ from ..utils import (
 
 __all__ = [
     "BoolConfigOption",
+    "FloatConfigOption",
     "IntConfigOption",
     "ListConfigOption",
+    "OptionalFloatConfigOption",
     "OptionalIntConfigOption",
     "OptionalPathConfigOption",
     "PathConfigOption",
@@ -159,6 +161,24 @@ if typing.TYPE_CHECKING:
         return typing.cast(Optional[int], default)
 
     # noinspection PyPep8Naming
+    def FloatConfigOption(  # noqa: N802
+        name: str,
+        help: str,
+        default: "typing.Union[float, ComputedDefaultValue[float]]",
+        **kwargs,
+    ) -> float:
+        return typing.cast(float, default)
+
+    # noinspection PyPep8Naming
+    def OptionalFloatConfigOption(  # noqa: N802
+        name: str,
+        help: str,
+        default: "typing.Union[Optional[float], ComputedDefaultValue[Optional[float]]]" = None,
+        **kwargs,
+    ) -> "Optional[float]":
+        return typing.cast(Optional[float], default)
+
+    # noinspection PyPep8Naming
     def PathConfigOption(  # noqa: N802
         name: str,
         help: str,
@@ -222,6 +242,32 @@ else:
             return typing.cast(
                 ConfigOptionHandle,
                 owner.add_config_option(self._name, default=self._default, help=self._help, kind=int, **self._kwargs),
+            )
+
+    class FloatConfigOption(PerProjectConfigOption[float]):
+        def __init__(self, name: str, help: str, default: "typing.Union[float, ComputedDefaultValue[float]]", **kwargs):
+            super().__init__(name, help, default, **kwargs)
+
+        def register_config_option(self, owner: "type[SimpleProjectBase]") -> ConfigOptionHandle:
+            return typing.cast(
+                ConfigOptionHandle,
+                owner.add_config_option(self._name, default=self._default, help=self._help, kind=float, **self._kwargs),
+            )
+
+    class OptionalFloatConfigOption(PerProjectConfigOption[Optional[float]]):
+        def __init__(
+            self,
+            name: str,
+            help: str,
+            default: "typing.Union[Optional[float], ComputedDefaultValue[Optional[float]]]" = None,
+            **kwargs,
+        ):
+            super().__init__(name, help, default, **kwargs)
+
+        def register_config_option(self, owner: "type[SimpleProjectBase]") -> ConfigOptionHandle:
+            return typing.cast(
+                ConfigOptionHandle,
+                owner.add_config_option(self._name, default=self._default, help=self._help, kind=float, **self._kwargs),
             )
 
     class PathConfigOption(PerProjectConfigOption[Path]):

--- a/pycheribuild/projects/simple_project.py
+++ b/pycheribuild/projects/simple_project.py
@@ -82,6 +82,7 @@ __all__ = [
     "OptionalFloatConfigOption",
     "OptionalIntConfigOption",
     "OptionalPathConfigOption",
+    "OptionalStringConfigOption",
     "PathConfigOption",
     "SimpleProject",
     "SimpleProjectBase",
@@ -207,6 +208,15 @@ if typing.TYPE_CHECKING:
         return typing.cast(str, default)
 
     # noinspection PyPep8Naming
+    def OptionalStringConfigOption(  # noqa: N802
+        name: str,
+        help: str,
+        default: "typing.Union[str, ComputedDefaultValue[Optional[str]], None]" = None,
+        **kwargs,
+    ) -> Optional[str]:
+        return typing.cast(Optional[str], default)
+
+    # noinspection PyPep8Naming
     def ListConfigOption(  # noqa: N802
         name: str,
         help: str,
@@ -326,6 +336,24 @@ else:
             return typing.cast(
                 ConfigOptionHandle,
                 owner.add_config_option(self._name, default=self._default, help=self._help, kind=str, **self._kwargs),
+            )
+
+    class OptionalStringConfigOption(PerProjectConfigOption[Optional[str]]):
+        def __init__(
+            self,
+            name: str,
+            help: str,
+            default: "typing.Union[str, ComputedDefaultValue[Optional[str]], None]" = None,
+            **kwargs,
+        ):
+            super().__init__(name, help, default, **kwargs)
+
+        def register_config_option(self, owner: "type[SimpleProjectBase]") -> ConfigOptionHandle:
+            return typing.cast(
+                ConfigOptionHandle,
+                owner.add_optional_config_option(
+                    self._name, default=self._default, help=self._help, kind=str, **self._kwargs
+                ),
             )
 
     class ListConfigOption(PerProjectConfigOption[typing.List[str]]):

--- a/pycheribuild/projects/simple_project.py
+++ b/pycheribuild/projects/simple_project.py
@@ -309,9 +309,7 @@ else:
         def register_config_option(self, owner: "type[SimpleProjectBase]") -> ConfigOptionHandle:
             return typing.cast(
                 ConfigOptionHandle,
-                owner.add_config_option(
-                    self._name, default=self._default, help=self._help, kind=Optional[Path], **self._kwargs
-                ),
+                owner.add_config_option(self._name, default=self._default, help=self._help, kind=Path, **self._kwargs),
             )
 
     class StringConfigOption(PerProjectConfigOption[str]):

--- a/pycheribuild/projects/simple_project.py
+++ b/pycheribuild/projects/simple_project.py
@@ -159,6 +159,17 @@ if typing.TYPE_CHECKING:
         return typing.cast(EnumTy, default)
 
     # noinspection PyPep8Naming
+    def OptionalEnumConfigOption(  # noqa: N802
+        name: str,
+        help: str,
+        default: "typing.Union[Optional[EnumTy], ComputedDefaultValue[Optional[EnumTy]]]" = None,
+        *,
+        kind: "type[EnumTy]",
+        **kwargs,
+    ) -> "Optional[EnumTy]":
+        return typing.cast(Optional[EnumTy], default)
+
+    # noinspection PyPep8Naming
     def IntConfigOption(  # noqa: N802
         name: str,
         help: str,
@@ -258,6 +269,26 @@ else:
             name: str,
             help: str,
             default: "typing.Union[EnumTy, ComputedDefaultValue[EnumTy]]",
+            *,
+            kind: "type[EnumTy]",
+            **kwargs,
+        ):
+            super().__init__(name, help, default, kind=kind, **kwargs)
+
+        def register_config_option(self, owner: "type[SimpleProjectBase]") -> ConfigOptionHandle:
+            kind = self._kwargs["kind"]
+            kwargs = {k: v for k, v in self._kwargs.items() if k != "kind"}
+            return typing.cast(
+                ConfigOptionHandle,
+                owner.add_config_option(self._name, default=self._default, help=self._help, kind=kind, **kwargs),
+            )
+
+    class OptionalEnumConfigOption(PerProjectConfigOption[Optional[EnumTy]], typing.Generic[EnumTy]):
+        def __init__(
+            self,
+            name: str,
+            help: str,
+            default: "typing.Union[Optional[EnumTy], ComputedDefaultValue[Optional[EnumTy]]]" = None,
             *,
             kind: "type[EnumTy]",
             **kwargs,

--- a/pycheribuild/projects/soaap.py
+++ b/pycheribuild/projects/soaap.py
@@ -45,11 +45,7 @@ class BuildSoaapLLVM(BuildLLVMSplitRepoBase):
     skip_static_analyzer = False
     _default_install_dir_fn = install_to_soaap_dir
     skip_cheri_symlinks = True
-
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        cls.included_projects = ["llvm", "clang"]
-        super().setup_config_options(include_lldb_revision=False, include_lld_revision=False, **kwargs)
+    included_projects = ["llvm", "clang"]
 
 
 class BuildSoaap(CMakeProject):

--- a/pycheribuild/projects/testrig.py
+++ b/pycheribuild/projects/testrig.py
@@ -35,7 +35,14 @@ from .build_qemu import BuildQEMU
 from .project import DefaultInstallDir, MakefileProject, Project
 from .repository import GitRepository
 from .sail import BuildSailCheriRISCV
-from .simple_project import BoolConfigOption, IntConfigOption, OptionalIntConfigOption, SimpleProject
+from .simple_project import (
+    BoolConfigOption,
+    IntConfigOption,
+    ListConfigOption,
+    OptionalIntConfigOption,
+    OptionalPathConfigOption,
+    SimpleProject,
+)
 from ..processutils import FakePopen, commandline_to_str, popen
 from ..utils import find_free_port
 
@@ -112,6 +119,11 @@ class RunTestRIGBase(SimpleProject):
         "test-implementation-port",
         help="Use a running test implementation instead.",
     )
+    vengine_options = ListConfigOption(
+        "extra-vengine-options",
+        metavar="OPTIONS",
+        help="Additional command line options to pass to QCVEngine",
+    )
 
     @property
     def extra_vengine_args(self) -> "list[str]":
@@ -133,15 +145,6 @@ class RunTestRIGBase(SimpleProject):
     @cached_property
     def run_implementations_with_tracing(self):
         return self.config.debug_output  # Only print traces in extremely verbose mode
-
-    @classmethod
-    def setup_config_options(cls, **kwargs) -> None:
-        super().setup_config_options(**kwargs)
-        cls.vengine_options = cls.add_list_option(
-            "extra-vengine-options",
-            metavar="OPTIONS",
-            help="Additional command line options to pass to QCVEngine",
-        )
 
     def get_test_impl(self, port: int):
         if self.existing_test_impl_port is not None:
@@ -230,15 +233,7 @@ class RunTestRIGFuzz(RunTestRIGBase, ABC):
         help="Replay traces captured in the default output directory",
     )
     number_of_runs = IntConfigOption("number-of-runs", default=20, help="Number of QCVEngine runs")
-    _replay_trace_path: Optional[Path]
-
-    @classmethod
-    def setup_config_options(cls, **kwargs) -> None:
-        super().setup_config_options(**kwargs)
-        if getattr(cls, "_replay_trace_path", None) is None:
-            cls._replay_trace_path = cls.add_optional_path_option(
-                "replay-trace", help="Run QCV trace from file/directory"
-            )
+    _replay_trace_path = OptionalPathConfigOption("replay-trace", help="Run QCV trace from file/directory")
 
     @cached_property
     def run_implementations_with_tracing(self) -> bool:

--- a/tests/test_argument_parsing.py
+++ b/tests/test_argument_parsing.py
@@ -17,7 +17,7 @@ import pytest
 from pycheribuild.config.compilation_targets import CompilationTargets, FreeBSDTargetInfo
 from pycheribuild.config.defaultconfig import CheribuildAction, DefaultCheriConfig
 from pycheribuild.config.loader import ConfigLoaderBase, ConfigOptionHandle, JsonAndCommandLineConfigOption
-from pycheribuild.jenkins_utils import jenkins_override_install_dirs_hack
+from pycheribuild.jenkins_utils import jenkins_override_install_dirs
 
 # noinspection PyUnresolvedReferences
 from pycheribuild.projects import *  # noqa: F401, F403, RUF100
@@ -1488,42 +1488,42 @@ def test_jenkins_hack_disk_image():
         "--cheribsd/build-bench-kernels",
     ]
     config = _parse_arguments(args)
-    jenkins_override_install_dirs_hack(config, Path("/rootfs"))
-    disk_image = _get_target_instance(
-        "disk-image-aarch64",
-        config,
-        BuildCheriBSDDiskImage,
-    )
-    assert disk_image.disk_image_path == Path("/tmp/tarball/cheribsd-aarch64.img")
-    assert disk_image.rootfs_dir == Path("/tmp/tarball/rootfs")
+    with jenkins_override_install_dirs(config, Path("/rootfs")):
+        disk_image = _get_target_instance(
+            "disk-image-aarch64",
+            config,
+            BuildCheriBSDDiskImage,
+        )
+        assert disk_image.disk_image_path == Path("/tmp/tarball/cheribsd-aarch64.img")
+        assert disk_image.rootfs_dir == Path("/tmp/tarball/rootfs")
 
 
 def test_jenkins_hack_hybrid_for_purecap_rootfs_prefix_none(monkeypatch):
     # Regression test for the jenkins install dir hack breaking hybrid-for-purecap-rootfs KDE targets
     config = _parse_arguments(["--output-root=/tmp/tarball", "--enable-hybrid-for-purecap-rootfs-targets"])
-    jenkins_override_install_dirs_hack(config, None)
-    cheribsd_morello_purecap = _get_target_instance("cheribsd-morello-purecap", config, BuildCHERIBSD)
-    # FIXME: we implicitly add /opt/morello-purecap for the rootfs dir here which does not make any sense
-    assert cheribsd_morello_purecap.target_info.install_prefix_dirname == "morello-purecap"
-    assert cheribsd_morello_purecap.install_dir == Path("/tmp/tarball")
-    assert cheribsd_morello_purecap.rootfs_dir == Path("/tmp/tarball")
-    # When building against the rootfs we do want the prefix though:
-    gmp_morello_purecap = _get_target_instance("gmp-morello-purecap", config, Project)
-    assert gmp_morello_purecap.crosscompile_target.is_cheri_purecap()
-    assert gmp_morello_purecap.target_info.install_prefix_dirname == "morello-purecap"
-    assert gmp_morello_purecap.install_dir == Path("/tmp/tarball/opt/morello-purecap")
-    assert gmp_morello_purecap.rootfs_dir == Path("/tmp/tarball")
-    assert gmp_morello_purecap.rootfs_dir == cheribsd_morello_purecap.install_dir
+    with jenkins_override_install_dirs(config, None):
+        cheribsd_morello_purecap = _get_target_instance("cheribsd-morello-purecap", config, BuildCHERIBSD)
+        # FIXME: we implicitly add /opt/morello-purecap for the rootfs dir here which does not make any sense
+        assert cheribsd_morello_purecap.target_info.install_prefix_dirname == "morello-purecap"
+        assert cheribsd_morello_purecap.install_dir == Path("/tmp/tarball")
+        assert cheribsd_morello_purecap.rootfs_dir == Path("/tmp/tarball")
+        # When building against the rootfs we do want the prefix though:
+        gmp_morello_purecap = _get_target_instance("gmp-morello-purecap", config, Project)
+        assert gmp_morello_purecap.crosscompile_target.is_cheri_purecap()
+        assert gmp_morello_purecap.target_info.install_prefix_dirname == "morello-purecap"
+        assert gmp_morello_purecap.install_dir == Path("/tmp/tarball/opt/morello-purecap")
+        assert gmp_morello_purecap.rootfs_dir == Path("/tmp/tarball")
+        assert gmp_morello_purecap.rootfs_dir == cheribsd_morello_purecap.install_dir
 
-    # The -hybrid-for-purecap-rootfs should install to the same rootfs but a different prefix:
-    gmp_morello_hybrid_for_purecap = _get_target_instance("gmp-morello-hybrid-for-purecap-rootfs", config, Project)
-    assert gmp_morello_hybrid_for_purecap.crosscompile_target.is_cheri_hybrid()
-    assert gmp_morello_hybrid_for_purecap.target_info.install_prefix_dirname == "morello-hybrid"
-    assert gmp_morello_hybrid_for_purecap.install_dir == Path("/tmp/tarball/opt/morello-hybrid")
-    # The rootfs should be the same as the gmp-purecap one:
-    assert gmp_morello_hybrid_for_purecap.rootfs_dir == gmp_morello_purecap.rootfs_dir
-    assert gmp_morello_hybrid_for_purecap.rootfs_dir == cheribsd_morello_purecap.install_dir
-    assert gmp_morello_hybrid_for_purecap.rootfs_dir == Path("/tmp/tarball")
+        # The -hybrid-for-purecap-rootfs should install to the same rootfs but a different prefix:
+        gmp_morello_hybrid_for_purecap = _get_target_instance("gmp-morello-hybrid-for-purecap-rootfs", config, Project)
+        assert gmp_morello_hybrid_for_purecap.crosscompile_target.is_cheri_hybrid()
+        assert gmp_morello_hybrid_for_purecap.target_info.install_prefix_dirname == "morello-hybrid"
+        assert gmp_morello_hybrid_for_purecap.install_dir == Path("/tmp/tarball/opt/morello-hybrid")
+        # The rootfs should be the same as the gmp-purecap one:
+        assert gmp_morello_hybrid_for_purecap.rootfs_dir == gmp_morello_purecap.rootfs_dir
+        assert gmp_morello_hybrid_for_purecap.rootfs_dir == cheribsd_morello_purecap.install_dir
+        assert gmp_morello_hybrid_for_purecap.rootfs_dir == Path("/tmp/tarball")
 
 
 # Another regression test, explicitly overriding the installation directory triggered an assertion
@@ -1539,9 +1539,9 @@ def test_jenkins_hack_hybrid_for_purecap_rootfs_prefix_none(monkeypatch):
 )
 def test_jenkins_hack_install_dirs(target: str, args: "list[str]", expected_install_dir: Path):
     config = _parse_arguments(["--output-root=/tmp/tarball", *args])
-    jenkins_override_install_dirs_hack(config, Path("/prefix"))
-    release = _get_target_instance(target, config, Project)
-    assert release.install_dir == expected_install_dir
+    with jenkins_override_install_dirs(config, Path("/prefix")):
+        release = _get_target_instance(target, config, Project)
+        assert release.install_dir == expected_install_dir
 
 
 def test_jenkins_hack_install_dir_for_dependencies():
@@ -1554,17 +1554,16 @@ def test_jenkins_hack_install_dir_for_dependencies():
         "gdb-riscv64-hybrid",
     ]
     config = _parse_arguments(args)
-    jenkins_override_install_dirs_hack(config, Path("/prefix"))
+    with jenkins_override_install_dirs(config, Path("/prefix")):
+        gmp = _get_target_instance("gmp-riscv64-hybrid", config, Project)
+        assert gmp.install_dir == Path("/tmp/tarball/prefix")
+        assert gmp.destdir == Path("/tmp/tarball")
+        assert gmp.install_prefix == Path("/prefix")
 
-    gmp = _get_target_instance("gmp-riscv64-hybrid", config, Project)
-    assert gmp.install_dir == Path("/tmp/tarball/prefix")
-    assert gmp.destdir == Path("/tmp/tarball")
-    assert gmp.install_prefix == Path("/prefix")
-
-    mpfr = _get_target_instance("mpfr-riscv64-hybrid", config, Project)
-    assert mpfr.install_dir == Path("/tmp/tarball/prefix")
-    assert mpfr.destdir == Path("/tmp/tarball")
-    assert mpfr.install_prefix == Path("/prefix")
+        mpfr = _get_target_instance("mpfr-riscv64-hybrid", config, Project)
+        assert mpfr.install_dir == Path("/tmp/tarball/prefix")
+        assert mpfr.destdir == Path("/tmp/tarball")
+        assert mpfr.install_prefix == Path("/prefix")
 
 
 def test_host_prefixes_and_install_dir():

--- a/tests/test_argument_parsing.py
+++ b/tests/test_argument_parsing.py
@@ -1544,6 +1544,29 @@ def test_jenkins_hack_install_dirs(target: str, args: "list[str]", expected_inst
     assert release.install_dir == expected_install_dir
 
 
+def test_jenkins_hack_install_dir_for_dependencies():
+    # When building gdb, we should expect the gmp and mpfr projects to install to the same prefix,
+    # even if they are not explicitly built (not in config.targets).
+    args = [
+        "--output-root=/tmp/tarball",
+        "--sysroot-install-dir-targets=gmp-riscv64-hybrid mpfr-riscv64-hybrid",
+        "--enable-hybrid-targets",
+        "gdb-riscv64-hybrid",
+    ]
+    config = _parse_arguments(args)
+    jenkins_override_install_dirs_hack(config, Path("/prefix"))
+
+    gmp = _get_target_instance("gmp-riscv64-hybrid", config, Project)
+    assert gmp.install_dir == Path("/tmp/tarball/prefix")
+    assert gmp.destdir == Path("/tmp/tarball")
+    assert gmp.install_prefix == Path("/prefix")
+
+    mpfr = _get_target_instance("mpfr-riscv64-hybrid", config, Project)
+    assert mpfr.install_dir == Path("/tmp/tarball/prefix")
+    assert mpfr.destdir == Path("/tmp/tarball")
+    assert mpfr.install_prefix == Path("/prefix")
+
+
 def test_host_prefixes_and_install_dir():
     # Building the wayland target was failing because it was trying to find wayland-scanner
     # inside the morello-purecap rootfs.

--- a/tests/test_project_helpers.py
+++ b/tests/test_project_helpers.py
@@ -5,11 +5,19 @@ from pathlib import Path
 import pytest
 
 from .setup_mock_chericonfig import CheriConfig, setup_mock_chericonfig
+from pycheribuild.config.compilation_targets import CompilationTargets
+from pycheribuild.config.config_loader_base import ComputedDefaultValue
 from pycheribuild.config.loader import ConfigOptionHandle
 from pycheribuild.config.target_info import BasicCompilationTargets, DefaultInstallDir
 from pycheribuild.projects.cmake_project import CMakeProject
 from pycheribuild.projects.repository import ExternallyManagedSourceRepository
-from pycheribuild.projects.simple_project import BoolConfigOption, PerProjectConfigOption, SimpleProject
+from pycheribuild.projects.simple_project import (
+    BoolConfigOption,
+    DefaultValueOnlyDescriptor,
+    IntConfigOption,
+    PerProjectConfigOption,
+    SimpleProject,
+)
 from pycheribuild.targets import target_manager
 
 
@@ -110,3 +118,76 @@ def test_mixin_and_overridden_config_options():
 
     instance_override = TestOverrideMixinProject(config, crosscompile_target=BasicCompilationTargets.NATIVE_NON_PURECAP)
     assert instance_override.mixin_option is False
+
+
+def test_conditional_config_options():
+    """
+    Verify that options defined with an extra_condition are correctly pruned
+    during metaclass options registration on targets where the condition is not met.
+    """
+    target_manager.reset()
+    config: CheriConfig = setup_mock_chericonfig(Path("/this/path/does/not/exist"))
+
+    class TestMultiArchProject(SimpleProject):
+        target = "test-multiarch-project"
+        repository = ExternallyManagedSourceRepository()
+        default_install_dir = DefaultInstallDir.DO_NOT_INSTALL
+        _supported_architectures = (CompilationTargets.NATIVE, CompilationTargets.CHERIBSD_RISCV_PURECAP)
+
+        cond_option = IntConfigOption(
+            "cond-option",
+            default=1234,
+            help="Condition Option",
+            extra_condition=lambda cls: cls._xtarget is not None and cls._xtarget.is_native(),
+        )
+
+        computed_option = IntConfigOption(
+            "computed-option",
+            default=ComputedDefaultValue(
+                lambda config, proj: 9999 if "native" in proj.target else 1111,
+                "description",
+            ),
+            help="Computed Option",
+            extra_condition=lambda cls: cls._xtarget is not None and cls._xtarget.is_native(),
+        )
+
+        def process(self):
+            pass
+
+    for target in target_manager.targets(config):
+        if issubclass(target.project_class, TestMultiArchProject):
+            target.project_class.setup_config_options()
+
+    # Verify multi-architecture get_class_for_target registration
+    native_cls = TestMultiArchProject.get_class_for_target(CompilationTargets.NATIVE)
+    cross_cls = TestMultiArchProject.get_class_for_target(CompilationTargets.CHERIBSD_RISCV_PURECAP)
+    assert "cond_option" in native_cls._local_config_options
+    assert "cond_option" in cross_cls._local_config_options
+
+    # Verify that the options are registered in the config loader for native, but not for cross
+    assert native_cls.target + "/cond-option" in config.loader.option_handles
+    assert cross_cls.target + "/cond-option" not in config.loader.option_handles
+    assert native_cls.target + "/computed-option" in config.loader.option_handles
+    assert cross_cls.target + "/computed-option" not in config.loader.option_handles
+
+    # Verify type of the field (should be ConfigOptionHandle for native, and DefaultValueOnlyDescriptor for cross)
+    native_opt = inspect.getattr_static(native_cls, "cond_option")
+    cross_opt = inspect.getattr_static(cross_cls, "cond_option")
+    assert isinstance(native_opt, ConfigOptionHandle)
+    assert isinstance(cross_opt, DefaultValueOnlyDescriptor)
+
+    native_computed_opt = inspect.getattr_static(native_cls, "computed_option")
+    cross_computed_opt = inspect.getattr_static(cross_cls, "computed_option")
+    assert isinstance(native_computed_opt, ConfigOptionHandle)
+    assert isinstance(cross_computed_opt, DefaultValueOnlyDescriptor)
+
+    instance_cond = native_cls(config, crosscompile_target=CompilationTargets.NATIVE)
+    assert isinstance(instance_cond.cond_option, int)
+    assert instance_cond.cond_option == 1234  # default value
+    assert instance_cond.computed_option == 9999
+
+    instance_cross = cross_cls(config, crosscompile_target=CompilationTargets.CHERIBSD_RISCV_PURECAP)
+    assert isinstance(instance_cross.cond_option, int)
+    assert instance_cross.cond_option == 1234  # default value evaluated via descriptor
+    # computed default evaluated dynamically via descriptor and different per-instance
+    assert instance_cross.computed_option == 1111

--- a/tests/test_project_helpers.py
+++ b/tests/test_project_helpers.py
@@ -1,12 +1,15 @@
+import inspect
 import re
 from pathlib import Path
 
 import pytest
 
 from .setup_mock_chericonfig import CheriConfig, setup_mock_chericonfig
+from pycheribuild.config.loader import ConfigOptionHandle
 from pycheribuild.config.target_info import BasicCompilationTargets, DefaultInstallDir
 from pycheribuild.projects.cmake_project import CMakeProject
 from pycheribuild.projects.repository import ExternallyManagedSourceRepository
+from pycheribuild.projects.simple_project import BoolConfigOption, PerProjectConfigOption, SimpleProject
 from pycheribuild.targets import target_manager
 
 
@@ -49,3 +52,61 @@ def test_add_cmake_option():
         add_options_test([], BYTE_OPTION=b"abc")
     with pytest.raises(TypeError, match=re.escape("Unsupported type <class 'tuple'>: ('abc',)")):
         add_options_test([], TUPLE_OPTION=("abc",))
+
+
+def test_mixin_and_overridden_config_options():
+    """
+    Verify that config option descriptors declared in mixin classes are correctly
+    registered on target subclasses, and that any options overridden as static
+    fixed values in concrete classes are successfully skipped and pruned.
+    """
+
+    class TestOptionMixin:
+        mixin_option = BoolConfigOption("mixin-option", help="Mixin Option", default=True)
+
+    class TestBaseProject(SimpleProject):
+        target = "test-base-project"
+        repository = ExternallyManagedSourceRepository()
+        default_install_dir = DefaultInstallDir.DO_NOT_INSTALL
+
+        base_option = BoolConfigOption("base-option", help="Base Option", default=False)
+
+    class TestConcreteProject(TestOptionMixin, TestBaseProject):
+        target = "test-concrete-project"
+        base_option = True
+
+        def process(self):
+            pass
+
+    class TestOverrideMixinProject(TestOptionMixin, TestBaseProject):
+        target = "test-override-mixin-project"
+        mixin_option = False
+
+        def process(self):
+            pass
+
+    target_manager.reset()
+    TestConcreteProject.setup_config_options()
+    TestOverrideMixinProject.setup_config_options()
+
+    assert isinstance(inspect.getattr_static(TestConcreteProject, "mixin_option"), ConfigOptionHandle)
+    assert isinstance(inspect.getattr_static(TestConcreteProject, "base_option"), bool)
+    assert inspect.getattr_static(TestConcreteProject, "base_option") is True
+
+    assert isinstance(inspect.getattr_static(TestOverrideMixinProject, "mixin_option"), bool)
+    assert inspect.getattr_static(TestOverrideMixinProject, "mixin_option") is False
+
+    assert "mixin_option" in TestConcreteProject._local_config_options
+    assert isinstance(TestConcreteProject._local_config_options["mixin_option"], PerProjectConfigOption)
+
+    assert "mixin_option" not in TestOverrideMixinProject._local_config_options
+    assert "base_option" not in TestConcreteProject._local_config_options
+
+    config: CheriConfig = setup_mock_chericonfig(Path("/this/path/does/not/exist"))
+
+    instance = TestConcreteProject(config, crosscompile_target=BasicCompilationTargets.NATIVE_NON_PURECAP)
+    assert instance.mixin_option is True
+    assert instance.base_option is True
+
+    instance_override = TestOverrideMixinProject(config, crosscompile_target=BasicCompilationTargets.NATIVE_NON_PURECAP)
+    assert instance_override.mixin_option is False

--- a/tests/test_project_helpers.py
+++ b/tests/test_project_helpers.py
@@ -191,3 +191,35 @@ def test_conditional_config_options():
     assert instance_cross.cond_option == 1234  # default value evaluated via descriptor
     # computed default evaluated dynamically via descriptor and different per-instance
     assert instance_cross.computed_option == 1111
+
+
+def test_subclass_option_inheritance_from_concrete_parent(tmp_path):
+    config = setup_mock_chericonfig(tmp_path)
+
+    class ParentConcreteProject(CMakeProject):
+        target = "parent-concrete"
+        _supported_architectures = (CompilationTargets.NATIVE,)
+
+        parent_option = IntConfigOption(
+            "parent-option",
+            default=100,
+            help="Parent Option",
+        )
+
+        def process(self):
+            pass
+
+    class ChildConcreteProject(ParentConcreteProject):
+        target = "child-concrete"
+        _supported_architectures = (CompilationTargets.NATIVE,)
+
+        def process(self):
+            pass
+
+    for target in target_manager.targets(config):
+        if target.name in ("parent-concrete", "child-concrete"):
+            target.project_class.setup_config_options()
+
+    # Both parent and child target classes should have their respective option registered in the config loader
+    assert "parent-concrete/parent-option" in config.loader.option_handles
+    assert "child-concrete/parent-option" in config.loader.option_handles

--- a/tests/test_qemu_forwarding_ports.py
+++ b/tests/test_qemu_forwarding_ports.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+import pytest
+
+from .setup_mock_chericonfig import CheriConfig, setup_mock_chericonfig
+from pycheribuild.projects import *  # noqa: F401, F403, RUF100
+from pycheribuild.projects.cross import *  # noqa: F401, F403, RUF100
+from pycheribuild.targets import target_manager
+
+
+def _get_original_class(cls) -> type:
+    return getattr(cls, "synthetic_base", cls)
+
+
+def test_qemu_launch_ports_no_conflict():
+    from pycheribuild.projects.run_qemu import LaunchQEMUBase
+
+    config: CheriConfig = setup_mock_chericonfig(Path("/this/path/does/not/exist"))
+    target_manager.register_command_line_options()
+
+    # Find all targets that derive from LaunchQEMUBase
+    qemu_targets = []
+    for target in target_manager.targets(config):
+        cls = target.project_class
+        if issubclass(cls, LaunchQEMUBase) and cls is not LaunchQEMUBase:
+            qemu_targets.append(target)
+
+    # For each QEMU target, check all supported architectures and collect the forwarding ports
+    allocated_ports = {}  # port -> (target_object, cls_object, arch_object)
+    for target in qemu_targets:
+        cls = target.project_class
+        for arch in cls.supported_architectures():
+            try:
+                project_instance = cls.get_instance(None, config=config, cross_target=arch)
+            except Exception:
+                continue
+
+            if not project_instance.forward_ssh_port:
+                continue
+
+            port = project_instance.ssh_forwarding_port
+            if port is not None:
+                if port in allocated_ports:
+                    prev_target, prev_cls, prev_arch = allocated_ports[port]
+                    if _get_original_class(prev_cls) is _get_original_class(cls) and prev_arch == arch:
+                        # This is just an alias target name for the exact same class/architecture, not a conflict!
+                        continue
+                    pytest.fail(
+                        f"SSH Port conflict detected! Port {port} is used by both:\n"
+                        f"1) Target: {prev_target.name} (Class: {prev_cls.__name__}, "
+                        f"Arch: {prev_arch.generic_arch_suffix})\n"
+                        f"2) Target: {target.name} (Class: {cls.__name__}, "
+                        f"Arch: {arch.generic_arch_suffix})"
+                    )
+                allocated_ports[port] = (target, cls, arch)


### PR DESCRIPTION
Use class variables instead of overriding setup_config_options.

This will eventually allow turning on the bad-attribute type checks.

The repetitive class-level conversion of setup_config_options->class attributes and adding tests was done using Gemini, but most of the logic changes were manual.

Confirmed the difference in default config options against HEAD using:
```
(cd /tmp && diff -u <(uv run ~/cheri/cheribuild-tmp/cheribuild.py --dump-configuration | sort | grep -Ev "test-against-running-qemu-instance|build-tests") <(uv run ~/cheri/cheribuild/cheribuild.py --dump-configuration | sort | grep -Ev "test-against-running-qemu-instance|build-tests")) > options.diff
```

This actually includes a few minor fixes where config options were not inherited properly previously, but otherwise this has no functional changes.

