### PR TITLE
Targets for the portable stand-alone variant of the CheriBSD test suite

### DIFF
--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -191,6 +191,10 @@ class _ClangBasedTargetInfo(TargetInfo, ABC):
         return self._compiler_dir / "ld.lld"
 
     @property
+    def objcopy(self) -> Path:
+        return self._compiler_dir / "objcopy"
+
+    @property
     def ar(self) -> Path:
         return self._compiler_dir / "llvm-ar"
 

--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -1705,7 +1705,7 @@ class CompilationTargets(BasicCompilationTargets):
     )
     UPSTREAM_LINUX_AARCH64 = CrossCompileTarget("aarch64", CPUArchitecture.AARCH64, UpstreamLinuxTargetInfo)
     CHERI_LINUX_AARCH64 = CrossCompileTarget("aarch64", CPUArchitecture.AARCH64, CheriLinuxTargetInfo)
-    MORELLO_LINUX_AARCH64 = CrossCompileTarget("aarch64", CPUArchitecture.AARCH64, MorelloLinuxTargetInfo)
+    MORELLO_LINUX_AARCH64 = CrossCompileTarget("legacy-aarch64", CPUArchitecture.AARCH64, MorelloLinuxTargetInfo)
     CHERI_LINUX_MORELLO_PURECAP = CrossCompileTarget(
         "morello-purecap",
         CPUArchitecture.AARCH64,
@@ -1714,8 +1714,12 @@ class CompilationTargets(BasicCompilationTargets):
         check_conflict_with=CHERI_LINUX_AARCH64,
         non_cheri_target=CHERI_LINUX_AARCH64,
     )
+    # This target is kept for historical reasons as Morello Linux (from Arm) was the first Linux kernel
+    # and target that added CHERI support. CHERI-Linux (from CHERI Alliance) has built on top of Morello
+    # Linux to include more features, targets (RISC-V), and is the currently active project and should
+    # be used instead of the following target unless there is a good reason not to.
     MORELLO_LINUX_MORELLO_PURECAP = CrossCompileTarget(
-        "morello-purecap",
+        "legacy-morello-purecap",
         CPUArchitecture.AARCH64,
         MorelloLinuxTargetInfo,
         is_cheri_purecap=True,

--- a/pycheribuild/config/compilation_targets.py
+++ b/pycheribuild/config/compilation_targets.py
@@ -1725,6 +1725,12 @@ class CompilationTargets(BasicCompilationTargets):
         CHERI_LINUX_MORELLO_PURECAP,
     )
     ALL_MORELLO_LINUX_TARGETS = (MORELLO_LINUX_MORELLO_PURECAP, MORELLO_LINUX_AARCH64)
+    ALL_CHERI_AND_MORELLO_LINUX_TARGETS = (*ALL_CHERI_LINUX_TARGETS, *ALL_MORELLO_LINUX_TARGETS)
+    ALL_LINUX_PURECAP_TARGETS = (
+        CHERI_LINUX_RISCV64_PURECAP_093,
+        CHERI_LINUX_MORELLO_PURECAP,
+        MORELLO_LINUX_MORELLO_PURECAP,
+    )
 
     # GCC-based Linux targets (only to be used for the linux-kernel classes for now!)
     # In the future we may want to allow using it for other targets as well, but for now

