### PR TITLE
Relax InstallInstructions equality assertions in SimpleProject.

### DIFF
--- a/pycheribuild/projects/simple_project.py
+++ b/pycheribuild/projects/simple_project.py
@@ -1317,7 +1317,6 @@ class SimpleProjectBase(AbstractProject, ABC):
             existing = self.__checked_system_tools[executable]
             assert instructions.cheribuild_target == existing.cheribuild_target
             assert instructions.alternative == existing.alternative
-            assert instructions.fixit_hint() == existing.fixit_hint(), f"mismatched instructions for {executable}"
             return  # already checked
         self._validate_cheribuild_target_for_system_deps(instructions.cheribuild_target)
         if not shutil.which(str(executable)):


### PR DESCRIPTION
When the install instructions for a tool have already been checked, these are cached in a private dictionary in SimpleProjectBase. The dictionary key does not take into account the compat_abi for which the tool is checked. As a result, it may occur that checking for the `ninja` tool from a project targeting native will generate an install hint using pkg64c, while the same call for a project targeting native-hybrid will generate the same hint for pkg64.
This results into incompatible hints that trigger an assertion.

This patch removes the install hint assertion, as the hint equality does not seem to be critical.