### PR TITLE
linux, rvy: add default QEMU -cpu flags

### DIFF
--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -556,7 +556,7 @@ class FreeBSDTargetInfo(_ClangBasedTargetInfo):
         rootfs_xtarget = xtarget.get_rootfs_target()
         from ..qemu_utils import QemuOptions
 
-        qemu_options = QemuOptions(rootfs_xtarget, riscv_cheri_isa=self.config.riscv_cheri_isa)
+        qemu_options = QemuOptions(rootfs_xtarget, config=self.config)
         run_instance: LaunchFreeBSDInterface = self._get_run_project(rootfs_xtarget, self.project)
         if rootfs_xtarget.cpu_architecture not in (
             CPUArchitecture.MIPS64,

--- a/pycheribuild/projects/cross/bbl.py
+++ b/pycheribuild/projects/cross/bbl.py
@@ -162,7 +162,7 @@ class BuildBBLTestPayload(BuildBBLBase):
         self.configure_args.append("--enable-print-device-tree")
 
     def run_tests(self) -> None:
-        options = QemuOptions(self.crosscompile_target, riscv_cheri_isa=self.config.riscv_cheri_isa)
+        options = QemuOptions(self.crosscompile_target, config=self.config)
         self.run_cmd(
             options.get_commandline(
                 qemu_command=BuildQEMU.qemu_binary(self),

--- a/pycheribuild/projects/cross/opensbi.py
+++ b/pycheribuild/projects/cross/opensbi.py
@@ -197,9 +197,7 @@ class BuildOpenSBI(Project):
         return cls.get_hybrid_instance(caller)._fw_jump_path()
 
     def run_tests(self):
-        options = QemuOptions(
-            self.crosscompile_target, riscv_cheri_isa=self.crosscompile_target.riscv_cheri_isa(self.config)
-        )
+        options = QemuOptions(self.crosscompile_target, config=self.config)
         abi = self.target_info.get_riscv_abi(self.crosscompile_target, softfloat=True)
         self.run_cmd(
             options.get_commandline(

--- a/pycheribuild/projects/run_qemu.py
+++ b/pycheribuild/projects/run_qemu.py
@@ -227,9 +227,7 @@ class LaunchQEMUBase(SimpleProject):
         self._project_specific_options = []
         self.bios_flags = []
         self.qemu_options = QemuOptions(
-            self.crosscompile_target,
-            want_debugger=self.config.wait_for_debugger,
-            riscv_cheri_isa=self.config.riscv_cheri_isa,
+            self.crosscompile_target, want_debugger=self.config.wait_for_debugger, config=self.config
         )
         self.qemu_user_networking = True
         self.rootfs_path: Optional[Path] = None

--- a/pycheribuild/projects/syzkaller.py
+++ b/pycheribuild/projects/syzkaller.py
@@ -221,7 +221,7 @@ class RunSyzkaller(SimpleProject):
                 # Run in debug mode
                 vm_type = "none"
 
-            qemu_opts = QemuOptions(self.crosscompile_target, riscv_cheri_isa=self.config.riscv_cheri_isa)
+            qemu_opts = QemuOptions(self.crosscompile_target, config=self.config)
             qemu_args = [*qemu_opts.machine_flags, "-device", "virtio-rng-pci", "-D", "syz-trace.log"]
             template = {
                 "name": "cheribsd-n64",

--- a/pycheribuild/qemu_utils.py
+++ b/pycheribuild/qemu_utils.py
@@ -33,25 +33,22 @@ import subprocess
 from pathlib import Path
 from typing import Optional
 
-from .config.chericonfig import RiscvCheriISA
 from .config.target_info import CPUArchitecture, CrossCompileTarget
 from .processutils import run_command
+from .projects.project import CheriConfig
 from .utils import ConfigBase, OSInfo, warning_message
 
 
 class QemuOptions:
     machine_flags: "list[str]"
 
-    def __init__(
-        self, xtarget: CrossCompileTarget, want_debugger=False, riscv_cheri_isa: Optional[RiscvCheriISA] = None
-    ) -> None:
+    def __init__(self, xtarget: CrossCompileTarget, want_debugger=False, config: Optional[CheriConfig] = None) -> None:
         self.xtarget = xtarget
         self.virtio_disk = True
         self.force_virtio_blk_device = False
         self.can_boot_kernel_directly = False
         self.memory_size = "2048"
         self.has_default_nic = False
-        self.riscv_cheri_isa = riscv_cheri_isa
         if xtarget.is_hybrid_or_purecap_cheri([CPUArchitecture.AARCH64]):
             self._qemu_arch_suffix = "morello"
             self.can_boot_kernel_directly = False  # boot from disk
@@ -71,9 +68,9 @@ class QemuOptions:
             # Note: we always use the CHERI QEMU
             xlen = 32 if xtarget.is_riscv32(include_purecap=True) else 64
             self.machine_flags = ["-M", "virt"]
-            if riscv_cheri_isa is RiscvCheriISA.EXPERIMENTAL_STD093:
+            if config is not None and xtarget.is_experimental_cheri093_std(config):
                 self._qemu_arch_suffix = self._qemu_arch_suffix = f"riscv{xlen}cheristd"
-                cpu_model = "codasip-l730" if xlen == 32 else "codasip-a730"
+                cpu_model = "rv32" if xlen == 32 else "rv64,cheri_pte=on,cheri_levels=2"
                 self.machine_flags.extend(["-cpu", f"{cpu_model}"])
             else:
                 self._qemu_arch_suffix = f"riscv{xlen}cheri"


### PR DESCRIPTION
Currently the launch target will add -cpu codasip-a730 only if --riscv-cheri-isa experimental_std093 is passed, and will discard -cpu if not. Discarding -cpu will result in a CHERI-enabled RVY QEMU, but with extended CHERI flags/features disabled such as cheri_pte, cheri_levels, etc, in the QEMU 7.1 branch.

This PR fixes this by:
1- Always pass -cpu rv64,cheri_pte,cheri_levels for CHERI-Linux by default, without having to check for the --riscv-cheri-isa flag.
2- Use a more generic -cpu rv64 and not codasip-a730.