### PR TITLE
ltp: fix new CI failure

### DIFF
--- a/pycheribuild/projects/cross/ltp.py
+++ b/pycheribuild/projects/cross/ltp.py
@@ -65,8 +65,8 @@ class BuildLTP(CrossCompileAutotoolsProject):
 
     def install(self) -> None:
         compflags = [*self.essential_compiler_and_linker_flags]
-        compflags += ["--sysroot", self.install_dir]
-        compflags += ["-isystem", self.install_dir / "usr/include"]
+        compflags += ["--sysroot", str(self.install_dir)]
+        compflags += ["-isystem", str(self.install_dir / "usr/include")]
         # Avoid dependency on libgcc_eh
         compflags += ["--unwindlib=none"]
         self.COMMON_LDFLAGS.append("--unwindlib=none")


### PR DESCRIPTION
This fixes the following new failure:

```
  ty check
  shell: /bin/bash -e {0}
  env:
    RUFF_VERSION: 0.15.11
    PYREFLY_VERSION: 0.62.0
    TY_VERSION: 0.0.32
error[unsupported-operator]: Unsupported `+=` operation
  --> pycheribuild/projects/cross/ltp.py:68:9
   |
68 |         compflags += ["--sysroot", self.install_dir]
   |         ---------^^^^-------------------------------
   |         |            |
   |         |            Has type `list[str | Path]`
   |         Has type `list[str]`
   |
```