--- a/pycheribuild/projects/cross/cheri_os_test.py
+++ b/pycheribuild/projects/cross/cheri_os_test.py
@@ -1,0 +1,97 @@
+#
+# Copyright (c) 2025-2026 Paul Metzger
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+
+import os
+import typing
+
+from .crosscompileproject import CrossCompileMakefileProject, DefaultInstallDir, GitRepository, MakeCommandKind
+from ...config.compilation_targets import CompilationTargets, LinuxTargetInfoBase
+from ...utils import classproperty
+
+
+class BuildCheriOSTest(CrossCompileMakefileProject):
+    _supported_architectures = CompilationTargets.ALL_LINUX_PURECAP_TARGETS
+    target = "cheri-os-test"
+    make_kind = MakeCommandKind.BsdMake
+    repository = GitRepository("https://github.com/CTSRD-CHERI/cheri-os-test.git", default_branch="preview")
+
+    @classproperty
+    def default_install_dir(self):
+        return DefaultInstallDir.ROOTFS_LOCALBASE
+
+    @classmethod
+    def dependencies(cls, config) -> "tuple[str, ...]":
+        ti = typing.cast(typing.Type[LinuxTargetInfoBase], cls.get_crosscompile_target().target_info_cls)
+        return ti.musl_target, "libxo", "libbsd"
+
+    def setup(self) -> None:
+        # Don't depend on libgcc_s
+        self.COMMON_LDFLAGS.append("--unwindlib=none")
+
+        return super().setup()
+
+    def compile(self, **kwargs):
+        # The binaries will be put into /opt/cheri-api-tests
+        # This ensures Pyrefly that destdir won't be None
+        assert self.destdir is not None
+        self.destdir = self.destdir / "rootfs" / "opt" / "cheri-os-test"
+        self.makedirs(self.destdir / "lib")
+
+        if self.get_crosscompile_target().is_aarch64(include_purecap=True):
+            self.make_args.set_env(MACHINE_ARCH="aarch64c")
+        elif self.get_crosscompile_target().is_experimental_cheri093_std(self.config):
+            self.make_args.set_env(
+                # The CheriBSD bmake makefiles are not RVY aware and so we need
+                # to manually set MACHINE_ABI and the RISC-V arch string.
+                MACHINE_ABI="purecap",
+                MACHINE_ARCH=self.target_info.get_riscv_arch_string(
+                    self.crosscompile_target, self.config, softfloat=False
+                ),
+            )
+        else:
+            target = self.target_info.target
+            raise NotImplementedError(f"Unsupported architecture: {target.cpu_architecture} {target._cheri_isa}")
+
+        self.make_args.set_env(
+            DESTDIR=str(self.destdir),
+            BINOWN=os.getuid(),
+            BINGRP=os.getgid(),
+            BINMODE=755,
+            # Suppress a warning related to absent exception handlers.
+            LD_FATAL_WARNINGS="no",
+            # This is not supported by Morello LLVM,
+            MAKESYSPATH=str(self.source_dir / "mk"),
+            MAKEOBJDIRPREFIX=str(self.build_dir),
+        )
+
+        self.run_make(cwd=self.source_dir / "cheriostest")
+
+    def install(self, **kwargs):
+        self.run_make_install(cwd=self.source_dir / "cheriostest")
+
+    def process(self):
+        self.check_required_system_tool("bmake", homebrew="bmake", cheribuild_target="bmake")
+        super().process()

--- a/pycheribuild/projects/cross/cheri_os_test.py
+++ b/pycheribuild/projects/cross/cheri_os_test.py
@@ -85,6 +85,8 @@ class BuildCheriOSTest(CrossCompileMakefileProject):
             # This is not supported by Morello LLVM,
             MAKESYSPATH=str(self.source_dir / "mk"),
             MAKEOBJDIRPREFIX=str(self.build_dir),
+            # This property was added to _ClangBasedTargetInfo to support this specific use case.
+            OBJCOPY=self.target_info.objcopy,
         )
 
         self.run_make(cwd=self.source_dir / "cheriostest")

--- a/pycheribuild/projects/cross/cheri_os_test.py
+++ b/pycheribuild/projects/cross/cheri_os_test.py
@@ -25,10 +25,9 @@
 #
 
 import os
-import typing
 
 from .crosscompileproject import CrossCompileMakefileProject, DefaultInstallDir, GitRepository, MakeCommandKind
-from ...config.compilation_targets import CompilationTargets, LinuxTargetInfoBase
+from ...config.compilation_targets import CompilationTargets
 from ...utils import classproperty
 
 
@@ -44,8 +43,7 @@ class BuildCheriOSTest(CrossCompileMakefileProject):
 
     @classmethod
     def dependencies(cls, config) -> "tuple[str, ...]":
-        ti = typing.cast(typing.Type[LinuxTargetInfoBase], cls.get_crosscompile_target().target_info_cls)
-        return ti.musl_target, "libxo", "libbsd"
+        return "libxo", "libbsd"
 
     def setup(self) -> None:
         # Don't depend on libgcc_s

