### PR TITLE
mtree: escape METALOG filenames according to FreeBSD's mtree(8) / VIS_OCTAL

### DIFF
--- a/pycheribuild/mtree.py
+++ b/pycheribuild/mtree.py
@@ -128,8 +128,7 @@ class MtreeEntry:
     def __str__(self) -> str:
         components = [MtreePath.escape(str(self.path))]
         for k, v in self.attributes.items():
-            print("k=" + str(k) + " v=" + str(v))
-            components.append(k + "=" + shlex.quote(v))
+            components.append(k + "=" + MtreePath.escape(v))
         return " ".join(components)
 
     def __repr__(self) -> str:

--- a/pycheribuild/mtree.py
+++ b/pycheribuild/mtree.py
@@ -50,6 +50,32 @@ class MtreePath(PurePosixPath):
             pathstr = "./" + pathstr
         return pathstr
 
+    @staticmethod
+    def escape(s):
+        # mtree uses strsvis(3) (in the default flavour, in VIS_OCTAL format)
+        # to encode path names containing non-printable characters.
+        # Escape a string according to the VIS_OCTAL rules, also escaping non-printable and glob characters.
+        # Note that multibyte support in strsvis depends on LC_CTYPE.  For now, assume everything is UTF-8.
+        s_dest = ""
+        for i in range(0, len(s)):
+            # split string into Unicode code points
+            c = ord(s[i])
+
+            # if a non-ASCII character, convert to 3 digit octal without the 0o prefix
+            if c < 33 or c > 126 or c == "[" or c == "]" or c == "?" or c == "*":
+                # turn the character into a UTF-8 string of bytes (len(>1) if Unicode)
+                c_utf8 = chr(c).encode("utf-8")
+                # format each byte as an octal string \123
+                for b in c_utf8:
+                    b_octal = format(b, "03o")
+                    s_dest += "\\" + b_octal
+            else:
+                # append an ASCII character
+                s_dest += s[i]
+
+        # return s.upper().replace(" ", "\\s")
+        return s_dest
+
 
 class MtreeEntry:
     def __init__(self, path: MtreePath, attributes: "dict[str, str]"):
@@ -100,14 +126,9 @@ class MtreeEntry:
             return result
 
     def __str__(self) -> str:
-        def escape(s):
-            # mtree uses strsvis(3) (in VIS_CSTYLE format) to encode path names containing non-printable characters.
-            # Note: we only handle spaces here since we haven't seen any other special characters being use. If they do
-            # exist in practise we can just update this code to handle them too.
-            return s.replace(" ", "\\s")
-
-        components = [escape(str(self.path))]
+        components = [MtreePath.escape(str(self.path))]
         for k, v in self.attributes.items():
+            print("k=" + str(k) + " v=" + str(v))
             components.append(k + "=" + shlex.quote(v))
         return " ".join(components)
 
@@ -337,7 +358,7 @@ class MtreeFile:
             else:
                 mtree_type = "file"
                 # now add the actual entry (with contents=/path/to/file)
-                contents_path = str(file.absolute())
+                contents_path = MtreePath.escape(str(file.absolute()))
                 last_attrib = ("contents", contents_path)
         self.add_dir(
             str(Path(path_in_image).parent),

--- a/pycheribuild/mtree.py
+++ b/pycheribuild/mtree.py
@@ -61,7 +61,7 @@ class MtreePath(PurePosixPath):
             # split string into Unicode code points
             c = ord(s[i])
 
-            # if a non-ASCII character, convert to 3 digit octal without the 0o prefix
+            # if a non-ASCII or glob character, convert to 3 digit octal without the 0o prefix
             if c < 33 or c > 126 or c == "[" or c == "]" or c == "?" or c == "*":
                 # turn the character into a UTF-8 string of bytes (len(>1) if Unicode)
                 c_utf8 = chr(c).encode("utf-8")

--- a/pycheribuild/mtree.py
+++ b/pycheribuild/mtree.py
@@ -73,7 +73,6 @@ class MtreePath(PurePosixPath):
                 # append an ASCII character
                 s_dest += s[i]
 
-        # return s.upper().replace(" ", "\\s")
         return s_dest
 
 

--- a/tests/test_metalog.py
+++ b/tests/test_metalog.py
@@ -9,7 +9,7 @@ import pytest
 sys.path.append(str(Path(__file__).parent.parent))
 # The following line triggers a flake8 warning, but ruff is able to ignore the
 # sys.path modification, so silence the ruff warning while we still use flake8.
-from pycheribuild.mtree import MtreeFile  # noqa: E402, RUF100
+from pycheribuild.mtree import MtreeFile, MtreePath  # noqa: E402, RUF100
 
 HAVE_LCHMOD = True
 if "_TEST_SKIP_METALOG" in os.environ:
@@ -271,3 +271,26 @@ def test_symlink_infer_mode(temp_symlink):
 # END
 """
     assert expected == _get_as_str(mtree)
+
+
+# noinspection PyShadowingNames
+def test_path_escape_utf8():
+    input_path = "/foo/bar/ⴰⴻⵓⵍ"  # 'hello' in Tamazight
+    result = MtreePath.escape(input_path)
+    expected = "/foo/bar/" + "\\342\\264\\260\\342\\264\\273\\342\\265\\223\\342\\265\\215"
+    assert expected == result
+
+
+# noinspection PyShadowingNames
+def test_path_escape_brackets():
+    input_path = "/usr/local/riscv64-purecap/share/vim/vim92/lang/menu_chinese(gb)_gb.936.vim"
+    result = MtreePath.escape(input_path)
+    expected = "/usr/local/riscv64-purecap/share/vim/vim92/lang/menu_chinese(gb)_gb.936.vim"
+    assert expected == result
+
+
+def test_path_escape_spaces():
+    input_path = "/hello world.txt"
+    result = MtreePath.escape(input_path)
+    expected = "/hello\\040world.txt"
+    assert expected == result


### PR DESCRIPTION
FreeBSD's mtree file format by default uses the VIS_OCTAL format of
strsvis(3) to escape non-printable characters in filenames, namely
anything not within chars 33-126 or shell globs. Attempt to handle
non-printable characters, including UTF-8, with an escaping function.
Some basic tests are included.

(A comment indicated that the VIS_CSTYLE format should be used, which
encodes whitespace as \t, \n and \s. According to the FreeBSD
mtree(8) manpage, that is only correct when using the 'netbsd6'
flavour of mtree output. Debian's mtree(5) also specifies the
VIS_OCTAL format)