### PR TITLE
vim: add required -lrt needed to link

### DIFF
--- a/pycheribuild/projects/cross/vim.py
+++ b/pycheribuild/projects/cross/vim.py
@@ -66,6 +66,7 @@ class BuildVim(CrossCompileAutotoolsProject):
             )
             # Terminal library selection also uses AC_TRY_RUN
             self.configure_args.append("--with-tlib=tinfo")
+            self.LDFLAGS.append("-lrt")
 
     def needs_configure(self):
         # Makefile exists in the source (both at the top level and within


### PR DESCRIPTION
Vim now requires -lrt otherwise there are link failures for timer functions.

Building on FreeBSD without the patch:
```
$ ./cheribuild.py vim-morello-purecap
...
ld.lld: error: undefined symbol: timer_settime
>>> referenced by os_unix.c
>>>               objects/os_unix.o:(stop_timeout)
>>> referenced by os_unix.c
>>>               objects/os_unix.o:(start_timeout)
>>> did you mean: ktimer_settime
>>> defined in: ~/cheri/output/rootfs-morello-purecap/lib/libc.so.7

ld.lld: error: undefined symbol: timer_create
>>> referenced by os_unix.c
>>>               objects/os_unix.o:(start_timeout)
>>> did you mean: ktimer_create
>>> defined in: ~/cheri/output/rootfs-morello-purecap/lib/libc.so.7

ld.lld: error: undefined symbol: timer_delete
...
```