--- a/pycheribuild/projects/cross/libbsd.py
+++ b/pycheribuild/projects/cross/libbsd.py
@@ -1,0 +1,70 @@
+#
+# Copyright (c) 2025-2026 Paul Metzger
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+
+import typing
+
+from .crosscompileproject import CrossCompileAutotoolsProject, DefaultInstallDir, GitRepository, MakeCommandKind
+from ...config.compilation_targets import CompilationTargets, LinuxTargetInfoBase
+from ...utils import classproperty
+
+
+class BuildLibbsd(CrossCompileAutotoolsProject):
+    _can_use_autogen_sh = True
+    _supported_architectures = CompilationTargets.ALL_CHERI_AND_MORELLO_LINUX_TARGETS
+    make_kind = MakeCommandKind.GnuMake
+    repository = GitRepository(
+        "https://gitlab.freedesktop.org/libbsd/libbsd.git",
+        temporary_url_override="https://gitlab.freedesktop.org/paul-metzger/libbsd-private-fork-pmetzger.git",
+        default_branch="0_12_2_with_alignment_macro_fix",
+        force_branch=True,
+    )
+
+    @classproperty
+    def default_install_dir(self):
+        return DefaultInstallDir.ROOTFS_LOCALBASE
+
+    @classmethod
+    def dependencies(cls, config) -> "tuple[str, ...]":
+        ti = typing.cast(typing.Type[LinuxTargetInfoBase], cls.get_crosscompile_target().target_info_cls)
+        return ti.musl_target, "libmd"
+
+    def configure(self, **kwargs):
+        self.run_cmd(self.source_dir / "autogen", cwd=self.source_dir)
+        super().configure(**kwargs)
+
+    def setup(self) -> None:
+        super().setup()
+        # Remove dependency on libgcc_eh
+        self.COMMON_LDFLAGS.append("--unwindlib=none")
+        # Remove dependcy on libgcc_s
+        self.COMMON_LDFLAGS.append("-Wc,--unwindlib=none")
+
+    def install(self, **kwargs) -> None:
+        self.run_make_install()
+
+        # Copy the libraries from the cross-compile sysroot into rootfs/lib
+        for sofile in self.install_dir.glob("lib/libbsd.so*"):
+            self.install_file(sofile, self.install_dir / "rootfs/lib/" / sofile.name, create_dirs=True)

--- a/pycheribuild/projects/cross/libbsd.py
+++ b/pycheribuild/projects/cross/libbsd.py
@@ -24,10 +24,8 @@
 # SUCH DAMAGE.
 #
 
-import typing
-
 from .crosscompileproject import CrossCompileAutotoolsProject, DefaultInstallDir, GitRepository, MakeCommandKind
-from ...config.compilation_targets import CompilationTargets, LinuxTargetInfoBase
+from ...config.compilation_targets import CompilationTargets
 from ...utils import classproperty
 
 
@@ -48,8 +46,7 @@ class BuildLibbsd(CrossCompileAutotoolsProject):
 
     @classmethod
     def dependencies(cls, config) -> "tuple[str, ...]":
-        ti = typing.cast(typing.Type[LinuxTargetInfoBase], cls.get_crosscompile_target().target_info_cls)
-        return ti.musl_target, "libmd"
+        return ("libmd",)
 
     def configure(self, **kwargs):
         self.run_cmd(self.source_dir / "autogen", cwd=self.source_dir)

--- a/pycheribuild/projects/cross/libmd.py
+++ b/pycheribuild/projects/cross/libmd.py
@@ -24,10 +24,8 @@
 # SUCH DAMAGE.
 #
 
-import typing
-
 from .crosscompileproject import CrossCompileAutotoolsProject, DefaultInstallDir, GitRepository, MakeCommandKind
-from ...config.compilation_targets import CompilationTargets, LinuxTargetInfoBase
+from ...config.compilation_targets import CompilationTargets
 from ...utils import classproperty
 
 
@@ -40,11 +38,6 @@ class BuildLibmd(CrossCompileAutotoolsProject):
     @classproperty
     def default_install_dir(self):
         return DefaultInstallDir.ROOTFS_LOCALBASE
