### PR TITLE
Jenkins CI: update runs to supported baselines

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -26,7 +26,7 @@ jobs:
                 run: |
                     # Run as a non-root user to avoid cheribuild errors
                     adduser --disabled-password --gecos "Not Root" notroot
-                    su -c "python3 -m pip install --user --upgrade pip pytest pytest-xdist" notroot
+                    su -c "python3 -m pip install --user --upgrade --break-system-packages pip pytest pytest-xdist" notroot
             -   name: Run basic regression tests
                 run: su -c "tests/run_basic_tests.sh" notroot
     build:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -72,7 +72,6 @@ jobs:
                 uses: actions/setup-python@v5
                 with:
                     python-version: ${{ matrix.version }}
-                    cache: 'pip'
             -   name: Install uv
                 uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
                 with:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -26,7 +26,8 @@ jobs:
                 run: |
                     # Run as a non-root user to avoid cheribuild errors
                     adduser --disabled-password --gecos "Not Root" notroot
-                    su -c "python3 -m pip install --user --upgrade --break-system-packages pip pytest pytest-xdist" notroot
+                    su -c "python3 -m pip config set global.break-system-packages true || true" notroot
+                    su -c "python3 -m pip install --user --upgrade pip pytest pytest-xdist" notroot
             -   name: Run basic regression tests
                 run: su -c "tests/run_basic_tests.sh" notroot
     build:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,7 +13,7 @@ jobs:
     build-docker:
         strategy:
             matrix:
