### PR TITLE
Allocate unique default SSH port offsets for run-minimal and run-mfs-root

### DIFF
--- a/pycheribuild/projects/cherios.py
+++ b/pycheribuild/projects/cherios.py
@@ -30,7 +30,7 @@
 
 from .cmake_project import CMakeProject
 from .project import BuildType, ComputedDefaultValue, GitRepository
-from .run_qemu import LaunchQEMUBase, get_default_ssh_forwarding_port
+from .run_qemu import LaunchQEMUBase
 from .simple_project import BoolConfigOption, IntConfigOption
 from ..config.compilation_targets import CompilationTargets
 from ..utils import OSInfo
@@ -73,10 +73,6 @@ class LaunchCheriOSQEMU(LaunchQEMUBase):
     forward_ssh_port = False
     qemu_user_networking = False
     hide_options_from_help = True
-
-    @classmethod
-    def setup_config_options(cls, **kwargs):
-        super().setup_config_options(default_ssh_port=get_default_ssh_forwarding_port(40), **kwargs)
 
     @property
     def source_project(self):

--- a/pycheribuild/projects/run_qemu.py
+++ b/pycheribuild/projects/run_qemu.py
@@ -888,15 +888,13 @@ class LaunchCheriBSD(_RunMultiArchFreeBSDImage):
     kyua_test_files = tuple()  # don't run kyua tests by default for CheriBSD
 
     @classmethod
-    def setup_config_options(cls, **kwargs):
-        if "default_ssh_port" in kwargs:
-            # Subclass case
-            super().setup_config_options(**kwargs)
-        else:
+    def setup_config_options(cls, default_ssh_port: "Optional[int]" = None, **kwargs):
+        if default_ssh_port is None:
             add_to_port = cls.get_cross_target_index()
             if add_to_port != 0:  # 1 is used by run-purecap
                 add_to_port += 1
-            super().setup_config_options(default_ssh_port=get_default_ssh_forwarding_port(add_to_port), **kwargs)
+            default_ssh_port = get_default_ssh_forwarding_port(add_to_port)
+        super().setup_config_options(default_ssh_port=default_ssh_port, **kwargs)
 
     @classmethod
     def dependencies(cls, config: CheriConfig) -> "tuple[str, ...]":
@@ -961,9 +959,11 @@ class LaunchMinimalCheriBSD(LaunchCheriBSD):
     _disk_image_class = BuildMinimalCheriBSDDiskImage
 
     @classmethod
-    def setup_config_options(cls, **kwargs):
-        add_to_port = cls.get_cross_target_index()
-        super().setup_config_options(default_ssh_port=get_default_ssh_forwarding_port(20 + add_to_port), **kwargs)
+    def setup_config_options(cls, default_ssh_port: "Optional[int]" = None, **kwargs):
+        if default_ssh_port is None:
+            add_to_port = cls.get_cross_target_index()
+            default_ssh_port = get_default_ssh_forwarding_port(30 + add_to_port)
+        super().setup_config_options(default_ssh_port=default_ssh_port, **kwargs)
 
     @property
     def _extra_test_args(self) -> "list[str]":
@@ -975,6 +975,13 @@ class LaunchCheriBsdMfsRoot(LaunchMinimalCheriBSD):
     _freebsd_class = BuildCheriBsdMfsKernel
     _disk_image_class = None
     _uses_disk_image = False
+
+    @classmethod
+    def setup_config_options(cls, default_ssh_port: "Optional[int]" = None, **kwargs):
+        if default_ssh_port is None:
+            add_to_port = cls.get_cross_target_index()
+            default_ssh_port = get_default_ssh_forwarding_port(40 + add_to_port)
+        super().setup_config_options(default_ssh_port=default_ssh_port, **kwargs)
 
     # XXX: Existing code isn't ready to run these but we want to support building them
     @classmethod

--- a/tests/setup_mock_chericonfig.py
+++ b/tests/setup_mock_chericonfig.py
@@ -68,7 +68,7 @@ class MockConfig(CheriConfig):
         assert self._ensure_required_properties_set()
 
 
-def setup_mock_chericonfig(source_root: Path, pretend=True) -> MockConfig:
+def setup_mock_chericonfig(source_root: Path = Path("/this/path/does/not/exist"), pretend=True) -> MockConfig:
     config = MockConfig(source_root, pretend)
     # noinspection PyTypeChecker
     init_global_config(config, test_mode=True)

--- a/tests/test_project_helpers.py
+++ b/tests/test_project_helpers.py
@@ -32,7 +32,7 @@ def test_add_cmake_option():
         assert test_project.configure_args == expected
         test_project.configure_args.clear()  # reset for next test
 
-    config: CheriConfig = setup_mock_chericonfig(Path("/this/path/does/not/exist"))
+    config: CheriConfig = setup_mock_chericonfig()
     target_manager.reset()
     TestCMakeProject.setup_config_options()
     test_project = TestCMakeProject(config, crosscompile_target=BasicCompilationTargets.NATIVE_NON_PURECAP)
@@ -110,7 +110,7 @@ def test_mixin_and_overridden_config_options():
     assert "mixin_option" not in TestOverrideMixinProject._local_config_options
     assert "base_option" not in TestConcreteProject._local_config_options
 
-    config: CheriConfig = setup_mock_chericonfig(Path("/this/path/does/not/exist"))
+    config: CheriConfig = setup_mock_chericonfig()
 
     instance = TestConcreteProject(config, crosscompile_target=BasicCompilationTargets.NATIVE_NON_PURECAP)
     assert instance.mixin_option is True
