### PR TITLE
Fix AttributeError due to shutil.which fallback in get_matching_binutil

### DIFF
--- a/pycheribuild/processutils.py
+++ b/pycheribuild/processutils.py
@@ -723,7 +723,9 @@ class CompilerInfo:
                 warning_message("Could not find", binutil, "in expected path", result)
                 result = None
         if not result:
-            result = shutil.which(binutil)  # fall back to the default and assume clang can find the right one
+            fallback = shutil.which(binutil)  # fall back to the default and assume clang can find the right one
+            if fallback:
+                result = Path(fallback)
         return result
 
     @property


### PR DESCRIPTION
This bug is triggered when a user provides a custom compiler path:(e.g., via --clang-path /custom/bin/clang) that does not have the corresponding linker (e.g., ld.lld) in the exact same directory. When this happens, get_matching_binutil falls back to searching the system PATH using shutil.which.

However, shutil.which() returns a raw string. When the build system subsequently tries to configure Link Time Optimization (LTO) flags, linker_override_flags attempts to access the .suffix property on the returned value. Since strings do not have a .suffix property, an AttributeError is raised, crashing the build.

Fix the issue by explicitly wrapping the return value of shutil.which in a Path object before returning it, matching the function's type hint and the expectations of its callers.