-
-    @classmethod
-    def dependencies(cls, config) -> "tuple[str, ...]":
-        ti = typing.cast(typing.Type[LinuxTargetInfoBase], cls.get_crosscompile_target().target_info_cls)
-        return (ti.musl_target,)
 
     def configure(self, **kwargs):
         self.run_cmd(self.source_dir / "autogen", cwd=self.source_dir)

--- a/pycheribuild/projects/cross/libmd.py
+++ b/pycheribuild/projects/cross/libmd.py
@@ -1,0 +1,65 @@
+#
+# Copyright (c) 2025-2026 Paul Metzger
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+
+import typing
+
+from .crosscompileproject import CrossCompileAutotoolsProject, DefaultInstallDir, GitRepository, MakeCommandKind
+from ...config.compilation_targets import CompilationTargets, LinuxTargetInfoBase
+from ...utils import classproperty
+
+
+class BuildLibmd(CrossCompileAutotoolsProject):
+    _can_use_autogen_sh = True
+    _supported_architectures = CompilationTargets.ALL_CHERI_AND_MORELLO_LINUX_TARGETS
+    make_kind = MakeCommandKind.GnuMake
+    repository = GitRepository("https://git.hadrons.org/git/libmd.git")
+
+    @classproperty
+    def default_install_dir(self):
+        return DefaultInstallDir.ROOTFS_LOCALBASE
+
+    @classmethod
+    def dependencies(cls, config) -> "tuple[str, ...]":
+        ti = typing.cast(typing.Type[LinuxTargetInfoBase], cls.get_crosscompile_target().target_info_cls)
+        return (ti.musl_target,)
+
+    def configure(self, **kwargs):
+        self.run_cmd(self.source_dir / "autogen", cwd=self.source_dir)
+        super().configure(**kwargs)
+
+    def setup(self) -> None:
+        super().setup()
+        # Remove dependency on libgcc_eh
+        self.COMMON_LDFLAGS.append("--unwindlib=none")
+        # Remove dependcy on libgcc_s
+        self.COMMON_LDFLAGS.append("-Wc,--unwindlib=none")
+
+    def install(self, **kwargs) -> None:
+        super().install(**kwargs)
+
+        # Copy the libraries from the cross-compile sysroot into rootfs/lib
+        for sofile in self.install_dir.glob("lib/libmd.so*"):
+            self.install_file(sofile, self.install_dir / "rootfs/lib/" / sofile.name, create_dirs=True)

--- a/pycheribuild/projects/cross/libxo.py
+++ b/pycheribuild/projects/cross/libxo.py
@@ -24,10 +24,8 @@
 # SUCH DAMAGE.
 #
 
-import typing
-
 from .crosscompileproject import CrossCompileAutotoolsProject, DefaultInstallDir, GitRepository, MakeCommandKind
-from ...config.compilation_targets import CompilationTargets, LinuxTargetInfoBase
+from ...config.compilation_targets import CompilationTargets
 from ...utils import classproperty
 
 
@@ -43,8 +41,7 @@ class BuildLibxo(CrossCompileAutotoolsProject):
 
     @classmethod
     def dependencies(cls, config) -> "tuple[str, ...]":
-        ti = typing.cast(typing.Type[LinuxTargetInfoBase], cls.get_crosscompile_target().target_info_cls)
-        return ti.musl_target, "libbsd", "libmd"
+        return "libbsd", "libmd"
 
     def _patch_to_use_libbsd(self, path):
         self.run_cmd("sed", "-i", "s|<sys/queue.h>|<bsd/sys/queue.h>|g", path, cwd=self.source_dir)

