### PR TITLE
Add a (temporary) target for the CMake build of cheri-os-test

### DIFF
--- a/pycheribuild/projects/cross/cheri_os_test.py
+++ b/pycheribuild/projects/cross/cheri_os_test.py
@@ -43,7 +43,7 @@ class BuildCheriOSTest(CrossCompileMakefileProject):
     )
     target = "cheri-os-test"
     make_kind = MakeCommandKind.BsdMake
-    repository = GitRepository("https://github.com/CTSRD-CHERI/cheri-os-test.git", default_branch="preview")
+    repository = GitRepository("https://github.com/CTSRD-CHERI/cheri-os-test.git", default_branch="dev")
 
     @classproperty
     def default_install_dir(self):
@@ -78,10 +78,18 @@ class BuildCheriOSTest(CrossCompileMakefileProject):
                 MACHINE_ARCH=self.target_info.get_riscv_arch_string(
                     self.crosscompile_target, self.config, softfloat=False
                 ),
+                MACHINE="riscv",
             )
         else:
             target = self.target_info.target
             raise NotImplementedError(f"Unsupported architecture: {target.cpu_architecture} {target._cheri_isa}")
+
+        if self.target_info.is_freebsd():
+            self.make_args.set(TARGET_OS="FreeBSD")
+        elif self.target_info.is_linux():
+            self.make_args.set(TARGET_OS="FreeBSD")
+        else:
+            raise NotImplementedError(f"Unsupported target OS: {self.target_info.shortname}")
 
         self.make_args.set_env(
             DESTDIR=str(self.destdir),

--- a/pycheribuild/projects/cross/cheri_os_test.py
+++ b/pycheribuild/projects/cross/cheri_os_test.py
@@ -26,13 +26,21 @@
 
 import os
 
-from .crosscompileproject import CrossCompileMakefileProject, DefaultInstallDir, GitRepository, MakeCommandKind
+from .crosscompileproject import (
+    CrossCompileCMakeProject,
+    CrossCompileMakefileProject,
+    DefaultInstallDir,
+    GitRepository,
+    MakeCommandKind,
+)
 from ...config.compilation_targets import CompilationTargets
 from ...utils import classproperty
 
 
 class BuildCheriOSTest(CrossCompileMakefileProject):
-    _supported_architectures = CompilationTargets.ALL_LINUX_PURECAP_TARGETS
+    _supported_architectures = (
+        CompilationTargets.ALL_LINUX_PURECAP_TARGETS + CompilationTargets.ALL_CHERIBSD_PURECAP_TARGETS
+    )
     target = "cheri-os-test"
     make_kind = MakeCommandKind.BsdMake
     repository = GitRepository("https://github.com/CTSRD-CHERI/cheri-os-test.git", default_branch="preview")
@@ -43,6 +51,8 @@ class BuildCheriOSTest(CrossCompileMakefileProject):
 
     @classmethod
     def dependencies(cls, config) -> "tuple[str, ...]":
+        if cls.get_crosscompile_target().target_info_cls.is_freebsd():
+            return ()  # No need for extra libraries
         return "libxo", "libbsd"
 
     def setup(self) -> None:
@@ -60,7 +70,7 @@ class BuildCheriOSTest(CrossCompileMakefileProject):
 
         if self.get_crosscompile_target().is_aarch64(include_purecap=True):
             self.make_args.set_env(MACHINE_ARCH="aarch64c")
-        elif self.get_crosscompile_target().is_experimental_cheri093_std(self.config):
+        elif self.get_crosscompile_target().is_riscv(include_purecap=True):
             self.make_args.set_env(
                 # The CheriBSD bmake makefiles are not RVY aware and so we need
                 # to manually set MACHINE_ABI and the RISC-V arch string.
@@ -95,3 +105,22 @@ class BuildCheriOSTest(CrossCompileMakefileProject):
     def process(self):
         self.check_required_system_tool("bmake", homebrew="bmake", cheribuild_target="bmake")
         super().process()
+
+
+class BuildCheriOSTestCmake(CrossCompileCMakeProject):
+    _supported_architectures = (
+        CompilationTargets.ALL_LINUX_PURECAP_TARGETS + CompilationTargets.ALL_CHERIBSD_PURECAP_TARGETS
+    )
+    target = "cheri-os-test-cmake"
+    repository = GitRepository(
+        "https://github.com/CTSRD-CHERI/cheri-os-test.git",
+        default_branch="dev",
+        temporary_url_override="https://github.com/arichardson/cheri-os-test.git",
+        url_override_reason="Add CMake build system and CheriBSD fixes",
+    )
+
+    @classmethod
+    def dependencies(cls, config) -> "tuple[str, ...]":
+        if cls.get_crosscompile_target().target_info_cls.is_freebsd():
+            return ()  # No need for extra libraries
+        return "libxo", "libbsd"


### PR DESCRIPTION
Most tests should pass with `cheribuild.py cheri-os-test-cmake-riscv64-purecap --clean --build-and-test`, but there are some known failures for the hybrid case.