### PR TITLE
vim: Install real files, not symlink farm

### DIFF
--- a/pycheribuild/projects/cross/vim.py
+++ b/pycheribuild/projects/cross/vim.py
@@ -34,6 +34,8 @@ class BuildVim(CrossCompileAutotoolsProject):
     def setup(self):
         super().setup()
         self.configure_args.extend(["--disable-gui", "--without-x"])
+        self.make_args.set(INSTALL_DATA_R="cp -rL")
+
         if self.compiling_for_cheri():
             # Options storage uses void * with some longs stuffed in
             # TODO: Upstream using intptr_t?


### PR DESCRIPTION
vim's build uses the build_via_symlink_farm flag, to make a build tree that symlinks back to the source repository as it doesn't officially support out of tree builds.  Force its build to copy the real files during 'make install' rather than copying verbatim the symlinks from the farm.