--- a/pycheribuild/projects/cross/libxo.py
+++ b/pycheribuild/projects/cross/libxo.py
@@ -1,0 +1,83 @@
+#
+# Copyright (c) 2025-2026 Paul Metzger
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+
+import typing
+
+from .crosscompileproject import CrossCompileAutotoolsProject, DefaultInstallDir, GitRepository, MakeCommandKind
+from ...config.compilation_targets import CompilationTargets, LinuxTargetInfoBase
+from ...utils import classproperty
+
+
+class BuildLibxo(CrossCompileAutotoolsProject):
+    _can_use_autogen_sh = True
+    _supported_architectures = CompilationTargets.ALL_CHERI_AND_MORELLO_LINUX_TARGETS
+    make_kind = MakeCommandKind.GnuMake
+    repository = GitRepository("https://github.com/Juniper/libxo.git")
+
+    @classproperty
+    def default_install_dir(self):
+        return DefaultInstallDir.ROOTFS_LOCALBASE
+
+    @classmethod
+    def dependencies(cls, config) -> "tuple[str, ...]":
+        ti = typing.cast(typing.Type[LinuxTargetInfoBase], cls.get_crosscompile_target().target_info_cls)
+        return ti.musl_target, "libbsd", "libmd"
+
+    def _patch_to_use_libbsd(self, path):
+        self.run_cmd("sed", "-i", "s|<sys/queue.h>|<bsd/sys/queue.h>|g", path, cwd=self.source_dir)
+
+    def _patch_includes(self) -> None:
+        self._patch_to_use_libbsd("libxo/xo_encoder.c")
+        self._patch_to_use_libbsd("xopo/xopo.c")
+
+    def _patch_configure_ac(self) -> None:
+        # These tests fail due to cross-compilation issues. Muslc's malloc
+        # and realloc return a pointer when passed a size of zero.
+        self.configure_args.append("ac_cv_func_realloc_0_nonnull=yes")
+        self.configure_args.append("ac_cv_func_malloc_0_nonnull=yes")
+
+    def configure(self, **kwargs):
+        # Don't depend on libgcc_s. If this isn't set then clang wants to link
+        # with libgcc_s, which is not available on Morello Linux.
+        self.LDFLAGS.append("--unwindlib=none")
+        # This prompts libtool to pass '--unwindlib=none' to clang during
+        # linking. Libtool ignores "--unwindlib=none" and needs
+        # "-Wc,--unwindlib=none" instead. "-Wc,--unwindlib=none" is turned
+        # into "--unwindlib=none" by libtool when it invokes clang.
+        self.CFLAGS.append("-Wc,--unwindlib=none")
+
+        self._patch_configure_ac()
+        self._patch_includes()
+        self.run_shell_script("sh bin/setup.sh", shell="sh", cwd=self.source_dir)
+
+        super().configure(**kwargs)
+
+    def install(self, **kwargs) -> None:
+        self.run_make_install()
+
+        # Copy the libraries from the cross-compile sysroot into rootfs/lib
+        for sofile in self.install_dir.glob("lib/libxo.so*"):
+            self.install_file(sofile, self.install_dir / "rootfs/lib/" / sofile.name, create_dirs=True)

--- a/pycheribuild/projects/cross/linux.py
+++ b/pycheribuild/projects/cross/linux.py
@@ -172,7 +172,7 @@ class BuildLinux(CrossCompileAutotoolsProject):
 
 class BuildCheriAllianceLinux(BuildLinux):
     target = "linux-kernel"
-    repository = GitRepository("https://github.com/CHERI-Alliance/linux.git", default_branch="codasip-cheri-riscv-6.18")
+    repository = GitRepository("https://github.com/CHERI-Alliance/linux.git", default_branch="cambridge-morello-7.0")
     _supported_architectures = (
         *CompilationTargets.ALL_CHERI_LINUX_TARGETS,
         CompilationTargets.LINUX_KERNEL_RISCV64_GCC,

--- a/pycheribuild/projects/simple_project.py
+++ b/pycheribuild/projects/simple_project.py
@@ -885,6 +885,11 @@ class SimpleProjectBase(AbstractProject, ABC):
 
     # noinspection PyPep8Naming
     @property
+    def OBJCOPY(self) -> Path:  # noqa: N802
+        return self.target_info.objcopy
+
+    # noinspection PyPep8Naming
+    @property
     def host_CC(self) -> Path:  # noqa: N802
         return TargetInfo.host_c_compiler(self.config)
 


### PR DESCRIPTION
Supersedes [#479](https://github.com/CTSRD-CHERI/cheribuild/pull/479), which was automatically closed when the source branch was renamed.
I renamed the source branch from `cheritest` to `cheriostest`, as someone struggled to find it when looking for a branch with the cheriostest cheribuild targets.