### PR TITLE
qemu: no longer make smbd a hard dependency by default

### DIFF
--- a/pycheribuild/projects/build_qemu.py
+++ b/pycheribuild/projects/build_qemu.py
@@ -48,7 +48,7 @@ from .project import (
     MakeCommandKind,
     Project,
 )
-from .simple_project import BoolConfigOption, SimpleProject
+from .simple_project import BoolConfigOption, OptionalBoolConfigOption, SimpleProject
 from ..config.compilation_targets import BaremetalFreestandingTargetInfo, CompilationTargets
 from ..config.config_loader_base import ConfigOptionHandle
 from ..processutils import cached_get_homebrew_prefix
@@ -71,12 +71,11 @@ class BuildQEMUBase(AutotoolsProject):
     lto_compiler_flags_need_linker_flags = True
     qemu_targets: "str"
 
-    use_smbd = BoolConfigOption(
+    use_smbd = OptionalBoolConfigOption(
         "use-smbd",
         show_help=False,
-        default=True,
-        help="Don't require SMB support when building QEMU (warning: most --test "
-        "targets will fail without smbd support)",
+        default=None,
+        help="Enable SMB support in QEMU. If unset, it is enabled automatically if a usable smbd is found.",
     )
     gui = BoolConfigOption(
         "gui",
@@ -332,7 +331,7 @@ class BuildQEMUBase(AutotoolsProject):
             self.configure_args.append("--extra-cxxflags=" + self.commandline_to_str(cxxflags))
 
     @staticmethod
-    def find_smbd_binary(config: CheriConfig) -> Path:
+    def guessed_smbd_path(config: CheriConfig) -> Path:
         guess = Path("/usr/sbin/smbd")
         if OSInfo.IS_FREEBSD:
             guess = Path("/usr/local/sbin/smbd")
@@ -347,6 +346,44 @@ class BuildQEMUBase(AutotoolsProject):
             guess = config.other_tools_dir / "sbin/smbd"
         return guess
 
+    def find_smbd(self) -> "Optional[Path]":
+        if self.use_smbd is False:
+            return None
+        smbd_path = self.guessed_smbd_path(self.config)
+        smbd_found = smbd_path.exists()
+        if self.use_smbd is None and not smbd_found:
+            # Auto-detect mode and no usable smbd was found -> silently don't enable SMB support.
+            self.info(
+                f"Could not find smbd -> not enabling QEMU SMB shares support. Set --{self.target}/use-smbd to force."
+            )
+            return None
+        self.info("Guessed samba path", smbd_path)
+        if not smbd_found:
+            if self.target_info.is_macos():
+                # QEMU user networking expects a smbd that accepts the same flags and config files as the
+                # samba.org sources but the macOS /usr/sbin/smbd is incompatible with that:
+                self.warning(
+                    "QEMU user-mode samba shares require the samba.org smbd. You will need to install it "
+                    "using homebrew (`brew install samba`) or build from source (`cheribuild.py samba`) "
+                    "since the /usr/sbin/smbd shipped by macOS is incompatible with QEMU",
+                )
+            self.dependency_error(
+                "Could not find smbd -> QEMU SMB shares networking will not work",
+                install_instructions=OSInfo.install_instructions(
+                    "smbd",
+                    is_lib=False,
+                    freebsd="samba416",
+                    apt="samba",
+                    homebrew="samba",
+                    cheribuild_target="samba",
+                    alternative="if you really don't need QEMU host shares you can disable the samba "
+                    "dependency by setting --" + self.target + "/no-use-smbd",
+                ),
+                cheribuild_target="samba",
+                cheribuild_xtarget=CompilationTargets.NATIVE,
+            )
+        return smbd_path
+
     def configure(self, **kwargs):
         # We call this here instead of inside setup to make sure the repository has been cloned
         if self.repository.contains_commit(self, "5890258aeeba303704ec1adca415e46067800777", src_dir=self.source_dir):
@@ -357,32 +394,9 @@ class BuildQEMUBase(AutotoolsProject):
         else:
             self.configure_args.append("--enable-slirp=git")
 
-        if self.use_smbd:
-            smbd_path = self.find_smbd_binary(self.config)
-            self.info("Guessed samba path", smbd_path)
+        smbd_path = self.find_smbd()
+        if smbd_path is not None:
             self.configure_args.append("--smbd=" + str(smbd_path))
-            if not smbd_path.exists():
-                if self.target_info.is_macos():
-                    # QEMU user networking expects a smbd that accepts the same flags and config files as the samba.org
-                    # sources but the macOS /usr/sbin/smbd is incompatible with that:
-                    self.warning(
-                        "QEMU user-mode samba shares require the samba.org smbd. You will need to install it "
-                        "using homebrew (`brew install samba`) or build from source (`cheribuild.py samba`) "
-                        "since the /usr/sbin/smbd shipped by macOS is incompatible with QEMU",
-                    )
-                self.fatal(
-                    "Could not find smbd -> QEMU SMB shares networking will not work",
-                    fixit_hint="Either install samba using the system package manager or with cheribuild. "
-                    "If you really don't need QEMU host shares you can disable the samba dependency "
-                    "by setting --" + self.target + "/no-use-smbd",
-                )
-            self.check_required_system_tool(
-                str(smbd_path),
-                cheribuild_target="samba",
-                freebsd="samba416",
-                apt="samba",
-                homebrew="samba",
-            )
 
         chosen_targets = self.qemu_targets
         qemu_targets_option = typing.cast(ConfigOptionHandle, inspect.getattr_static(self, "qemu_targets"))

--- a/pycheribuild/projects/run_qemu.py
+++ b/pycheribuild/projects/run_qemu.py
@@ -477,7 +477,7 @@ class LaunchQEMUBase(SimpleProject):
         have_9pfs_support = qemu_supports_9pfs(self.chosen_qemu.binary, config=self.config)
         # Only default to providing the smb mount if smbd exists
         have_smbfs_support = (
-            self.chosen_qemu.can_provide_src_via_smb and BuildQEMU.find_smbd_binary(self.config).exists()
+            self.chosen_qemu.can_provide_src_via_smb and BuildQEMU.guessed_smbd_path(self.config).exists()
         )
 
         def add_smb_or_9p_dir(directory, target, share_name=None, readonly=False):

--- a/pycheribuild/projects/simple_project.py
+++ b/pycheribuild/projects/simple_project.py
@@ -166,6 +166,15 @@ if typing.TYPE_CHECKING:
         return typing.cast(bool, default)
 
     # noinspection PyPep8Naming
+    def OptionalBoolConfigOption(  # noqa: N802
+        name: str,
+        help: str,
+        default: "typing.Union[Optional[bool], ComputedDefaultValue[Optional[bool]]]" = None,
+        **kwargs,
+    ) -> "Optional[bool]":
+        return typing.cast(Optional[bool], default)
+
+    # noinspection PyPep8Naming
     def EnumConfigOption(  # noqa: N802
         name: str,
         help: str,
@@ -279,6 +288,24 @@ else:
             return typing.cast(
                 ConfigOptionHandle,
                 owner.add_bool_option(self._name, default=self._default, help=self._help, **self._kwargs, **kwargs),
+            )
+
+    class OptionalBoolConfigOption(PerProjectConfigOption[Optional[bool]]):
+        def __init__(
+            self,
+            name: str,
+            help: str,
+            default: "typing.Union[Optional[bool], ComputedDefaultValue[Optional[bool]]]" = None,
+            **kwargs,
+        ):
+            super().__init__(name, help, default, **kwargs)
+
+        def register_config_option(self, owner: "type[SimpleProjectBase]", **kwargs) -> ConfigOptionHandle:
+            return typing.cast(
+                ConfigOptionHandle,
+                owner.add_config_option(
+                    self._name, default=self._default, help=self._help, kind=bool, **self._kwargs, **kwargs
+                ),
             )
 
     class EnumConfigOption(PerProjectConfigOption[EnumTy], typing.Generic[EnumTy]):

--- a/tests/test_argument_parsing.py
+++ b/tests/test_argument_parsing.py
@@ -21,6 +21,7 @@ from pycheribuild.jenkins_utils import jenkins_override_install_dirs_hack
 
 # noinspection PyUnresolvedReferences
 from pycheribuild.projects import *  # noqa: F401, F403, RUF100
+from pycheribuild.projects.build_qemu import BuildQEMU
 from pycheribuild.projects.cross import *  # noqa: F401, F403, RUF100
 from pycheribuild.projects.cross.cheribsd import (
     BuildCHERIBSD,
@@ -115,6 +116,52 @@ def test_skip_update():
         # command line overrides config file:
         assert _parse_arguments(["--skip-update"], config_file=config).skip_update
         assert not _parse_arguments(["--no-skip-update"], config_file=config).skip_update
+
+
+def test_qemu_use_smbd(monkeypatch):
+    fake_smbd_path = Path("/fake/path/to/smbd")
+
+    def find_smbd_and_capture(cmdline_args, *, smbd_exists):
+        qemu = _get_target_instance("qemu", _parse_arguments(cmdline_args), BuildQEMU)
+        monkeypatch.setattr(qemu, "guessed_smbd_path", lambda _config: fake_smbd_path)
+        # Only fake the existence check for our fake smbd path, everything else (e.g. config files
+        # loaded by _parse_arguments()) should still behave normally:
+        real_path_exists = Path.exists
+        monkeypatch.setattr(Path, "exists", lambda p: smbd_exists if p == fake_smbd_path else real_path_exists(p))
+
+        recorded_dependency_error_calls = []
+        monkeypatch.setattr(
+            qemu, "dependency_error", lambda *call_args, **kwargs: recorded_dependency_error_calls.append(kwargs)
+        )
+        smbd_path = qemu.find_smbd()
+        return smbd_path, recorded_dependency_error_calls
+
+    # Default (auto-detect) mode with no usable smbd found: silently skip, no error.
+    result, dependency_error_calls = find_smbd_and_capture([], smbd_exists=False)
+    assert result is None
+    assert dependency_error_calls == []
+
+    # Default (auto-detect) mode with a usable smbd found: use it, no error.
+    result, dependency_error_calls = find_smbd_and_capture([], smbd_exists=True)
+    assert result == fake_smbd_path
+    assert dependency_error_calls == []
+
+    # --no-use-smbd: smbd is disabled entirely, we don't even try to find it, no error.
+    result, dependency_error_calls = find_smbd_and_capture(["--qemu/no-use-smbd"], smbd_exists=True)
+    assert result is None
+    assert dependency_error_calls == []
+
+    # --use-smbd: force enable -> a path is always returned, but if no usable smbd could be found this is reported via
+    # dependency_error() and cheribuild's "samba" target is offered as an install option.
+    result, dependency_error_calls = find_smbd_and_capture(["--qemu/use-smbd"], smbd_exists=False)
+    assert result == fake_smbd_path
+    assert len(dependency_error_calls) == 1
+    assert dependency_error_calls[0]["cheribuild_target"] == "samba"
+
+    # --use-smbd with a usable smbd present: no error/warning.
+    result, dependency_error_calls = find_smbd_and_capture(["--qemu/use-smbd"], smbd_exists=True)
+    assert result == fake_smbd_path
+    assert dependency_error_calls == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
We now support p9fs on all supported operating systems, so instead of making smbd a hard requirement, only enable it if a usable version was found. I recently started using a new system without samba installed and getting build errors in QEMU by default is not a nice UX considering SMBD is not strictly required any more.