### PR TITLE
Fix tag-related question for repositories that don't force a tag

### DIFF
--- a/pycheribuild/projects/repository.py
+++ b/pycheribuild/projects/repository.py
@@ -940,7 +940,8 @@ class GitRepository(SourceRepository):
         # remote if we are about to switch branches anyway.
         self._handle_branch_switch(current_project, src_dir)
 
-        self._handle_tag_switch(current_project, src_dir)
+        if self.force_tag:
+            self._handle_tag_switch(current_project, src_dir)
 
         # First fetch all the current upstream branch to see if we need to autostash/pull.
         # Note: "git fetch" without other arguments will fetch from the currently configured upstream.


### PR DESCRIPTION
The tag-handling functionality introduced a bug that causes 'Update to correct tag?' to be asked for repositories that don't set a tag. This is a fix for that.