### PR TITLE
Really use CHERI-Alliance QEMU repo

### DIFF
--- a/pycheribuild/projects/build_qemu.py
+++ b/pycheribuild/projects/build_qemu.py
@@ -541,7 +541,12 @@ class BuildCheriQEMUBase(BuildQEMUBase):
 
 class BuildQEMU(BuildCheriQEMUBase):
     target = "qemu"
-    repository = GitRepository("https://github.com/CHERI-Alliance/qemu.git", default_branch="main")
+    repository = GitRepository(
+        "https://github.com/CHERI-Alliance/qemu.git",
+        default_branch="main",
+        old_urls=["https://github.com/CTSRD-CHERI/qemu.git"],
+        old_branches={"qemu-cheri": "main"},
+    )
     default_targets = (
         "arm-softmmu,aarch64-softmmu,morello-softmmu,"
         "mips64-softmmu,mips64cheri128-softmmu,"

--- a/pycheribuild/projects/repository.py
+++ b/pycheribuild/projects/repository.py
@@ -496,6 +496,20 @@ class GitRepository(SourceRepository):
             return base_project_source_dir
         return base_project_source_dir.with_name(target_override.directory_name)
 
+    def _find_unique_branch_name(self, current_project: "Project", src_dir: Path, base_name: str) -> str:
+        suffix_counter = 1
+        new_branch_name = f"{base_name}-cheribuild"
+        while True:
+            has_branch = current_project.try_run_cmd(
+                ["git", "show-ref", "--verify", f"refs/heads/{new_branch_name}"],
+                cwd=src_dir,
+                capture_error=True,
+            )
+            if not has_branch:
+                return new_branch_name
+            suffix_counter += 1
+            new_branch_name = f"{base_name}-cheribuild-{suffix_counter}"
+
     def _handle_old_urls(self, current_project: "Project", src_dir: Path) -> None:
         if not (src_dir.exists() and self.old_urls):
             return
@@ -518,47 +532,94 @@ class GitRepository(SourceRepository):
         # Strip any .git suffix to match more old URLs
         if remote_url.endswith(".git"):
             remote_url = remote_url[:-4]
-        # Update from the old url:
+
+        # Find if we match any old URL
+        matched_old_url = None
         for old_url in self.old_urls:
             if old_url.endswith(".git"):
                 old_url = old_url[:-4]
             if remote_url == old_url:
-                current_project.warning(
-                    current_project.target, "still points to old repository", remote_url, "instead of", self.url
-                )
-                if current_project.query_yes_no("Update to correct URL?"):
-                    has_origin = current_project.try_run_cmd(
-                        ["git", "remote", "get-url", "origin"],
-                        capture_output=True,
+                matched_old_url = old_url
+                break
+
+        if matched_old_url is None:
+            return
+
+        current_project.warning(
+            current_project.target, "still points to old repository", remote_url, "instead of", self.url
+        )
+        if not current_project.query_yes_no("Update to correct URL?"):
+            return
+
+        has_origin = current_project.try_run_cmd(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True,
+            cwd=src_dir,
+            print_verbose_only=True,
+        )
+
+        if has_origin:
+            new_name = "old-origin"
+            while not current_project.try_run_cmd(
+                ["git", "remote", "rename", "origin", new_name],
+                run_in_pretend_mode=_PRETEND_RUN_GIT_COMMANDS,
+                cwd=src_dir,
+                capture_error=True,
+            ):
+                new_name = "old-" + new_name
+
+        current_project.run_cmd(
+            ["git", "remote", "add", "origin", self.url],
+            run_in_pretend_mode=_PRETEND_RUN_GIT_COMMANDS,
+            cwd=src_dir,
+        )
+        branch_info = branch_info._replace(remote_name="origin")
+        default_branch = self.get_default_branch(current_project, include_per_target=True)
+        if not default_branch:
+            return
+
+        current_project.info(f"Switching to default branch {default_branch} for new URL")
+        current_project.run_cmd(["git", "fetch", branch_info.remote_name], cwd=src_dir)
+        expected_upstream = f"{branch_info.remote_name}/{default_branch}"
+        has_branch = current_project.try_run_cmd(
+            ["git", "show-ref", "--verify", f"refs/heads/{default_branch}"],
+            cwd=src_dir,
+            capture_error=True,
+        )
+        if has_branch:
+            try:
+                upstream = (
+                    current_project.run_cmd(
+                        ["git", "rev-parse", "--abbrev-ref", f"{default_branch}@{{u}}"],
                         cwd=src_dir,
+                        capture_output=True,
+                        capture_error=True,
                         print_verbose_only=True,
                     )
+                    .stdout.decode("utf-8")
+                    .strip()
+                )
+            except subprocess.CalledProcessError:
+                upstream = None
 
-                    if has_origin:
-                        new_name = "old-origin"
-                        while not current_project.try_run_cmd(
-                            ["git", "remote", "rename", "origin", new_name],
-                            run_in_pretend_mode=_PRETEND_RUN_GIT_COMMANDS,
-                            cwd=src_dir,
-                            capture_error=True,
-                        ):
-                            new_name = "old-" + new_name
+            if upstream == expected_upstream:
+                current_project.info(f"Checking out existing branch {default_branch}")
+                checkout_args = [default_branch]
+            else:
+                new_branch_name = self._find_unique_branch_name(current_project, src_dir, default_branch)
+                if upstream:
+                    msg = f"Branch {default_branch} tracks wrong branch {upstream}."
+                else:
+                    msg = f"Branch {default_branch} has no upstream."
+                current_project.info(msg, f"Creating new branch {new_branch_name}")
+                checkout_args = ["-b", new_branch_name, expected_upstream]
+        else:
+            current_project.info(
+                f"Branch {default_branch} does not exist locally. Checking it out from {expected_upstream}"
+            )
+            checkout_args = ["--track", expected_upstream]
 
-                    current_project.run_cmd(
-                        ["git", "remote", "add", "origin", self.url],
-                        run_in_pretend_mode=_PRETEND_RUN_GIT_COMMANDS,
-                        cwd=src_dir,
-                    )
-                    branch_info = branch_info._replace(remote_name="origin")
-                    default_branch = self.get_default_branch(current_project, include_per_target=True)
-                    if default_branch:
-                        current_project.info(f"Switching to default branch {default_branch} for new URL")
-                        current_project.run_cmd(["git", "fetch", branch_info.remote_name], cwd=src_dir)
-                        current_project.run_cmd(
-                            ["git", "checkout", "--track", f"{branch_info.remote_name}/{default_branch}"],
-                            cwd=src_dir,
-                            capture_error=True,
-                        )
+        current_project.run_cmd(["git", "checkout", *checkout_args], cwd=src_dir)
 
     def _handle_branch_switch(self, current_project: "Project", src_dir: Path) -> None:
         if not (src_dir.exists() and (self.force_branch or self.old_branches)):
@@ -642,7 +703,7 @@ class GitRepository(SourceRepository):
                         current_project.info(f"Checking out existing branch {default_branch}")
                         checkout_args = [default_branch]
                     else:
-                        new_branch_name = f"{default_branch}-cheribuild"
+                        new_branch_name = self._find_unique_branch_name(current_project, src_dir, default_branch)
                         if upstream:
                             msg = f"Branch {default_branch} tracks wrong branch {upstream}."
                         else:

--- a/tests/test_git_branch_switching.py
+++ b/tests/test_git_branch_switching.py
@@ -10,6 +10,7 @@ if shutil.which("git") is None:
     pytest.skip("git command not found", allow_module_level=True)
 
 from .setup_mock_chericonfig import setup_mock_chericonfig
+from pycheribuild.config.compilation_targets import CompilationTargets
 from pycheribuild.config.target_info import BasicCompilationTargets, DefaultInstallDir
 from pycheribuild.projects.project import Project
 from pycheribuild.projects.repository import GitRepository, TargetBranchInfo
@@ -88,7 +89,14 @@ class MockProject(Project):
         return super().run_cmd(*args, **kwargs)
 
 
-def setup_test_project(local_dir, remote_dir, target_branch="target-branch"):
+def setup_test_project(
+    local_dir,
+    remote_dir,
+    *,
+    crosscompile_target=BasicCompilationTargets.NATIVE_NON_PURECAP,
+    force_branch=True,
+    old_urls=None,
+):
     local_dir.parent.mkdir(parents=True, exist_ok=True)
 
     config = setup_mock_chericonfig(local_dir.parent, pretend=False)
@@ -99,21 +107,22 @@ def setup_test_project(local_dir, remote_dir, target_branch="target-branch"):
         target = "test-git-project"
         do_not_add_to_targets = True
         _should_not_be_instantiated = False
-        _xtarget = BasicCompilationTargets.NATIVE_NON_PURECAP
+        _xtarget = crosscompile_target
         repository = GitRepository(
             str(remote_dir),
-            force_branch=True,
+            force_branch=force_branch,
             default_branch="main",
             per_target_branches={
                 BasicCompilationTargets.NATIVE_NON_PURECAP: TargetBranchInfo(
-                    branch=target_branch, directory_name="dummy-dir"
+                    branch="target-branch", directory_name="dummy-dir"
                 )
             },
+            old_urls=old_urls,
         )
 
     TestProject.setup_config_options()
 
-    project = TestProject(config, crosscompile_target=BasicCompilationTargets.NATIVE_NON_PURECAP)
+    project = TestProject(config, crosscompile_target=crosscompile_target)
     return project
 
 
@@ -206,6 +215,7 @@ def test_switch_branch_tracks_wrong_remote(shared_remote: Path, local_repo: Path
         ("command", ["git", "fetch", "origin"]),
         ("command", ["git", "show-ref", "--verify", "refs/heads/target-branch"]),
         ("command", ["git", "rev-parse", "--abbrev-ref", "target-branch@{u}"]),
+        ("command", ["git", "show-ref", "--verify", "refs/heads/target-branch-cheribuild"]),
         (
             "info",
             "Branch target-branch tracks wrong branch other/target-branch. "
@@ -238,6 +248,7 @@ def test_switch_branch_tracks_wrong_branch_same_remote(shared_remote: Path, loca
         ("command", ["git", "fetch", "origin"]),
         ("command", ["git", "show-ref", "--verify", "refs/heads/target-branch"]),
         ("command", ["git", "rev-parse", "--abbrev-ref", "target-branch@{u}"]),
+        ("command", ["git", "show-ref", "--verify", "refs/heads/target-branch-cheribuild"]),
         (
             "info",
             "Branch target-branch tracks wrong branch origin/other-branch. "
@@ -270,6 +281,7 @@ def test_switch_branch_no_upstream(shared_remote: Path, local_repo: Path):
         ("command", ["git", "fetch", "origin"]),
         ("command", ["git", "show-ref", "--verify", "refs/heads/target-branch"]),
         ("command", ["git", "rev-parse", "--abbrev-ref", "target-branch@{u}"]),
+        ("command", ["git", "show-ref", "--verify", "refs/heads/target-branch-cheribuild"]),
         ("info", "Branch target-branch has no upstream. Creating new branch target-branch-cheribuild"),
         ("command", ["git", "checkout", "-b", "target-branch-cheribuild", "origin/target-branch"]),
         ("command", ["git", "fetch"]),
@@ -369,3 +381,48 @@ def test_switch_branch_origin_and_new_origin_wrong_url(shared_remote: Path, loca
         ("verbose", "HEAD contains commit @{upstream}"),
         ("info", "Skipping update: Current HEAD is up-to-date or ahead of upstream."),
     ]
+
+
+def test_handle_old_urls_branch_exists(shared_remote: Path, local_repo: Path, tmp_path: Path):
+    # Set up an "old remote" directory and a "new remote" directory
+    old_remote_dir = tmp_path / "old_remote"
+    create_remote_repo(old_remote_dir)
+
+    # Local repo 'origin' points to the old remote URL
+    subprocess.run(["git", "remote", "set-url", "origin", str(old_remote_dir)], cwd=local_repo, check=True)
+    subprocess.run(["git", "fetch", "origin"], cwd=local_repo, check=True)
+    subprocess.run(["git", "branch", "--set-upstream-to=origin/main", "main"], cwd=local_repo, check=True)
+
+    # Create 'main-cheribuild' branch beforehand to trigger the collision loop!
+    subprocess.run(["git", "branch", "main-cheribuild", "origin/main"], cwd=local_repo, check=True)
+
+    # We are currently on local 'main' branch, which tracks 'origin/main' (which is the old URL)
+    assert get_git_revision(local_repo, "HEAD") == "main"
+    assert get_git_revision(local_repo, "main@{u}") == "origin/main"
+
+    # Now we configure the project with the new remote URL (shared_remote) and the old remote URL (old_remote_dir)
+    project = setup_test_project(
+        local_repo,
+        shared_remote,
+        crosscompile_target=CompilationTargets.CHERIBSD_RISCV_PURECAP,
+        force_branch=False,
+        old_urls=[str(old_remote_dir)],
+    )
+
+    repo = project.repository
+    # This will trigger _handle_old_urls
+    repo.update(project, src_dir=local_repo)
+
+    # Since 'main' and 'main-cheribuild' already exist locally, it should have created a new branch 'main-cheribuild-2'
+    # tracking the new remote 'origin/main'
+    assert get_git_revision(local_repo, "HEAD") == "main-cheribuild-2"
+    assert get_git_revision(local_repo, "main-cheribuild-2@{u}") == "origin/main"
+
+    # The old remote should have been renamed to 'old-origin'
+    res = subprocess.run(["git", "remote", "-v"], cwd=local_repo, capture_output=True, check=True)
+    remotes = res.stdout.decode("utf-8")
+    assert "old-origin" in remotes
+    assert str(old_remote_dir) in remotes
+    # The new remote should be 'origin'
+    assert "origin" in remotes
+    assert str(shared_remote) in remotes


### PR DESCRIPTION
Previously this only affected new clones, now it will warn if you are
still on the qemu-cheri branch and suggest switching.