@@ -126,7 +126,7 @@ def test_conditional_config_options():
     during metaclass options registration on targets where the condition is not met.
     """
     target_manager.reset()
-    config: CheriConfig = setup_mock_chericonfig(Path("/this/path/does/not/exist"))
+    config: CheriConfig = setup_mock_chericonfig()
 
     class TestMultiArchProject(SimpleProject):
         target = "test-multiarch-project"

--- a/tests/test_qemu_forwarding_ports.py
+++ b/tests/test_qemu_forwarding_ports.py
@@ -1,5 +1,4 @@
 import typing
-from pathlib import Path
 
 import pytest
 
@@ -11,7 +10,7 @@ from pycheribuild.targets import target_manager
 
 
 def test_qemu_launch_ports_no_conflict():
-    config: CheriConfig = setup_mock_chericonfig(Path("/this/path/does/not/exist"))
+    config: CheriConfig = setup_mock_chericonfig()
     config.enable_hybrid_targets = True
     target_manager.register_command_line_options()
 

--- a/tests/test_qemu_forwarding_ports.py
+++ b/tests/test_qemu_forwarding_ports.py
@@ -1,0 +1,39 @@
+import typing
+from pathlib import Path
+
+import pytest
+
+from .setup_mock_chericonfig import CheriConfig, setup_mock_chericonfig
+from pycheribuild.projects import *  # noqa: F401, F403, RUF100
+from pycheribuild.projects.cross import *  # noqa: F401, F403, RUF100
+from pycheribuild.projects.run_qemu import LaunchQEMUBase
+from pycheribuild.targets import target_manager
+
+
+def test_qemu_launch_ports_no_conflict():
+    config: CheriConfig = setup_mock_chericonfig(Path("/this/path/does/not/exist"))
+    config.enable_hybrid_targets = True
+    target_manager.register_command_line_options()
+
+    # For each QEMU target, check all supported architectures and collect the forwarding ports
+    allocated_ports = {}  # port -> (target_object, cls_object, arch_object)
+    for target in target_manager.targets(config):
+        cls = target.project_class
+        if not issubclass(cls, LaunchQEMUBase):
+            continue
+        project_instance = typing.cast(LaunchQEMUBase, target.create_project(config))
+        if not project_instance.forward_ssh_port:
+            print("Ignoring", target.name, "since it does not forward SSH port")
+            continue
+
+        port = project_instance.ssh_forwarding_port
+        print("Checking", target.name, "->", port)
+        assert port is not None, "Port should be set since forward_ssh_port=True"
+        if port in allocated_ports:
+            prev_target, prev_cls, prev_arch = allocated_ports[port]
+            pytest.fail(
+                f"SSH Port conflict detected! Port {port} is used by both:\n"
+                f"1) Target: {prev_target.name} (Class: {prev_cls.__name__}, Arch: {prev_arch})\n"
+                f"2) Target: {target.name} (Class: {cls.__name__}, Arch: {project_instance.crosscompile_target})"
+            )
+        allocated_ports[port] = (target, cls, project_instance.crosscompile_target)

--- a/tests/test_target_order.py
+++ b/tests/test_target_order.py
@@ -3,8 +3,6 @@ import inspect
 import itertools
 
 # noinspection PyUnresolvedReferences
-from pathlib import Path
-
 import pytest
 
 from .setup_mock_chericonfig import CheriConfig, setup_mock_chericonfig
@@ -49,7 +47,7 @@ def _sort_targets(
 ) -> "list[str]":
     target_manager.reset()
     # print(real_targets)
-    global_config = setup_mock_chericonfig(Path("/this/path/does/not/exist"))
+    global_config = setup_mock_chericonfig()
     global_config.include_dependencies = add_dependencies
     global_config.include_toolchain_dependencies = add_toolchain
     global_config.skip_sdk = skip_sdk
@@ -492,7 +490,7 @@ def test_ksyntaxhighlighting_includes_native_dependency():
 
 def test_webkit_cached_deps():
     # regression test for a bug in caching deps
-    config = copy.copy(setup_mock_chericonfig(Path("/this/path/does/not/exist")))
+    config = copy.copy(setup_mock_chericonfig())
     config.skip_sdk = True
     config.include_toolchain_dependencies = False
     config.include_dependencies = True
@@ -732,7 +730,7 @@ def test_skip_toolchain_deps(
 )
 def test_hybrid_targets(enable_hybrid_targets: bool):
     # there should only be very few targets that are built hybrid
-    config = setup_mock_chericonfig(Path("/this/path/does/not/exist"))
+    config = setup_mock_chericonfig()
     config.enable_hybrid_targets = enable_hybrid_targets
     all_hybrid_targets = [
         x
@@ -804,7 +802,7 @@ def test_hybrid_targets(enable_hybrid_targets: bool):
 
 
 def _get_native_targets():
-    config = setup_mock_chericonfig(Path("/this/path/does/not/exist"))
+    config = setup_mock_chericonfig()
     for target in target_manager.targets(config):
         if target.xtarget.is_native():
             yield pytest.param(config, target, id=target.name)
@@ -861,7 +859,7 @@ def test_no_dependencies_in_build_dir(config: CheriConfig, native_target: Target
     ],
 )
 def test_toolchain_dependencies(xtarget: CrossCompileTarget, expected: "list[str]"):
-    config = setup_mock_chericonfig(Path("/this/path/does/not/exist"))
+    config = setup_mock_chericonfig()
     assert xtarget.target_info_cls.toolchain_targets(xtarget, config) == expected
     if expected:
         assert len(expected) == 1


### PR DESCRIPTION
While refactoring the config setup I noticed that these were overlapping.
Also add a test to ensure that we don't have this issue again in the future.