### PR TITLE
libxo 2.0 treats some failing configure tests as errors

### DIFF
--- a/pycheribuild/projects/cross/libxo.py
+++ b/pycheribuild/projects/cross/libxo.py
@@ -38,7 +38,7 @@ class BuildLibxo(CrossCompileAutotoolsProject):
         # Version 2.0 treats failing libint- and msgfmt-related
         # tests performed by configure as errors. As a
         # temporary workaround, stay with the preceding version.
-        default_branch="1.7.5",
+        force_tag="1.7.5",
     )
 
     @classproperty

--- a/pycheribuild/projects/cross/libxo.py
+++ b/pycheribuild/projects/cross/libxo.py
@@ -33,7 +33,13 @@ from ...utils import classproperty
 class BuildLibxo(CrossCompileAutotoolsProject):
     _supported_architectures = CompilationTargets.ALL_CHERI_AND_MORELLO_LINUX_TARGETS
     make_kind = MakeCommandKind.GnuMake
-    repository = GitRepository("https://github.com/Juniper/libxo.git")
+    repository = GitRepository(
+        "https://github.com/Juniper/libxo.git",
+        # Version 2.0 treats failing libint- and msgfmt-related
+        # tests performed by configure as errors. As a
+        # temporary workaround, stay with the preceding version.
+        default_branch="1.7.5",
+    )
 
     @classproperty
     def default_install_dir(self):

--- a/pycheribuild/projects/cross/libxo.py
+++ b/pycheribuild/projects/cross/libxo.py
@@ -69,6 +69,11 @@ class BuildLibxo(CrossCompileAutotoolsProject):
         self.CFLAGS.append(str(self.build_dir / "libbsd-workaround"))
 
     def configure(self, **kwargs):
+        # setup.sh does not re-run autoreconf if the 'configure' file exists,
+        # which creates problems when switching between branches and tags.
+        if self.configure_command is not None and self.configure_command.exists():
+            self.delete_file(self.configure_command)
+
         self.run_shell_script("sh bin/setup.sh", shell="sh", cwd=self.source_dir)
         self.makedirs(self.build_dir / "libbsd-workaround/sys")
         self.create_symlink(

--- a/pycheribuild/projects/repository.py
+++ b/pycheribuild/projects/repository.py
@@ -187,6 +187,7 @@ class GitRepository(SourceRepository):
         old_urls: "Optional[list[str]]" = None,
         default_branch: "Optional[str]" = None,
         force_branch: bool = False,
+        force_tag: Optional[str] = None,
         temporary_url_override: "Optional[str]" = None,
         url_override_reason: "typing.Any" = None,
         per_target_branches: "Optional[dict[CrossCompileTarget, TargetBranchInfo]]" = None,
@@ -205,6 +206,7 @@ class GitRepository(SourceRepository):
             self.url = url
         self._default_branch = default_branch
         self.force_branch = force_branch
+        self.force_tag = force_tag
         if per_target_branches is None:
             per_target_branches = dict()
         self.per_target_branches = per_target_branches
@@ -419,7 +421,11 @@ class GitRepository(SourceRepository):
                 clone_cmd.extend(["--depth", "1", "--no-single-branch"])
             if not skip_submodules:
                 clone_cmd.append("--recurse-submodules")
-            clone_branch = self.get_default_branch(current_project, include_per_target=False)
+            if self.force_tag:
+                # --branch supports tags since at least git 2.0.5
+                clone_branch = self.force_tag
+            else:
+                clone_branch = self.get_default_branch(current_project, include_per_target=False)
             if clone_branch:
                 clone_cmd += ["--branch", clone_branch]
             current_project.run_cmd([*clone_cmd, self.url, base_project_source_dir], cwd="/")
@@ -879,6 +885,34 @@ class GitRepository(SourceRepository):
         rebase_flag = "--rebase=merges" if git_version >= (2, 18) else "--rebase=preserve"
         current_project.run_cmd([*pull_cmd, rebase_flag], cwd=src_dir, print_verbose_only=True)
 
+    @staticmethod
+    def is_target_tag(current_project: "Project", src_dir: Path, tag: str):
+        desc = current_project.run_cmd(
+            ["git", "describe", "--exact-match", "--tags", "HEAD"],
+            allow_unexpected_returncode=True,
+            capture_output=True,
+            capture_error=True,
+            cwd=src_dir,
+            run_in_pretend_mode=_PRETEND_RUN_GIT_COMMANDS,
+        )
+        if desc.returncode == 0 and desc.stdout.decode("utf-8").strip() == tag:
+            return True
+        return False
+
+    def _handle_tag_switch(self, current_project: "Project", src_dir: Path):
+        # It is possible to switch from a tag to a branch by setting 'default_branch'
+        # and 'force_branch'. The logic for this is implemented by _handle_branch_switch().
+
+        if self.force_tag and self.is_target_tag(current_project, src_dir, self.force_tag):
+            return
+
+        if not current_project.query_yes_no("Update to correct tag?"):
+            return
+
+        if self.force_tag:
+            current_project.run_cmd(["git", "fetch", "--tags"], cwd=src_dir)
+            current_project.run_cmd(["git", "checkout", self.force_tag], cwd=src_dir)
+
     def update(
         self,
         current_project: "Project",
@@ -905,6 +939,8 @@ class GitRepository(SourceRepository):
         # Handle forced branches before fetching, so we don't try to fetch from a broken
         # remote if we are about to switch branches anyway.
         self._handle_branch_switch(current_project, src_dir)
+
+        self._handle_tag_switch(current_project, src_dir)
 
         # First fetch all the current upstream branch to see if we need to autostash/pull.
         # Note: "git fetch" without other arguments will fetch from the currently configured upstream.


### PR DESCRIPTION
Some failing configure tests related to `gettext()` functions and `msgfmt` are now treated as errors by version 2.0.0. As a fix does not appear to be straight forward, use the preceding version 1.7.5 instead for now to allow others to continue using cheriostest.