-                image: [ 'python:3.10', 'python:3.12', 'python:latest', 'ubuntu:22.04', 'ubuntu:24.04', 'ubuntu:26.04', 'ubuntu:latest' ]
+                image: [ 'python:3.9.6', 'python:3.12', 'python:latest', 'ubuntu:22.04', 'ubuntu:24.04', 'ubuntu:26.04', 'ubuntu:latest' ]
         runs-on: ubuntu-latest
         container:
           image: ${{ matrix.image }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,7 +13,7 @@ jobs:
     build-docker:
         strategy:
             matrix:
-              image: [ 'python:3.10', 'python:3.12', 'python:latest', 'ubuntu:22.04', 'ubuntu:latest' ]
+                image: [ 'python:3.10', 'python:3.12', 'python:latest', 'ubuntu:22.04', 'ubuntu:latest' ]
         runs-on: ubuntu-latest
         container:
           image: ${{ matrix.image }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,7 +13,7 @@ jobs:
     build-docker:
         strategy:
             matrix:
-                image: [ 'python:3.10', 'python:3.12', 'python:latest', 'ubuntu:22.04', 'ubuntu:latest' ]
+                image: [ 'python:3.10', 'python:3.12', 'python:latest', 'ubuntu:22.04', 'ubuntu:24.04', 'ubuntu:26.04', 'ubuntu:atest' ]
         runs-on: ubuntu-latest
         container:
           image: ${{ matrix.image }}
@@ -21,7 +21,7 @@ jobs:
             -   uses: actions/checkout@v7
             -   name: Install Python
                 if: startsWith(matrix.image, 'ubuntu:')
-                run: apt-get update && apt-get install -y python3 python3-pip
+                run: apt-get update && apt-get install -y python3 python3-pip adduser
             -   name: Install dependencies
                 run: |
                     # Run as a non-root user to avoid cheribuild errors

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,7 +13,7 @@ jobs:
     build-docker:
         strategy:
             matrix:
-                image: [ 'python:3.10', 'python:3.12', 'python:latest', 'ubuntu:22.04', 'ubuntu:24.04', 'ubuntu:26.04', 'ubuntu:atest' ]
+                image: [ 'python:3.10', 'python:3.12', 'python:latest', 'ubuntu:22.04', 'ubuntu:24.04', 'ubuntu:26.04', 'ubuntu:latest' ]
         runs-on: ubuntu-latest
         container:
           image: ${{ matrix.image }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,7 +13,7 @@ jobs:
     build-docker:
         strategy:
             matrix:
-                image: [ 'python:3.8.0', 'python:3.12', 'python:latest', 'ubuntu:20.04' ]
+              image: [ 'python:3.10', 'python:3.12', 'python:latest', 'ubuntu:22.04', 'ubuntu:latest' ]
         runs-on: ubuntu-latest
         container:
           image: ${{ matrix.image }}

--- a/tests/python-baseline.Dockerfile
+++ b/tests/python-baseline.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.0
+FROM python:3.10
 
 LABEL maintainer="Alexander.Richardson@cl.cam.ac.uk"
 

--- a/tests/python-baseline.Dockerfile
+++ b/tests/python-baseline.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.9.6
 
 LABEL maintainer="Alexander.Richardson@cl.cam.ac.uk"
 

--- a/tests/python-baseline.Dockerfile
+++ b/tests/python-baseline.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.0
+FROM python:3.10.0
 
 LABEL maintainer="Alexander.Richardson@cl.cam.ac.uk"
 

--- a/tests/test_git_branch_switching.py
+++ b/tests/test_git_branch_switching.py
@@ -385,6 +385,7 @@ def test_negative_fetch_refspecs(tmp_path: Path):
     assert get_all_branches(local_dir) == [
         "main",
         "origin",
+        "origin/HEAD",
         "origin/main",
         "origin/other-branch",
         "origin/target-branch",

--- a/tests/test_git_branch_switching.py
+++ b/tests/test_git_branch_switching.py
@@ -382,10 +382,12 @@ def test_negative_fetch_refspecs(tmp_path: Path):
     project.repository.ensure_cloned(project, src_dir=local_dir, base_project_source_dir=None)
     assert get_all_branches(remote_dir) == ["main", "other-branch", "revert-123", "target-branch", "users/someone/wip"]
     # In the new clone, we should not have fetched the revert-123 or users/someone/wip branches
-    assert "revert-123" not in get_all_branches(local_dir)
-    assert "users/someone/wip" not in get_all_branches(local_dir)
+    local_branches = get_all_branches(local_dir)
+    assert "revert-123" not in local_branches
+    assert "users/someone/wip" not in local_branches
+
     fetch_config = (
-        subprocess.check_output(["git", "config", "get", "--all", "remote.origin.fetch"], cwd=local_dir)
+        subprocess.check_output(["git", "config", "--get-all", "remote.origin.fetch"], cwd=local_dir)
         .decode("utf-8")
         .split()
     )

--- a/tests/test_git_branch_switching.py
+++ b/tests/test_git_branch_switching.py
@@ -382,14 +382,8 @@ def test_negative_fetch_refspecs(tmp_path: Path):
     project.repository.ensure_cloned(project, src_dir=local_dir, base_project_source_dir=None)
     assert get_all_branches(remote_dir) == ["main", "other-branch", "revert-123", "target-branch", "users/someone/wip"]
     # In the new clone, we should not have fetched the revert-123 or users/someone/wip branches
-    assert get_all_branches(local_dir) == [
-        "main",
-        "origin",
-        "origin/HEAD",
-        "origin/main",
-        "origin/other-branch",
-        "origin/target-branch",
-    ]
+    assert "revert-123" not in get_all_branches(local_dir)
+    assert "users/someone/wip" not in get_all_branches(local_dir)
     fetch_config = (
         subprocess.check_output(["git", "config", "get", "--all", "remote.origin.fetch"], cwd=local_dir)
         .decode("utf-8")

--- a/tests/ubuntu-baseline.Dockerfile
+++ b/tests/ubuntu-baseline.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 LABEL maintainer="Alexander.Richardson@cl.cam.ac.uk"
 


### PR DESCRIPTION
The CI scripts were running tests on no-longer-supported versions such as Python 3.8 and Ubuntu 20.04.  Bump forward the baselines to the oldest currently supported by these projects.

Also, tests/test_git_branch_switching.py was overly sensitive to the exact behaviour of certain versions of git which varies by OS release; now look for undesired behaviour rather than fully specifying behaviour.